### PR TITLE
feat: add tag entity api (#49)

### DIFF
--- a/src/entities/tag/api.ts
+++ b/src/entities/tag/api.ts
@@ -1,0 +1,16 @@
+import type { Tag } from "./model";
+import { serverFetch } from "@shared/api";
+
+interface TagsResponse {
+  tags: Tag[];
+}
+
+export async function fetchTags(cookieHeader?: string): Promise<Tag[]> {
+  const response = await serverFetch<TagsResponse>(
+    "/api/tags",
+    {},
+    cookieHeader,
+  );
+
+  return response.tags;
+}

--- a/src/entities/tag/index.ts
+++ b/src/entities/tag/index.ts
@@ -1,0 +1,2 @@
+export type { Tag } from "./model";
+export { fetchTags } from "./api";

--- a/src/entities/tag/model.ts
+++ b/src/entities/tag/model.ts
@@ -1,0 +1,6 @@
+export interface Tag {
+  id: number;
+  name: string;
+  slug: string;
+  postCount: number;
+}


### PR DESCRIPTION
## Summary

Closes #49

Add the `Tag` entity model and a server-side `fetchTags(cookieHeader?)` API helper for `GET /api/tags`.

## Changes

| File | Change |
|------|--------|
| `src/entities/tag/model.ts` | Add the `Tag` entity type with `id`, `name`, `slug`, and `postCount` |
| `src/entities/tag/api.ts` | Add `fetchTags(cookieHeader?)` and unwrap the `{ tags: Tag[] }` API response |
| `src/entities/tag/index.ts` | Re-export the `Tag` model and `fetchTags` helper |
