### PR TITLE
feat: tag list page and tag cloud component (#168)

### DIFF
--- a/src/features/post-list/ui/post-list-item.tsx
+++ b/src/features/post-list/ui/post-list-item.tsx
@@ -110,6 +110,20 @@ export function PostListItem({ post }: PostListItemProps) {
             {post.commentCount.toLocaleString()}
           </span>
         </div>
+
+        {/* Tag badges — text only, no link */}
+        {post.tags.length > 0 && (
+          <ul className="flex flex-wrap gap-2" aria-label="태그">
+            {post.tags.map((tag) => (
+              <li
+                key={tag.id}
+                className="rounded-full border border-border-3 px-3 py-1 text-body-xs text-text-4"
+              >
+                #{tag.name}
+              </li>
+            ))}
+          </ul>
+        )}
       </article>
     </Link>
   );

--- a/src/features/tag-cloud/index.ts
+++ b/src/features/tag-cloud/index.ts
@@ -1,0 +1,1 @@
+export { TagCloud } from "./ui/tag-cloud";

--- a/src/features/tag-cloud/ui/tag-cloud.tsx
+++ b/src/features/tag-cloud/ui/tag-cloud.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import type { Tag } from "@entities/tag";
+
+const MAX_SIDEBAR_TAGS = 20;
+
+interface TagCloudProps {
+  tags: Tag[];
+}
+
+export function TagCloud({ tags }: TagCloudProps) {
+  const displayTags = tags.slice(0, MAX_SIDEBAR_TAGS);
+
+  if (displayTags.length === 0) {
+    return null;
+  }
+
+  return (
+    <div>
+      <ul className="flex flex-wrap gap-2" aria-label="태그 목록">
+        {displayTags.map((tag) => (
+          <li key={tag.id}>
+            <Link
+              href={`/tags/${tag.slug}`}
+              className="inline-flex rounded-full border border-border-3 px-2.5 py-1 text-body-xs text-text-3 transition-colors hover:border-primary-1 hover:text-primary-1"
+            >
+              #{tag.name}
+            </Link>
+          </li>
+        ))}
+      </ul>
+      <Link
+        href="/tags"
+        className="mt-3 inline-flex items-center text-body-xs text-primary-1 hover:underline"
+      >
+        태그 전체보기 →
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Refs #168

Implements the tag list feature: text-only tag badges in `PostListItem`, and the `TagCloud` feature component (top 20 tags + "태그 전체보기" link) for sidebar use in F-39.

Note: `/tags` and `/tags/[slug]` pages were already implemented in a prior PR. Sidebar integration (unchecked AC items) is tracked in [F-39] Public 사이드바 레이아웃 (#185).

## Changes

| File | Change |
|------|--------|
| `src/features/post-list/ui/post-list-item.tsx` | Add text-only tag badges below stats row |
| `src/features/tag-cloud/ui/tag-cloud.tsx` | New `TagCloud` component - top 20 tags with links + "태그 전체보기" footer link |
| `src/features/tag-cloud/index.ts` | Export `TagCloud` |