### PR TITLE
feat: Auth entity types + API (#38)

### DIFF
--- a/src/entities/auth/api.ts
+++ b/src/entities/auth/api.ts
@@ -1,0 +1,23 @@
+import { clientFetch, serverFetch } from "@/shared/api";
+import type { AdminUser, LoginCredentials } from "./model";
+
+export async function login(credentials: LoginCredentials): Promise<AdminUser> {
+  return clientFetch<AdminUser>("/api/auth/admin/login", {
+    method: "POST",
+    body: JSON.stringify(credentials),
+  });
+}
+
+export async function logout(): Promise<void> {
+  return clientFetch<void>("/api/auth/admin/logout", {
+    method: "POST",
+  });
+}
+
+export async function fetchMe(): Promise<AdminUser> {
+  return clientFetch<AdminUser>("/api/auth/me");
+}
+
+export async function fetchMeServer(cookieHeader: string): Promise<AdminUser> {
+  return serverFetch<AdminUser>("/api/auth/me", {}, cookieHeader);
+}

--- a/src/entities/auth/index.ts
+++ b/src/entities/auth/index.ts
@@ -1,0 +1,2 @@
+export type { AdminUser, LoginCredentials } from "./model";
+export { login, logout, fetchMe, fetchMeServer } from "./api";

--- a/src/entities/auth/model.ts
+++ b/src/entities/auth/model.ts
@@ -1,0 +1,10 @@
+export interface AdminUser {
+  id: string;
+  email: string;
+  displayName: string;
+}
+
+export interface LoginCredentials {
+  email: string;
+  password: string;
+}


### PR DESCRIPTION
## Summary

Closes #38

관리자 인증 엔티티 타입과 API 함수 구현. 세션 쿠키 기반 인증을 위한 `AdminUser`, `LoginCredentials` 타입과 로그인/로그아웃/세션 확인 API를 `src/entities/auth/` 아래에 추가.

## Changes

| File | Change |
|------|--------|
| `src/entities/auth/model.ts` | `AdminUser`, `LoginCredentials` 타입 정의 |
| `src/entities/auth/api.ts` | `login`, `logout`, `fetchMe`, `fetchMeServer` 구현 |
| `src/entities/auth/index.ts` | barrel export |
