### PR TITLE
feat: env var separation for server/client fetch (#178)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,2 +1,6 @@
-API_URL=http://localhost:5500
+## 브라우저에서 API 서버로의 요청 URL
 NEXT_PUBLIC_API_URL=http://localhost:5500
+
+## Next.js 서버(RSC, middleware)에서 API 서버로의 내부 요청 URL
+## 미설정 시 NEXT_PUBLIC_API_URL 폴백
+API_URL=http://localhost:5500

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,6 +1,8 @@
 import { ApiResponseError, type ApiError } from "./types";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5500";
+const PUBLIC_API_URL =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5500";
+const INTERNAL_API_URL = process.env.API_URL ?? PUBLIC_API_URL;
 
 async function handleResponse<T>(response: Response): Promise<T> {
   if (!response.ok) {
@@ -33,7 +35,7 @@ export async function serverFetch<T>(
     ...(cookieHeader ? { Cookie: cookieHeader } : {}),
   };
 
-  const response = await fetch(`${API_URL}${path}`, {
+  const response = await fetch(`${INTERNAL_API_URL}${path}`, {
     ...options,
     headers,
     cache: options.cache ?? "no-store",
@@ -55,7 +57,7 @@ export async function clientFetch<T>(
     ...options.headers,
   };
 
-  const response = await fetch(`${API_URL}${path}`, {
+  const response = await fetch(`${PUBLIC_API_URL}${path}`, {
     ...options,
     headers,
     credentials: "include",


### PR DESCRIPTION
## Summary

Closes #178

Separates the API URL for browser and server-side usage. `serverFetch()` now uses `API_URL` (internal), while `clientFetch()` uses `NEXT_PUBLIC_API_URL` (public). Falls back to `NEXT_PUBLIC_API_URL` when `API_URL` is not set.

## Changes

| File | Change |
|------|--------|
| `src/shared/api/client.ts` | Split single `API_URL` into `PUBLIC_API_URL` and `INTERNAL_API_URL`; wire each to the correct fetch function |
| `.env.local.example` | Add inline comments explaining each variable's purpose and fallback behavior |
