### PR TITLE
feat: Admin 레이아웃 (사이드바) (#46)

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,0 +1,14 @@
+import { AdminSidebar } from "@widgets/admin-sidebar";
+
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-h-screen">
+      <AdminSidebar />
+      <main className="flex-1 p-6">{children}</main>
+    </div>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,3 @@
+export default function DashboardPage() {
+  return <h1 className="text-2xl font-semibold text-text-1">대시보드</h1>;
+}

--- a/src/widgets/admin-sidebar/index.ts
+++ b/src/widgets/admin-sidebar/index.ts
@@ -1,0 +1,1 @@
+export { AdminSidebar } from "./ui/admin-sidebar";

--- a/src/widgets/admin-sidebar/ui/admin-sidebar.tsx
+++ b/src/widgets/admin-sidebar/ui/admin-sidebar.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@shared/lib/style-utils";
+
+const MENU_ITEMS = [
+  { label: "대시보드", path: "/dashboard" },
+  { label: "글 관리", path: "/dashboard/posts" },
+  { label: "카테고리", path: "/dashboard/categories" },
+  { label: "댓글", path: "/dashboard/comments" },
+  { label: "방명록", path: "/dashboard/guestbook" },
+  { label: "에셋", path: "/dashboard/assets" },
+] as const;
+
+export function AdminSidebar() {
+  const pathname = usePathname();
+
+  return (
+    <aside className="w-60 shrink-0 h-screen sticky top-0 border-r border-border-3 bg-background-2">
+      <div className="px-5 py-6">
+        <Link
+          href="/dashboard"
+          className="text-lg font-semibold text-text-1 hover:text-primary-1 transition-colors"
+        >
+          Admin
+        </Link>
+      </div>
+
+      <nav>
+        <ul className="flex flex-col gap-1 px-3">
+          {MENU_ITEMS.map((item) => {
+            const isActive =
+              item.path === "/dashboard"
+                ? pathname === "/dashboard"
+                : pathname.startsWith(item.path);
+
+            return (
+              <li key={item.path}>
+                <Link
+                  href={item.path}
+                  className={cn(
+                    "block px-3 py-2 rounded-md text-sm transition-colors",
+                    isActive
+                      ? "bg-primary-1/10 text-primary-1 font-medium"
+                      : "text-text-3 hover:bg-background-3 hover:text-text-1",
+                  )}
+                >
+                  {item.label}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #46

Admin 전용 레이아웃 + 사이드바 네비게이션 구현. `/dashboard/*` 경로에서 좌측 사이드바(240px) + 메인 컨텐츠 레이아웃 적용.

## Changes

| File | Change |
|------|--------|
| `src/widgets/admin-sidebar/ui/admin-sidebar.tsx` | AdminSidebar 위젯 - 6개 메뉴, usePathname 활성 하이라이트 |
| `src/widgets/admin-sidebar/index.ts` | 위젯 barrel export |
| `src/app/dashboard/layout.tsx` | Admin 레이아웃 - 사이드바 + 메인 컨텐츠 |
| `src/app/dashboard/page.tsx` | 대시보드 플레이스홀더 페이지 |
