### PR TITLE
feat: add admin comment and guestbook api functions (#65)

### DIFF
--- a/src/entities/comment/api.ts
+++ b/src/entities/comment/api.ts
@@ -1,11 +1,68 @@
 import type {
+  CommentAuthor,
   Comment,
   CommentResponse,
   CommentsResponse,
   CreateCommentBody,
   DeleteCommentBody,
 } from "./model";
-import { clientMutate, serverFetch } from "@shared/api";
+import type { PaginatedResponse } from "@shared/api";
+import { clientFetch, clientMutate, serverFetch } from "@shared/api";
+
+export interface AdminCommentItem {
+  id: number;
+  postId: number;
+  parentId: number | null;
+  depth: number;
+  body: string;
+  isSecret: boolean;
+  status: "active" | "deleted" | "hidden";
+  author: CommentAuthor;
+  replyToName: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FetchAdminCommentsParams {
+  page?: number;
+  limit?: number;
+  postId?: number;
+  authorType?: "oauth" | "guest";
+  startDate?: string;
+  endDate?: string;
+}
+
+function buildAdminCommentSearchParams(
+  params: FetchAdminCommentsParams,
+): string {
+  const searchParams = new URLSearchParams();
+
+  if (params.page !== undefined) {
+    searchParams.set("page", String(params.page));
+  }
+
+  if (params.limit !== undefined) {
+    searchParams.set("limit", String(params.limit));
+  }
+
+  if (params.postId !== undefined) {
+    searchParams.set("postId", String(params.postId));
+  }
+
+  if (params.authorType !== undefined) {
+    searchParams.set("authorType", params.authorType);
+  }
+
+  if (params.startDate !== undefined) {
+    searchParams.set("startDate", params.startDate);
+  }
+
+  if (params.endDate !== undefined) {
+    searchParams.set("endDate", params.endDate);
+  }
+
+  return searchParams.toString();
+}
 
 export async function fetchComments(
   postId: number,
@@ -45,5 +102,25 @@ export async function deleteComment(
   await clientMutate<void>(`/api/comments/${commentId}`, {
     method: "DELETE",
     body: JSON.stringify(payload),
+  });
+}
+
+export async function fetchAdminComments(
+  params: FetchAdminCommentsParams = {},
+  cookieHeader?: string,
+): Promise<PaginatedResponse<AdminCommentItem>> {
+  const queryString = buildAdminCommentSearchParams(params);
+  const path = queryString
+    ? `/api/admin/comments?${queryString}`
+    : "/api/admin/comments";
+
+  return cookieHeader
+    ? serverFetch<PaginatedResponse<AdminCommentItem>>(path, {}, cookieHeader)
+    : clientFetch<PaginatedResponse<AdminCommentItem>>(path);
+}
+
+export async function adminDeleteComment(id: number): Promise<void> {
+  await clientMutate<void>(`/api/admin/comments/${id}`, {
+    method: "DELETE",
   });
 }

--- a/src/entities/comment/index.ts
+++ b/src/entities/comment/index.ts
@@ -8,4 +8,11 @@ export type {
   DeleteCommentGuestBody,
   DeleteCommentOAuthBody,
 } from "./model";
-export { fetchComments, createComment, deleteComment } from "./api";
+export type { AdminCommentItem, FetchAdminCommentsParams } from "./api";
+export {
+  adminDeleteComment,
+  createComment,
+  deleteComment,
+  fetchAdminComments,
+  fetchComments,
+} from "./api";

--- a/src/entities/guestbook/api.ts
+++ b/src/entities/guestbook/api.ts
@@ -1,11 +1,59 @@
 import type {
+  CommentAuthor,
   CreateGuestbookBody,
   DeleteGuestbookBody,
   GuestbookEntry,
   GuestbookEntryResponse,
 } from "./model";
 import type { PaginatedResponse } from "@shared/api";
-import { clientMutate, serverFetch } from "@shared/api";
+import { clientFetch, clientMutate, serverFetch } from "@shared/api";
+
+export interface AdminGuestbookItem {
+  id: number;
+  parentId: number | null;
+  body: string;
+  isSecret: boolean;
+  status: "active" | "deleted";
+  author: CommentAuthor;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FetchAdminGuestbookParams {
+  page?: number;
+  limit?: number;
+  authorType?: "oauth" | "guest";
+  startDate?: string;
+  endDate?: string;
+}
+
+function buildAdminGuestbookSearchParams(
+  params: FetchAdminGuestbookParams,
+): string {
+  const searchParams = new URLSearchParams();
+
+  if (params.page !== undefined) {
+    searchParams.set("page", String(params.page));
+  }
+
+  if (params.limit !== undefined) {
+    searchParams.set("limit", String(params.limit));
+  }
+
+  if (params.authorType !== undefined) {
+    searchParams.set("authorType", params.authorType);
+  }
+
+  if (params.startDate !== undefined) {
+    searchParams.set("startDate", params.startDate);
+  }
+
+  if (params.endDate !== undefined) {
+    searchParams.set("endDate", params.endDate);
+  }
+
+  return searchParams.toString();
+}
 
 export async function fetchGuestbook(
   page = 1,
@@ -39,5 +87,25 @@ export async function deleteGuestbookEntry(
   await clientMutate<void>(`/api/guestbook/${id}`, {
     method: "DELETE",
     body: JSON.stringify(body),
+  });
+}
+
+export async function fetchAdminGuestbook(
+  params: FetchAdminGuestbookParams = {},
+  cookieHeader?: string,
+): Promise<PaginatedResponse<AdminGuestbookItem>> {
+  const queryString = buildAdminGuestbookSearchParams(params);
+  const path = queryString
+    ? `/api/admin/guestbook?${queryString}`
+    : "/api/admin/guestbook";
+
+  return cookieHeader
+    ? serverFetch<PaginatedResponse<AdminGuestbookItem>>(path, {}, cookieHeader)
+    : clientFetch<PaginatedResponse<AdminGuestbookItem>>(path);
+}
+
+export async function adminDeleteGuestbookEntry(id: number): Promise<void> {
+  await clientMutate<void>(`/api/admin/guestbook/${id}`, {
+    method: "DELETE",
   });
 }

--- a/src/entities/guestbook/index.ts
+++ b/src/entities/guestbook/index.ts
@@ -4,8 +4,11 @@ export type {
   CreateGuestbookBody,
   DeleteGuestbookBody,
 } from "./model";
+export type { AdminGuestbookItem, FetchAdminGuestbookParams } from "./api";
 export {
+  adminDeleteGuestbookEntry,
   fetchGuestbook,
+  fetchAdminGuestbook,
   createGuestbookEntry,
   deleteGuestbookEntry,
 } from "./api";


### PR DESCRIPTION
## Summary

Closes #65

Add admin comment and guestbook entity API functions for list and hard-delete flows.

## Changes

| File | Change |
|------|--------|
| `src/entities/comment/api.ts` | Add admin comment item/query types and admin list/delete API functions |
| `src/entities/comment/index.ts` | Re-export admin comment API types and functions |
| `src/entities/guestbook/api.ts` | Add admin guestbook item/query types and admin list/delete API functions |
| `src/entities/guestbook/index.ts` | Re-export admin guestbook API types and functions |
