### PR TITLE
feat: add asset entity api (#58)

### DIFF
--- a/src/entities/asset/api.ts
+++ b/src/entities/asset/api.ts
@@ -1,0 +1,58 @@
+import type { Asset, UploadedAsset, UploadAssetsResponse } from "./model";
+import type { PaginatedResponse } from "@shared/api";
+import {
+  ApiResponseError,
+  type ApiError,
+  clientFetch,
+  clientMutate,
+  getCsrfToken,
+} from "@shared/api";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5500";
+
+async function handleUploadResponse(
+  response: Response,
+): Promise<UploadAssetsResponse> {
+  if (!response.ok) {
+    const fallback: ApiError = {
+      statusCode: response.status,
+      message: response.statusText,
+    };
+    const error: ApiError = await response.json().catch(() => fallback);
+    throw new ApiResponseError(error);
+  }
+
+  return response.json() as Promise<UploadAssetsResponse>;
+}
+
+export async function fetchAssets(page = 1): Promise<PaginatedResponse<Asset>> {
+  return clientFetch<PaginatedResponse<Asset>>(`/api/assets?page=${page}`);
+}
+
+export async function uploadAssets(files: File[]): Promise<UploadedAsset[]> {
+  const formData = new FormData();
+
+  files.forEach((file) => {
+    formData.append("files", file);
+  });
+
+  const csrfToken = await getCsrfToken();
+  const response = await fetch(`${API_URL}/api/assets/upload`, {
+    method: "POST",
+    body: formData,
+    credentials: "include",
+    headers: {
+      "x-csrf-token": csrfToken,
+    },
+  });
+
+  const data = await handleUploadResponse(response);
+
+  return data.assets;
+}
+
+export async function deleteAsset(id: number): Promise<void> {
+  await clientMutate<void>(`/api/assets/${id}`, {
+    method: "DELETE",
+  });
+}

--- a/src/entities/asset/index.ts
+++ b/src/entities/asset/index.ts
@@ -1,0 +1,2 @@
+export type { Asset, UploadedAsset } from "./model";
+export { fetchAssets, uploadAssets, deleteAsset } from "./api";

--- a/src/entities/asset/model.ts
+++ b/src/entities/asset/model.ts
@@ -1,0 +1,16 @@
+export interface UploadedAsset {
+  id: number;
+  url: string;
+  mimeType: string;
+  sizeBytes: number;
+  width?: number;
+  height?: number;
+}
+
+export interface Asset extends UploadedAsset {
+  createdAt: string;
+}
+
+export interface UploadAssetsResponse {
+  assets: UploadedAsset[];
+}


### PR DESCRIPTION
## Summary

Closes #58

Add the asset entity model and client API helpers for paginated asset listing, multipart upload, and deletion.

## Changes

| File | Change |
|------|--------|
| `src/entities/asset/model.ts` | Added asset list and upload response types matching the server contract |
| `src/entities/asset/api.ts` | Added paginated fetch, CSRF-backed multipart upload, and delete helpers |
| `src/entities/asset/index.ts` | Exported the asset entity public API |
