### PR TITLE
feat: 마크다운 렌더링 유틸리티 (shiki) (#24)

### DIFF
--- a/src/shared/lib/markdown.ts
+++ b/src/shared/lib/markdown.ts
@@ -5,6 +5,7 @@ import remarkParse from "remark-parse";
 import remarkRehype from "remark-rehype";
 import { unified } from "unified";
 
+// Allow shiki's inline style attributes for syntax highlighting colors
 const sanitizeSchema = {
   ...defaultSchema,
   attributes: {
@@ -15,14 +16,15 @@ const sanitizeSchema = {
   },
 };
 
-export async function renderMarkdown(md: string): Promise<string> {
-  const result = await unified()
-    .use(remarkParse)
-    .use(remarkRehype)
-    .use(rehypeShiki, { theme: "github-dark" })
-    .use(rehypeSanitize, sanitizeSchema)
-    .use(rehypeStringify)
-    .process(md);
+// Create once at module level so rehypeShiki's highlighter is not re-initialized per call
+const processor = unified()
+  .use(remarkParse)
+  .use(remarkRehype)
+  .use(rehypeShiki, { theme: "github-dark" })
+  .use(rehypeSanitize, sanitizeSchema)
+  .use(rehypeStringify)
+  .freeze();
 
-  return String(result);
+export async function renderMarkdown(md: string): Promise<string> {
+  return String(await processor.process(md));
 }


### PR DESCRIPTION
## Summary

Closes #24

서버 사이드 마크다운 → HTML 변환 유틸리티 함수 구현. unified 파이프라인으로 shiki 코드 하이라이팅과 rehype-sanitize XSS 방지를 적용.

## Changes

| File | Change |
|------|--------|
| `src/shared/lib/markdown.ts` | `renderMarkdown` 함수 추가 |
