### PR TITLE
fix: PaginatedResponse meta.total 필드 수정 (#23)

### DIFF
--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -3,7 +3,7 @@ export interface PaginatedResponse<T> {
   meta: {
     page: number;
     limit: number;
-    totalCount: number;
+    total: number;
     totalPages: number;
   };
 }


### PR DESCRIPTION
## Summary

Closes #23

서버 `PaginationMetaSchema`의 `total` 필드와 일치하도록 클라이언트 타입을 수정합니다.

## Changes

| File | Change |
|------|--------|
| `src/shared/api/types.ts` | `meta.totalCount` → `meta.total` |
