### PR TITLE
feat: add post API functions (#26)

### DIFF
--- a/src/entities/post/api.ts
+++ b/src/entities/post/api.ts
@@ -1,10 +1,60 @@
 import type {
   CreatePostBody,
+  FetchPostsParams,
   Post,
   PostDetailResponse,
+  PostDetailWithNavigationResponse,
   UpdatePostBody,
 } from "./model";
+import type { PaginatedResponse } from "@shared/api";
 import { clientMutate, serverFetch } from "@shared/api";
+
+function buildPostSearchParams(params: FetchPostsParams): string {
+  const searchParams = new URLSearchParams();
+
+  if (params.page !== undefined) {
+    searchParams.set("page", String(params.page));
+  }
+
+  if (params.limit !== undefined) {
+    searchParams.set("limit", String(params.limit));
+  }
+
+  if (params.categoryId !== undefined) {
+    searchParams.set("categoryId", String(params.categoryId));
+  }
+
+  if (params.tagSlug !== undefined) {
+    searchParams.set("tagSlug", params.tagSlug);
+  }
+
+  if (params.q !== undefined) {
+    searchParams.set("q", params.q);
+  }
+
+  return searchParams.toString();
+}
+
+export async function fetchPosts(
+  params: FetchPostsParams = {},
+  cookieHeader?: string,
+): Promise<PaginatedResponse<Post>> {
+  const queryString = buildPostSearchParams(params);
+  const path = queryString ? `/api/posts?${queryString}` : "/api/posts";
+
+  return serverFetch<PaginatedResponse<Post>>(path, {}, cookieHeader);
+}
+
+export async function fetchPostBySlug(
+  slug: string,
+  cookieHeader?: string,
+): Promise<PostDetailWithNavigationResponse> {
+  return serverFetch<PostDetailWithNavigationResponse>(
+    `/api/posts/${encodeURIComponent(slug)}`,
+    {},
+    cookieHeader,
+  );
+}
 
 export async function fetchAdminPost(
   id: number,

--- a/src/entities/post/index.ts
+++ b/src/entities/post/index.ts
@@ -1,10 +1,18 @@
 export type {
+  FetchPostsParams,
   Post,
   PostTag,
   PostCategory,
   PostNavigation,
   PostDetailResponse,
+  PostDetailWithNavigationResponse,
   CreatePostBody,
   UpdatePostBody,
 } from "./model";
-export { fetchAdminPost, createPost, updatePost } from "./api";
+export {
+  fetchAdminPost,
+  fetchPostBySlug,
+  fetchPosts,
+  createPost,
+  updatePost,
+} from "./api";

--- a/src/entities/post/model.ts
+++ b/src/entities/post/model.ts
@@ -32,8 +32,22 @@ export interface PostNavigation {
   title: string;
 }
 
+export interface FetchPostsParams {
+  page?: number;
+  limit?: number;
+  categoryId?: number;
+  tagSlug?: string;
+  q?: string;
+}
+
 export interface PostDetailResponse {
   post: Post;
+}
+
+export interface PostDetailWithNavigationResponse {
+  post: Post;
+  prevPost: PostNavigation | null;
+  nextPost: PostNavigation | null;
 }
 
 export interface CreatePostBody {


### PR DESCRIPTION
## Summary

Closes #26

Add public post entity API helpers for list/detail reads using `serverFetch`.

## Changes

| File | Change |
|------|--------|
| `src/entities/post/api.ts` | Added `fetchPosts` query serialization and `fetchPostBySlug` public detail fetcher |
| `src/entities/post/model.ts` | Added public query and detail-with-navigation response types |
| `src/entities/post/index.ts` | Re-exported new public API helpers and types |
