### PR TITLE
feat: add popular page filter (#61)

### DIFF
--- a/src/app/popular/page.tsx
+++ b/src/app/popular/page.tsx
@@ -1,74 +1,39 @@
-import Link from "next/link";
+import { redirect } from "next/navigation";
+import { PopularPageContent } from "./popular-page-content";
 import { fetchPopularPosts } from "@entities/stat";
 
 export const dynamic = "force-dynamic";
 
-const DEFAULT_DAYS = 30;
+const DEFAULT_DAYS = 7;
+const VALID_DAYS = new Set([7, 30]);
 
-export default async function PopularPage() {
-  const posts = await fetchPopularPosts(DEFAULT_DAYS);
+interface PopularPageProps {
+  searchParams?: {
+    days?: string | string[];
+  };
+}
 
-  return (
-    <main className="mx-auto flex min-h-screen w-full max-w-5xl flex-col gap-8 px-6 py-12">
-      <header className="rounded-[2rem] border border-border-3 bg-background-2 p-8 md:p-10">
-        <p className="text-body-xs uppercase tracking-[0.24em] text-text-4">
-          Popular Posts
-        </p>
-        <h1 className="mt-3 text-heading-md text-text-1">인기 글</h1>
-        <p className="mt-4 max-w-2xl text-body-md text-text-3">
-          최근 {DEFAULT_DAYS}일 동안 가장 많이 읽힌 글을 모아봤습니다.
-        </p>
-      </header>
+function getSingleValue(value?: string | string[]) {
+  return Array.isArray(value) ? value[0] : value;
+}
 
-      {posts.length > 0 ? (
-        <ol className="grid gap-4">
-          {posts.map((post, index) => (
-            <li key={post.postId}>
-              <Link
-                href={`/posts/${post.slug}`}
-                className="flex flex-col gap-4 rounded-[1.5rem] border border-border-3 bg-background-1 p-6 transition-colors hover:border-border-2 md:flex-row md:items-center md:justify-between"
-              >
-                <div className="flex min-w-0 items-start gap-4">
-                  <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-background-2 text-body-md font-semibold text-text-2">
-                    {index + 1}
-                  </span>
-                  <div className="min-w-0">
-                    <h2 className="text-body-lg font-semibold text-text-1">
-                      {post.title}
-                    </h2>
-                    <p className="mt-2 text-body-sm text-text-3">
-                      {post.pageviews.toLocaleString("ko-KR")} views
-                    </p>
-                  </div>
-                </div>
+function parseDays(value?: string): 7 | 30 {
+  if (value === undefined) {
+    redirect(`/popular?days=${DEFAULT_DAYS}`);
+  }
 
-                <dl className="flex gap-6 text-body-sm text-text-3">
-                  <div>
-                    <dt className="text-body-xs uppercase tracking-[0.18em] text-text-4">
-                      Pageviews
-                    </dt>
-                    <dd className="mt-1 text-body-md font-semibold text-text-1">
-                      {post.pageviews.toLocaleString("ko-KR")}
-                    </dd>
-                  </div>
-                  <div>
-                    <dt className="text-body-xs uppercase tracking-[0.18em] text-text-4">
-                      Visitors
-                    </dt>
-                    <dd className="mt-1 text-body-md font-semibold text-text-1">
-                      {post.uniques.toLocaleString("ko-KR")}
-                    </dd>
-                  </div>
-                </dl>
-              </Link>
-            </li>
-          ))}
-        </ol>
-      ) : (
-        <section className="rounded-[2rem] border border-dashed border-border-3 bg-background-2 p-8 text-body-md text-text-3 md:p-10">
-          아직 집계된 인기 글이 없습니다.
-        </section>
-      )}
-    </main>
-  );
+  const days = Number(value);
+
+  if (!Number.isInteger(days) || !VALID_DAYS.has(days)) {
+    redirect(`/popular?days=${DEFAULT_DAYS}`);
+  }
+
+  return days as 7 | 30;
+}
+
+export default async function PopularPage({ searchParams }: PopularPageProps) {
+  const days = parseDays(getSingleValue(searchParams?.days));
+  const posts = await fetchPopularPosts(days);
+
+  return <PopularPageContent days={days} posts={posts} />;
 }

--- a/src/app/popular/popular-page-content.tsx
+++ b/src/app/popular/popular-page-content.tsx
@@ -1,0 +1,103 @@
+import Link from "next/link";
+import type { PopularPost } from "@entities/stat";
+
+interface PopularPageContentProps {
+  days: 7 | 30;
+  posts: PopularPost[];
+}
+
+const PERIOD_OPTIONS = [
+  { days: 7, label: "7일" },
+  { days: 30, label: "30일" },
+] as const;
+
+export function PopularPageContent({ days, posts }: PopularPageContentProps) {
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-5xl flex-col gap-8 px-6 py-12">
+      <header className="rounded-[2rem] border border-border-3 bg-background-2 p-8 md:p-10">
+        <p className="text-body-xs uppercase tracking-[0.24em] text-text-4">
+          Popular Posts
+        </p>
+        <h1 className="mt-3 text-heading-md text-text-1">인기 글</h1>
+        <p className="mt-4 max-w-2xl text-body-md text-text-3">
+          최근 {days}일 동안 가장 많이 읽힌 글을 모아봤습니다.
+        </p>
+
+        <nav
+          aria-label="인기 글 기간 선택"
+          className="mt-6 inline-flex w-fit rounded-full border border-border-3 bg-background-1 p-1"
+        >
+          {PERIOD_OPTIONS.map((option) => {
+            const isActive = option.days === days;
+
+            return (
+              <Link
+                key={option.days}
+                href={`/popular?days=${option.days}`}
+                aria-current={isActive ? "page" : undefined}
+                className={[
+                  "rounded-full px-4 py-2 text-body-sm font-medium transition-colors",
+                  isActive
+                    ? "bg-background-3 text-text-1"
+                    : "text-text-3 hover:text-text-1",
+                ].join(" ")}
+              >
+                {option.label}
+              </Link>
+            );
+          })}
+        </nav>
+      </header>
+
+      {posts.length > 0 ? (
+        <ol className="grid gap-4">
+          {posts.map((post, index) => (
+            <li key={post.postId}>
+              <Link
+                href={`/posts/${post.slug}`}
+                className="flex flex-col gap-4 rounded-[1.5rem] border border-border-3 bg-background-1 p-6 transition-colors hover:border-border-2 md:flex-row md:items-center md:justify-between"
+              >
+                <div className="flex min-w-0 items-start gap-4">
+                  <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-background-2 text-body-md font-semibold text-text-2">
+                    {index + 1}
+                  </span>
+                  <div className="min-w-0">
+                    <h2 className="text-body-lg font-semibold text-text-1">
+                      {post.title}
+                    </h2>
+                    <p className="mt-2 text-body-sm text-text-3">
+                      {post.pageviews.toLocaleString("ko-KR")} views
+                    </p>
+                  </div>
+                </div>
+
+                <dl className="flex gap-6 text-body-sm text-text-3">
+                  <div>
+                    <dt className="text-body-xs uppercase tracking-[0.18em] text-text-4">
+                      Pageviews
+                    </dt>
+                    <dd className="mt-1 text-body-md font-semibold text-text-1">
+                      {post.pageviews.toLocaleString("ko-KR")}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-body-xs uppercase tracking-[0.18em] text-text-4">
+                      Visitors
+                    </dt>
+                    <dd className="mt-1 text-body-md font-semibold text-text-1">
+                      {post.uniques.toLocaleString("ko-KR")}
+                    </dd>
+                  </div>
+                </dl>
+              </Link>
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <section className="rounded-[2rem] border border-dashed border-border-3 bg-background-2 p-8 text-body-md text-text-3 md:p-10">
+          아직 집계된 인기 글이 없습니다.
+        </section>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #61

`/popular` 페이지에 SSR 기반 기간 필터를 추가하고, 잘못된 `days` 값은 canonical URL로 정정합니다.

## Changes

| File | Change |
|------|--------|
| `src/app/popular/page.tsx` | `days` 쿼리 파라미터를 검증하고 `?days=7` canonical redirect 및 SSR fetch를 수행하도록 수정 |
| `src/app/popular/popular-page-content.tsx` | 기간 탭과 인기 글 랭킹 목록을 렌더링하는 페이지 로컬 프레젠테이션 컴포넌트 추가 |

## Screenshots

UI 변경이지만 서버 렌더링 필터 동작 중심이라 스크린샷은 생략했습니다.
