### PR TITLE
feat: add popular post api (#56)

### DIFF
--- a/src/entities/stat/api.ts
+++ b/src/entities/stat/api.ts
@@ -1,6 +1,27 @@
-import type { DashboardStats } from "./model";
-import { clientFetch } from "@shared/api";
+import type { DashboardStats, PopularPost } from "./model";
+import { clientFetch, serverFetch } from "@shared/api";
+
+interface PopularPostsResponse {
+  data: PopularPost[];
+}
 
 export async function fetchDashboardStats(): Promise<DashboardStats> {
   return clientFetch<DashboardStats>("/api/admin/stats/dashboard");
+}
+
+export async function fetchPopularPosts(
+  days: number,
+  cookieHeader?: string,
+): Promise<PopularPost[]> {
+  const searchParams = new URLSearchParams({
+    days: String(days),
+    limit: "10",
+  });
+  const response = await serverFetch<PopularPostsResponse>(
+    `/api/stats/popular?${searchParams.toString()}`,
+    {},
+    cookieHeader,
+  );
+
+  return response.data;
 }

--- a/src/entities/stat/index.ts
+++ b/src/entities/stat/index.ts
@@ -1,2 +1,2 @@
-export type { DashboardStats } from "./model";
-export { fetchDashboardStats } from "./api";
+export type { DashboardStats, PopularPost } from "./model";
+export { fetchDashboardStats, fetchPopularPosts } from "./api";

--- a/src/entities/stat/model.ts
+++ b/src/entities/stat/model.ts
@@ -5,3 +5,11 @@ export interface DashboardStats {
   totalPosts: number;
   totalComments: number;
 }
+
+export interface PopularPost {
+  postId: number;
+  slug: string;
+  title: string;
+  pageviews: number;
+  uniques: number;
+}


### PR DESCRIPTION
## Summary

Closes #56

Add the public popular-post stats entity API in the client so server components can fetch and consume `/api/stats/popular`.

## Changes

| File | Change |
|------|--------|
| `src/entities/stat/model.ts` | Add the `PopularPost` type for the public stats payload. |
| `src/entities/stat/api.ts` | Add `fetchPopularPosts(days, cookieHeader?)` using `serverFetch` and unwrap the backend `data` field. |
| `src/entities/stat/index.ts` | Export the new type and API helper. |
