### PR TITLE
feat: add SEO metadata and Open Graph (#63)

### DIFF
--- a/src/app/categories/[slug]/page.tsx
+++ b/src/app/categories/[slug]/page.tsx
@@ -5,7 +5,7 @@ import type { Category } from "@entities/category";
 import { fetchCategories } from "@entities/category";
 import { fetchPosts } from "@entities/post";
 import { PostCard } from "@features/post-list";
-import { getSiteName } from "@shared/lib/metadata";
+import { getSiteName, toAbsoluteUrl } from "@shared/lib/metadata";
 import { Pagination } from "@shared/ui/libs";
 import { CategoryNav } from "@widgets/category-nav";
 
@@ -66,6 +66,9 @@ function findCategoryBySlug(
 export const dynamic = "force-dynamic";
 
 const getCategories = cache(async () => fetchCategories());
+const getCategoryPosts = cache((categoryId: number, page: number) =>
+  fetchPosts({ categoryId, page }),
+);
 
 export async function generateMetadata({
   params,
@@ -81,24 +84,33 @@ export async function generateMetadata({
   const title = `${activeCategory.name} 카테고리`;
   const description = `${activeCategory.name} 카테고리에 등록된 글 모음입니다.`;
   const page = parsePage(getSingleValue(searchParams?.page));
+  const response = await getCategoryPosts(activeCategory.id, page);
+
+  if (isOutOfRangePage(page, response.meta.totalPages)) {
+    notFound();
+  }
+
   const url =
     page > 1
       ? `/categories/${activeCategory.slug}?page=${page}`
       : `/categories/${activeCategory.slug}`;
+  const canonicalUrl = toAbsoluteUrl(url);
 
   return {
     title,
     description,
-    alternates: {
-      canonical: url,
-    },
+    alternates: canonicalUrl
+      ? {
+          canonical: canonicalUrl,
+        }
+      : undefined,
     openGraph: {
       type: "website",
       locale: "ko_KR",
       siteName: getSiteName(),
       title,
       description,
-      url,
+      url: canonicalUrl,
     },
     twitter: {
       card: "summary",
@@ -120,7 +132,7 @@ export default async function CategoryPage({
     notFound();
   }
 
-  const response = await fetchPosts({ categoryId: activeCategory.id, page });
+  const response = await getCategoryPosts(activeCategory.id, page);
   const posts = response.data;
   const { meta } = response;
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,9 +10,10 @@ import {
 
 const siteName = getSiteName();
 const siteDescription = getDefaultDescription();
+const metadataBase = getMetadataBase();
 
 export const metadata: Metadata = {
-  metadataBase: getMetadataBase(),
+  metadataBase,
   title: {
     default: siteName,
     template: `%s | ${siteName}`,
@@ -30,7 +31,7 @@ export const metadata: Metadata = {
     siteName,
     title: siteName,
     description: siteDescription,
-    url: "/",
+    url: metadataBase ? "/" : undefined,
   },
   twitter: {
     card: "summary_large_image",

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -89,38 +89,44 @@ export async function generateMetadata({
       createMetadataSummary(post.contentMd) || getDefaultDescription();
     const url = `/posts/${post.slug}`;
     const siteName = getSiteName();
+    const canonicalUrl = toAbsoluteUrl(url);
+    const imageUrl = post.thumbnailUrl
+      ? toAbsoluteUrl(post.thumbnailUrl)
+      : null;
 
     return {
       title: post.title,
       description,
-      alternates: {
-        canonical: url,
-      },
+      alternates: canonicalUrl
+        ? {
+            canonical: canonicalUrl,
+          }
+        : undefined,
       openGraph: {
         type: "article",
         locale: "ko_KR",
         siteName,
         title: post.title,
         description,
-        url,
+        url: canonicalUrl,
         publishedTime: post.publishedAt ?? post.createdAt,
         modifiedTime: post.updatedAt,
         section: post.category.name,
         tags: post.tags.map((tag) => tag.name),
-        images: post.thumbnailUrl
+        images: imageUrl
           ? [
               {
-                url: toAbsoluteUrl(post.thumbnailUrl),
+                url: imageUrl,
                 alt: post.title,
               },
             ]
           : undefined,
       },
       twitter: {
-        card: post.thumbnailUrl ? "summary_large_image" : "summary",
+        card: imageUrl ? "summary_large_image" : "summary",
         title: post.title,
         description,
-        images: post.thumbnailUrl ? [toAbsoluteUrl(post.thumbnailUrl)] : [],
+        images: imageUrl ? [imageUrl] : [],
       },
     };
   } catch (error) {

--- a/src/shared/lib/metadata.ts
+++ b/src/shared/lib/metadata.ts
@@ -1,4 +1,3 @@
-const DEFAULT_SITE_URL = "http://localhost:3000";
 const DEFAULT_SITE_NAME = "Pyosh Blog";
 const DEFAULT_DESCRIPTION =
   "프론트엔드, 개발 메모, 그리고 만드는 과정을 기록하는 Pyosh Blog입니다.";
@@ -14,15 +13,15 @@ export function getSiteUrl() {
     process.env.VERCEL_PROJECT_PRODUCTION_URL?.trim() ??
     process.env.VERCEL_URL?.trim();
 
-  if (!envSiteUrl) {
-    if (!vercelSiteUrl) {
-      return DEFAULT_SITE_URL;
-    }
+  if (envSiteUrl) {
+    return trimTrailingSlash(envSiteUrl);
+  }
 
+  if (vercelSiteUrl) {
     return trimTrailingSlash(`https://${vercelSiteUrl}`);
   }
 
-  return trimTrailingSlash(envSiteUrl);
+  return null;
 }
 
 export function getSiteName() {
@@ -34,11 +33,27 @@ export function getDefaultDescription() {
 }
 
 export function getMetadataBase() {
-  return new URL(getSiteUrl());
+  const siteUrl = getSiteUrl();
+
+  if (!siteUrl) {
+    return undefined;
+  }
+
+  return new URL(siteUrl);
 }
 
 export function toAbsoluteUrl(path: string) {
-  return new URL(path, getMetadataBase());
+  try {
+    return new URL(path);
+  } catch {
+    const metadataBase = getMetadataBase();
+
+    if (!metadataBase) {
+      return undefined;
+    }
+
+    return new URL(path, metadataBase);
+  }
 }
 
 export function createMetadataSummary(contentMd: string) {


### PR DESCRIPTION
## Summary

Closes #63

Add Next.js metadata configuration for the public blog shell, post detail pages, and category archive pages so SEO, Open Graph, and RSS discovery are wired consistently.

## Changes

| File | Change |
|------|--------|
| `src/app/layout.tsx` | Add global metadata, title template, default description, Open Graph, Twitter, and RSS alternates |
| `src/app/posts/[slug]/page.tsx` | Add `generateMetadata` for post-specific title, summary, canonical URL, and OG image |
| `src/app/categories/[slug]/page.tsx` | Add category archive metadata and canonical URL |
| `src/shared/lib/metadata.ts` | Add shared site URL and markdown summary helpers for metadata generation |
