### PR TITLE
feat: add admin post api functions (#44)

### DIFF
--- a/src/entities/post/api.ts
+++ b/src/entities/post/api.ts
@@ -1,5 +1,6 @@
 import type {
   CreatePostBody,
+  FetchAdminPostsParams,
   FetchPostsParams,
   Post,
   PostDetailResponse,
@@ -10,6 +11,16 @@ import type { PaginatedResponse } from "@shared/api";
 import { clientMutate, serverFetch } from "@shared/api";
 
 function buildPostSearchParams(params: FetchPostsParams): string {
+  return buildSearchParams(params);
+}
+
+function buildAdminPostSearchParams(params: FetchAdminPostsParams): string {
+  return buildSearchParams(params);
+}
+
+function buildSearchParams(
+  params: FetchPostsParams | FetchAdminPostsParams,
+): string {
   const searchParams = new URLSearchParams();
 
   if (params.page !== undefined) {
@@ -30,6 +41,26 @@ function buildPostSearchParams(params: FetchPostsParams): string {
 
   if (params.q !== undefined) {
     searchParams.set("q", params.q);
+  }
+
+  if ("status" in params && params.status !== undefined) {
+    searchParams.set("status", params.status);
+  }
+
+  if ("visibility" in params && params.visibility !== undefined) {
+    searchParams.set("visibility", params.visibility);
+  }
+
+  if ("sort" in params && params.sort !== undefined) {
+    searchParams.set("sort", params.sort);
+  }
+
+  if ("order" in params && params.order !== undefined) {
+    searchParams.set("order", params.order);
+  }
+
+  if ("includeDeleted" in params && params.includeDeleted !== undefined) {
+    searchParams.set("includeDeleted", String(params.includeDeleted));
   }
 
   return searchParams.toString();
@@ -69,12 +100,47 @@ export async function fetchAdminPost(
   return response.post;
 }
 
+export async function fetchAdminPosts(
+  params: FetchAdminPostsParams = {},
+  cookieHeader?: string,
+): Promise<PaginatedResponse<Post>> {
+  const queryString = buildAdminPostSearchParams(params);
+  const path = queryString
+    ? `/api/admin/posts?${queryString}`
+    : "/api/admin/posts";
+
+  return serverFetch<PaginatedResponse<Post>>(path, {}, cookieHeader);
+}
+
 export async function createPost(body: CreatePostBody): Promise<Post> {
   const response = await clientMutate<PostDetailResponse>("/api/admin/posts", {
     body: JSON.stringify(body),
   });
 
   return response.post;
+}
+
+export async function deletePost(id: number): Promise<void> {
+  await clientMutate<void>(`/api/admin/posts/${id}`, {
+    method: "DELETE",
+  });
+}
+
+export async function restorePost(id: number): Promise<Post> {
+  const response = await clientMutate<PostDetailResponse>(
+    `/api/admin/posts/${id}/restore`,
+    {
+      method: "PUT",
+    },
+  );
+
+  return response.post;
+}
+
+export async function hardDeletePost(id: number): Promise<void> {
+  await clientMutate<void>(`/api/admin/posts/${id}/hard`, {
+    method: "DELETE",
+  });
 }
 
 export async function updatePost(

--- a/src/entities/post/index.ts
+++ b/src/entities/post/index.ts
@@ -1,4 +1,5 @@
 export type {
+  FetchAdminPostsParams,
   FetchPostsParams,
   Post,
   PostTag,
@@ -11,8 +12,12 @@ export type {
 } from "./model";
 export {
   fetchAdminPost,
+  fetchAdminPosts,
   fetchPostBySlug,
   fetchPosts,
   createPost,
+  deletePost,
+  hardDeletePost,
+  restorePost,
   updatePost,
 } from "./api";

--- a/src/entities/post/model.ts
+++ b/src/entities/post/model.ts
@@ -40,6 +40,19 @@ export interface FetchPostsParams {
   q?: string;
 }
 
+export interface FetchAdminPostsParams {
+  page?: number;
+  limit?: number;
+  categoryId?: number;
+  tagSlug?: string;
+  q?: string;
+  status?: "draft" | "published" | "archived";
+  visibility?: "public" | "private";
+  sort?: "published_at" | "created_at";
+  order?: "asc" | "desc";
+  includeDeleted?: boolean;
+}
+
 export interface PostDetailResponse {
   post: Post;
 }

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -12,6 +12,10 @@ async function handleResponse<T>(response: Response): Promise<T> {
     throw new ApiResponseError(error);
   }
 
+  if (response.status === 204 || response.status === 205) {
+    return undefined as T;
+  }
+
   return response.json() as Promise<T>;
 }
 


### PR DESCRIPTION
## Summary

Closes #44

Add the admin post API helpers needed for post management flows, including list, soft delete, restore, and hard delete operations.

## Changes

| File | Change |
|------|--------|
| `src/entities/post/model.ts` | Add `FetchAdminPostsParams` for the admin posts query contract |
| `src/entities/post/api.ts` | Add `fetchAdminPosts`, `deletePost`, `restorePost`, and `hardDeletePost` helpers |
| `src/entities/post/index.ts` | Export the new admin post API helpers and query type |
| `src/shared/api/client.ts` | Handle `204` and `205` empty responses so delete mutations resolve correctly |
