### PR TITLE
feat: add category admin page (#57)

### DIFF
--- a/src/app/dashboard/categories/page.tsx
+++ b/src/app/dashboard/categories/page.tsx
@@ -1,0 +1,5 @@
+import { CategoryManager } from "@features/category-manager";
+
+export default function DashboardCategoriesPage() {
+  return <CategoryManager />;
+}

--- a/src/features/category-manager/index.ts
+++ b/src/features/category-manager/index.ts
@@ -1,0 +1,3 @@
+export { CategoryManager } from "./ui/category-manager";
+export { CategoryFormModal } from "./ui/category-form-modal";
+export { CategoryTree } from "./ui/category-tree";

--- a/src/features/category-manager/ui/category-form-modal.tsx
+++ b/src/features/category-manager/ui/category-form-modal.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type {
+  Category,
+  CreateCategoryBody,
+  UpdateCategoryBody,
+} from "@entities/category";
+import { Modal } from "@shared/ui/libs";
+
+interface CategoryFormModalProps {
+  isOpen: boolean;
+  mode: "create" | "edit";
+  category: Category | null;
+  parentOptions: CategoryOption[];
+  isSubmitting: boolean;
+  errorMessage: string | null;
+  onClose: () => void;
+  onSubmit: (values: CategoryFormValues) => void;
+}
+
+export interface CategoryFormValues {
+  name: string;
+  parentId: number | null;
+  isVisible: boolean;
+}
+
+export interface CategoryOption {
+  id: number;
+  label: string;
+}
+
+function getInitialValues(category: Category | null): CategoryFormValues {
+  return {
+    name: category?.name ?? "",
+    parentId: category?.parentId ?? null,
+    isVisible: category?.isVisible ?? true,
+  };
+}
+
+export function CategoryFormModal({
+  isOpen,
+  mode,
+  category,
+  parentOptions,
+  isSubmitting,
+  errorMessage,
+  onClose,
+  onSubmit,
+}: CategoryFormModalProps) {
+  const [values, setValues] = useState<CategoryFormValues>(() =>
+    getInitialValues(category),
+  );
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    setValues(getInitialValues(category));
+    setValidationError(null);
+  }, [category, isOpen]);
+
+  const title = mode === "create" ? "카테고리 추가" : "카테고리 수정";
+  const submitLabel = isSubmitting
+    ? mode === "create"
+      ? "추가 중..."
+      : "저장 중..."
+    : mode === "create"
+      ? "추가"
+      : "저장";
+
+  const handleSubmit = () => {
+    if (!values.name.trim()) {
+      setValidationError("카테고리 이름을 입력하세요.");
+
+      return;
+    }
+
+    setValidationError(null);
+    onSubmit({
+      name: values.name.trim(),
+      parentId: values.parentId,
+      isVisible: values.isVisible,
+    });
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={() => {
+        if (!isSubmitting) {
+          onClose();
+        }
+      }}
+      withBackground
+      className="w-[min(100%,40rem)] p-0 text-left"
+    >
+      <div className="border-b border-border-3 px-6 py-5">
+        <p className="text-body-xs uppercase tracking-[0.2em] text-text-4">
+          Category form
+        </p>
+        <h2 className="mt-2 text-xl font-semibold text-text-1">{title}</h2>
+      </div>
+
+      <div className="space-y-5 px-6 py-5">
+        <label className="flex flex-col gap-2 text-sm text-text-2">
+          <span className="font-medium text-text-1">이름</span>
+          <input
+            type="text"
+            value={values.name}
+            onChange={(event) =>
+              setValues((current) => ({ ...current, name: event.target.value }))
+            }
+            placeholder="카테고리 이름"
+            disabled={isSubmitting}
+            className="rounded-[0.9rem] border border-border-3 bg-background-1 px-4 py-3 text-sm text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+          />
+        </label>
+
+        <label className="flex flex-col gap-2 text-sm text-text-2">
+          <span className="font-medium text-text-1">부모 카테고리</span>
+          <select
+            value={values.parentId ?? ""}
+            onChange={(event) =>
+              setValues((current) => ({
+                ...current,
+                parentId: event.target.value
+                  ? Number(event.target.value)
+                  : null,
+              }))
+            }
+            disabled={isSubmitting}
+            className="rounded-[0.9rem] border border-border-3 bg-background-1 px-4 py-3 text-sm text-text-1 outline-none transition-colors focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <option value="">최상위 카테고리</option>
+            {parentOptions.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex items-center gap-3 rounded-[0.9rem] border border-border-3 bg-background-1 px-4 py-3 text-sm text-text-2">
+          <input
+            type="checkbox"
+            checked={values.isVisible}
+            onChange={(event) =>
+              setValues((current) => ({
+                ...current,
+                isVisible: event.target.checked,
+              }))
+            }
+            disabled={isSubmitting}
+            className="h-4 w-4 rounded border-border-3"
+          />
+          화면에 표시
+        </label>
+
+        {validationError ? (
+          <div className="rounded-[1rem] border border-negative-1/20 bg-negative-1/10 px-4 py-3 text-sm text-negative-1">
+            {validationError}
+          </div>
+        ) : null}
+
+        {errorMessage ? (
+          <div className="rounded-[1rem] border border-negative-1/20 bg-negative-1/10 px-4 py-3 text-sm text-negative-1">
+            {errorMessage}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="flex flex-wrap justify-end gap-3 border-t border-border-3 px-6 py-5">
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={isSubmitting}
+          className="inline-flex items-center justify-center rounded-[0.75rem] border border-border-3 px-4 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          취소
+        </button>
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={isSubmitting}
+          className="inline-flex items-center justify-center rounded-[0.75rem] bg-primary-1 px-4 py-2 text-sm font-medium text-text-1 transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {submitLabel}
+        </button>
+      </div>
+    </Modal>
+  );
+}
+
+export function toCreateCategoryBody(
+  values: CategoryFormValues,
+): CreateCategoryBody {
+  return {
+    name: values.name,
+    parentId: values.parentId,
+    isVisible: values.isVisible,
+  };
+}
+
+export function toUpdateCategoryBody(
+  values: CategoryFormValues,
+): UpdateCategoryBody {
+  return {
+    name: values.name,
+    parentId: values.parentId,
+    isVisible: values.isVisible,
+  };
+}

--- a/src/features/category-manager/ui/category-manager.tsx
+++ b/src/features/category-manager/ui/category-manager.tsx
@@ -1,0 +1,359 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  CategoryFormModal,
+  type CategoryFormValues,
+  toCreateCategoryBody,
+  toUpdateCategoryBody,
+} from "./category-form-modal";
+import { CategoryTree } from "./category-tree";
+import {
+  createCategory,
+  deleteCategory,
+  fetchCategoriesAdmin,
+  updateCategory,
+  type Category,
+} from "@entities/category";
+import { ApiResponseError } from "@shared/api";
+import { Modal } from "@shared/ui/libs";
+
+const QUERY_KEY = ["admin-categories"] as const;
+
+type FormMode = "create" | "edit";
+
+export function CategoryManager() {
+  const queryClient = useQueryClient();
+  const [formState, setFormState] = useState<{
+    open: boolean;
+    mode: FormMode;
+    category: Category | null;
+  }>({
+    open: false,
+    mode: "create",
+    category: null,
+  });
+  const [categoryToDelete, setCategoryToDelete] = useState<Category | null>(
+    null,
+  );
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const categoriesQuery = useQuery({
+    queryKey: QUERY_KEY,
+    queryFn: () => fetchCategoriesAdmin(),
+  });
+
+  const categories = categoriesQuery.data ?? [];
+  const parentOptions = useMemo(
+    () => getParentOptions(categories, formState.category),
+    [categories, formState.category],
+  );
+
+  const createMutation = useMutation({
+    mutationFn: (values: CategoryFormValues) =>
+      createCategory(toCreateCategoryBody(values)),
+    onSuccess: async () => {
+      setActionError(null);
+      setFormState({ open: false, mode: "create", category: null });
+      await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+    },
+    onError: (error) => {
+      setActionError(getErrorMessage(error, "카테고리 추가에 실패했습니다."));
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, values }: { id: number; values: CategoryFormValues }) =>
+      updateCategory(id, toUpdateCategoryBody(values)),
+    onSuccess: async () => {
+      setActionError(null);
+      setFormState({ open: false, mode: "create", category: null });
+      await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+    },
+    onError: (error) => {
+      setActionError(getErrorMessage(error, "카테고리 수정에 실패했습니다."));
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteCategory,
+    onSuccess: async () => {
+      setActionError(null);
+      setCategoryToDelete(null);
+      await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+    },
+    onError: (error) => {
+      setActionError(getErrorMessage(error, "카테고리 삭제에 실패했습니다."));
+    },
+  });
+
+  const formError =
+    createMutation.isError || updateMutation.isError ? actionError : null;
+
+  const handleCreate = () => {
+    setActionError(null);
+    setFormState({ open: true, mode: "create", category: null });
+  };
+
+  const handleEdit = (category: Category) => {
+    setActionError(null);
+    setFormState({ open: true, mode: "edit", category });
+  };
+
+  const handleDelete = (category: Category) => {
+    if (category.children && category.children.length > 0) {
+      setActionError("하위 카테고리가 있는 항목은 삭제할 수 없습니다.");
+
+      return;
+    }
+
+    setActionError(null);
+    setCategoryToDelete(category);
+  };
+
+  const handleSubmit = (values: CategoryFormValues) => {
+    if (formState.mode === "create") {
+      createMutation.mutate(values);
+
+      return;
+    }
+
+    if (!formState.category) {
+      return;
+    }
+
+    updateMutation.mutate({
+      id: formState.category.id,
+      values,
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-4 rounded-[1.75rem] border border-border-3 bg-background-2 p-6 shadow-[0px_18px_60px_0px_rgba(0,0,0,0.06)] md:flex-row md:items-end md:justify-between">
+        <div>
+          <p className="text-body-xs uppercase tracking-[0.24em] text-text-4">
+            Categories
+          </p>
+          <h1 className="mt-3 text-2xl font-semibold text-text-1">
+            카테고리 관리
+          </h1>
+          <p className="mt-2 text-sm text-text-3">
+            카테고리 구조를 확인하고, 노출 여부와 부모 관계를 조정할 수
+            있습니다.
+          </p>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleCreate}
+          className="inline-flex items-center justify-center rounded-[0.9rem] bg-primary-1 px-4 py-3 text-sm font-medium text-text-1"
+        >
+          카테고리 추가
+        </button>
+      </header>
+
+      <section className="rounded-[1.75rem] border border-border-3 bg-background-2 p-6">
+        <div className="flex flex-col gap-3 border-b border-border-3 pb-5 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-text-1">카테고리 트리</h2>
+            <p className="mt-1 text-sm text-text-3">
+              숨김 상태와 계층 구조를 한 번에 확인할 수 있습니다.
+            </p>
+          </div>
+          <span className="text-sm text-text-4">
+            총 {countCategories(categories)}개
+          </span>
+        </div>
+
+        {actionError ? (
+          <div className="mt-5 rounded-[1rem] border border-negative-1/20 bg-negative-1/10 px-4 py-3 text-sm text-negative-1">
+            {actionError}
+          </div>
+        ) : null}
+
+        <div className="mt-6">
+          {categoriesQuery.isPending ? <TreeSkeleton /> : null}
+
+          {!categoriesQuery.isPending && categoriesQuery.isError ? (
+            <div className="rounded-[1.5rem] border border-negative-1/20 bg-negative-1/10 px-6 py-8 text-center">
+              <p className="text-sm text-negative-1">
+                {getErrorMessage(
+                  categoriesQuery.error,
+                  "카테고리 목록을 불러오지 못했습니다.",
+                )}
+              </p>
+              <button
+                type="button"
+                onClick={() => void categoriesQuery.refetch()}
+                className="mt-4 inline-flex rounded-[0.75rem] border border-negative-1/20 px-4 py-2 text-sm font-medium text-negative-1 transition-colors hover:bg-negative-1/10"
+              >
+                다시 시도
+              </button>
+            </div>
+          ) : null}
+
+          {!categoriesQuery.isPending && !categoriesQuery.isError ? (
+            <CategoryTree
+              categories={categories}
+              onEdit={handleEdit}
+              onDelete={handleDelete}
+            />
+          ) : null}
+        </div>
+      </section>
+
+      <CategoryFormModal
+        isOpen={formState.open}
+        mode={formState.mode}
+        category={formState.category}
+        parentOptions={parentOptions}
+        isSubmitting={createMutation.isPending || updateMutation.isPending}
+        errorMessage={formError}
+        onClose={() =>
+          setFormState({ open: false, mode: "create", category: null })
+        }
+        onSubmit={handleSubmit}
+      />
+
+      <DeleteCategoryModal
+        category={categoryToDelete}
+        isDeleting={deleteMutation.isPending}
+        onCancel={() => setCategoryToDelete(null)}
+        onConfirm={() => {
+          if (categoryToDelete) {
+            deleteMutation.mutate(categoryToDelete.id);
+          }
+        }}
+      />
+    </div>
+  );
+}
+
+function DeleteCategoryModal({
+  category,
+  isDeleting,
+  onCancel,
+  onConfirm,
+}: {
+  category: Category | null;
+  isDeleting: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <Modal
+      isOpen={Boolean(category)}
+      onClose={() => {
+        if (!isDeleting) {
+          onCancel();
+        }
+      }}
+      withBackground
+      className="w-[min(100%,30rem)] p-0 text-left"
+    >
+      <div className="border-b border-border-3 px-6 py-5">
+        <p className="text-body-xs uppercase tracking-[0.2em] text-text-4">
+          Delete category
+        </p>
+        <h2 className="mt-2 text-xl font-semibold text-text-1">
+          카테고리 삭제
+        </h2>
+      </div>
+
+      <div className="space-y-3 px-6 py-5">
+        <p className="text-sm text-text-2">
+          <strong className="font-semibold text-text-1">
+            {category?.name}
+          </strong>
+          을(를) 삭제하시겠습니까?
+        </p>
+        <p className="text-sm text-text-3">이 작업은 되돌릴 수 없습니다.</p>
+      </div>
+
+      <div className="flex justify-end gap-3 border-t border-border-3 px-6 py-5">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isDeleting}
+          className="inline-flex items-center justify-center rounded-[0.75rem] border border-border-3 px-4 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          취소
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={isDeleting}
+          className="inline-flex items-center justify-center rounded-[0.75rem] bg-negative-1 px-4 py-2 text-sm font-medium text-text-1 transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isDeleting ? "삭제 중..." : "삭제"}
+        </button>
+      </div>
+    </Modal>
+  );
+}
+
+function TreeSkeleton() {
+  return (
+    <div className="space-y-4">
+      {Array.from({ length: 4 }).map((_, index) => (
+        <div
+          key={index}
+          className="h-24 animate-pulse rounded-[1.25rem] bg-background-3"
+        />
+      ))}
+    </div>
+  );
+}
+
+function countCategories(categories: Category[]): number {
+  return categories.reduce((total, category) => {
+    return total + 1 + countCategories(category.children ?? []);
+  }, 0);
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof ApiResponseError) {
+    return error.message;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return fallback;
+}
+
+function getParentOptions(
+  categories: Category[],
+  editingCategory: Category | null,
+): Array<{ id: number; label: string }> {
+  const excludedIds = editingCategory
+    ? new Set([editingCategory.id, ...collectDescendantIds(editingCategory)])
+    : new Set<number>();
+
+  return flattenCategories(categories)
+    .filter((category) => !excludedIds.has(category.id))
+    .map(({ id, name, depth }) => ({
+      id,
+      label: `${"— ".repeat(depth)}${name}`,
+    }));
+}
+
+function flattenCategories(
+  categories: Category[],
+  depth = 0,
+): Array<{ id: number; name: string; depth: number }> {
+  return categories.flatMap((category) => [
+    { id: category.id, name: category.name, depth },
+    ...flattenCategories(category.children ?? [], depth + 1),
+  ]);
+}
+
+function collectDescendantIds(category: Category): number[] {
+  return (category.children ?? []).flatMap((child) => [
+    child.id,
+    ...collectDescendantIds(child),
+  ]);
+}

--- a/src/features/category-manager/ui/category-tree.tsx
+++ b/src/features/category-manager/ui/category-tree.tsx
@@ -1,0 +1,152 @@
+import type { ReactNode } from "react";
+import type { Category } from "@entities/category";
+import { cn } from "@shared/lib/style-utils";
+
+interface CategoryTreeProps {
+  categories: Category[];
+  onEdit: (category: Category) => void;
+  onDelete: (category: Category) => void;
+}
+
+function CategoryBadge({
+  children,
+  tone = "neutral",
+}: {
+  children: ReactNode;
+  tone?: "neutral" | "warning";
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium",
+        tone === "neutral" && "bg-background-3 text-text-3",
+        tone === "warning" && "bg-negative-1/10 text-negative-1",
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+function TreeActionButton({
+  children,
+  onClick,
+  tone = "default",
+}: {
+  children: ReactNode;
+  onClick: () => void;
+  tone?: "default" | "danger";
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "inline-flex items-center justify-center rounded-[0.75rem] border px-3 py-2 text-sm font-medium transition-colors",
+        tone === "default" &&
+          "border-border-3 text-text-2 hover:border-border-2 hover:text-text-1",
+        tone === "danger" &&
+          "border-negative-1/30 text-negative-1 hover:bg-negative-1/10",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function TreeRow({
+  category,
+  depth,
+  onEdit,
+  onDelete,
+}: {
+  category: Category;
+  depth: number;
+  onEdit: (category: Category) => void;
+  onDelete: (category: Category) => void;
+}) {
+  const hasChildren = Boolean(
+    category.children && category.children.length > 0,
+  );
+
+  return (
+    <li className="space-y-3">
+      <div className="rounded-[1.25rem] border border-border-3 bg-background-1 p-4">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2 text-body-xs uppercase tracking-[0.18em] text-text-4">
+              <span>{depth === 0 ? "Root" : `Depth ${depth}`}</span>
+              {category.isVisible ? null : (
+                <CategoryBadge tone="warning">숨김</CategoryBadge>
+              )}
+              {hasChildren ? (
+                <CategoryBadge>
+                  {category.children?.length}개 하위 카테고리
+                </CategoryBadge>
+              ) : null}
+            </div>
+            <div className="mt-3 flex flex-wrap items-center gap-3">
+              <h3 className="text-body-lg font-semibold text-text-1">
+                {category.name}
+              </h3>
+              <span className="rounded-full border border-border-3 px-3 py-1 text-body-xs text-text-4">
+                /{category.slug}
+              </span>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <TreeActionButton onClick={() => onEdit(category)}>
+              수정
+            </TreeActionButton>
+            <TreeActionButton onClick={() => onDelete(category)} tone="danger">
+              삭제
+            </TreeActionButton>
+          </div>
+        </div>
+      </div>
+
+      {hasChildren ? (
+        <ul className="space-y-3 border-l border-border-3 pl-4 md:pl-6">
+          {category.children?.map((child) => (
+            <TreeRow
+              key={child.id}
+              category={child}
+              depth={depth + 1}
+              onEdit={onEdit}
+              onDelete={onDelete}
+            />
+          ))}
+        </ul>
+      ) : null}
+    </li>
+  );
+}
+
+export function CategoryTree({
+  categories,
+  onEdit,
+  onDelete,
+}: CategoryTreeProps) {
+  if (categories.length === 0) {
+    return (
+      <div className="rounded-[1.5rem] border border-dashed border-border-3 bg-background-1 px-6 py-12 text-center">
+        <p className="text-sm text-text-3">등록된 카테고리가 없습니다.</p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="space-y-4">
+      {categories.map((category) => (
+        <TreeRow
+          key={category.id}
+          category={category}
+          depth={0}
+          onEdit={onEdit}
+          onDelete={onDelete}
+        />
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #57

카테고리 관리 페이지와 category-manager feature를 추가해 트리 조회, 추가/수정 모달, 삭제 확인 흐름을 제공합니다.

## Changes

| File | Change |
|------|--------|
| `src/app/dashboard/categories/page.tsx` | 카테고리 관리 페이지 entry 추가 |
| `src/features/category-manager/index.ts` | category-manager exports 추가 |
| `src/features/category-manager/ui/category-tree.tsx` | 재귀 카테고리 트리 UI 구현 |
| `src/features/category-manager/ui/category-form-modal.tsx` | 추가/수정 공용 모달 구현 |
| `src/features/category-manager/ui/category-manager.tsx` | TanStack Query 기반 목록/CRUD orchestration 구현 |
