### PR TITLE
feat: Post entity types 정의 (#25)

### DIFF
--- a/src/entities/post/index.ts
+++ b/src/entities/post/index.ts
@@ -2,6 +2,7 @@ export type {
   Post,
   PostTag,
   PostCategory,
+  PostNavigation,
   PostDetailResponse,
   CreatePostBody,
   UpdatePostBody,

--- a/src/entities/post/model.ts
+++ b/src/entities/post/model.ts
@@ -27,6 +27,11 @@ export interface Post {
   tags: PostTag[];
 }
 
+export interface PostNavigation {
+  slug: string;
+  title: string;
+}
+
 export interface PostDetailResponse {
   post: Post;
 }


### PR DESCRIPTION
## Summary

Closes #25

`PostNavigation` 인터페이스를 `entities/post/` 계층에 추가합니다.

## Changes

| File | Change |
|------|--------|
| `src/entities/post/model.ts` | `PostNavigation` 인터페이스 추가 (slug, title) |
| `src/entities/post/index.ts` | `PostNavigation` barrel export 추가 |
