### PR TITLE
feat: asset upload progress, drag feedback, xhr (#191)

### DIFF
--- a/src/entities/asset/api.ts
+++ b/src/entities/asset/api.ts
@@ -10,21 +10,6 @@ import {
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5500";
 
-async function handleUploadResponse(
-  response: Response,
-): Promise<UploadAssetsResponse> {
-  if (!response.ok) {
-    const fallback: ApiError = {
-      statusCode: response.status,
-      message: response.statusText,
-    };
-    const error: ApiError = await response.json().catch(() => fallback);
-    throw new ApiResponseError(error);
-  }
-
-  return response.json() as Promise<UploadAssetsResponse>;
-}
-
 export async function fetchAssets(
   page = 1,
   limit = 20,
@@ -34,7 +19,10 @@ export async function fetchAssets(
   );
 }
 
-export async function uploadAssets(files: File[]): Promise<UploadedAsset[]> {
+export async function uploadAssets(
+  files: File[],
+  onProgress?: (percent: number) => void,
+): Promise<UploadedAsset[]> {
   const formData = new FormData();
 
   files.forEach((file) => {
@@ -42,18 +30,48 @@ export async function uploadAssets(files: File[]): Promise<UploadedAsset[]> {
   });
 
   const csrfToken = await getCsrfToken();
-  const response = await fetch(`${API_URL}/api/assets/upload`, {
-    method: "POST",
-    body: formData,
-    credentials: "include",
-    headers: {
-      "x-csrf-token": csrfToken,
-    },
+
+  return new Promise<UploadedAsset[]>((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+
+    xhr.upload.onprogress = (event) => {
+      if (event.lengthComputable && onProgress) {
+        onProgress(Math.round((event.loaded / event.total) * 100));
+      }
+    };
+
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        try {
+          const data = JSON.parse(xhr.responseText) as UploadAssetsResponse;
+          resolve(data.assets);
+        } catch {
+          reject(new Error("응답을 파싱할 수 없습니다."));
+        }
+        return;
+      }
+
+      const fallback: ApiError = {
+        statusCode: xhr.status,
+        message: xhr.statusText,
+      };
+      try {
+        const error: ApiError = JSON.parse(xhr.responseText) as ApiError;
+        reject(new ApiResponseError(error));
+      } catch {
+        reject(new ApiResponseError(fallback));
+      }
+    };
+
+    xhr.onerror = () => {
+      reject(new Error("업로드 중 네트워크 오류가 발생했습니다."));
+    };
+
+    xhr.open("POST", `${API_URL}/api/assets/upload`);
+    xhr.withCredentials = true;
+    xhr.setRequestHeader("x-csrf-token", csrfToken);
+    xhr.send(formData);
   });
-
-  const data = await handleUploadResponse(response);
-
-  return data.assets;
 }
 
 export async function deleteAsset(id: number): Promise<void> {

--- a/src/features/asset-uploader/ui/asset-uploader.tsx
+++ b/src/features/asset-uploader/ui/asset-uploader.tsx
@@ -30,6 +30,7 @@ export function AssetUploader() {
   const queryClient = useQueryClient();
   const [page, setPage] = useState(1);
   const [pendingFiles, setPendingFiles] = useState<PendingUploadFile[]>([]);
+  const [uploadProgress, setUploadProgress] = useState<number | null>(null);
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
   const [deleteTargetIds, setDeleteTargetIds] = useState<number[]>([]);
   const [copiedState, setCopiedState] = useState<{
@@ -43,16 +44,21 @@ export function AssetUploader() {
   });
 
   const uploadMutation = useMutation({
-    mutationFn: (files: File[]) => uploadAssets(files),
+    mutationFn: (files: File[]) => {
+      setUploadProgress(0);
+      return uploadAssets(files, setUploadProgress);
+    },
     onSuccess: async () => {
       toast.success(
         "업로드가 완료되었습니다. 최신 에셋을 맨 위에서 확인하세요.",
       );
+      setUploadProgress(null);
       setPage(1);
       clearPendingFiles();
       await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
     },
     onError: (error) => {
+      setUploadProgress(null);
       toast.error(getErrorMessage(error, "에셋 업로드에 실패했습니다."));
     },
   });
@@ -273,6 +279,7 @@ export function AssetUploader() {
       <UploadZone
         files={pendingFiles}
         isUploading={uploadMutation.isPending}
+        uploadProgress={uploadProgress}
         errorMessage={null}
         onFilesAdded={addFiles}
         onRemoveFile={removePendingFile}

--- a/src/features/asset-uploader/ui/upload-zone.tsx
+++ b/src/features/asset-uploader/ui/upload-zone.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { cn } from "@shared/lib/style-utils";
 import { Spinner } from "@shared/ui/libs";
 
@@ -13,6 +13,7 @@ export interface PendingUploadFile {
 interface UploadZoneProps {
   files: PendingUploadFile[];
   isUploading: boolean;
+  uploadProgress: number | null;
   errorMessage: string | null;
   onFilesAdded: (files: FileList | File[]) => void;
   onRemoveFile: (id: string) => void;
@@ -23,6 +24,7 @@ interface UploadZoneProps {
 export function UploadZone({
   files,
   isUploading,
+  uploadProgress,
   errorMessage,
   onFilesAdded,
   onRemoveFile,
@@ -100,6 +102,21 @@ export function UploadZone({
       {errorMessage ? (
         <div className="mt-5 rounded-[1rem] border border-negative-1/20 bg-negative-1/10 px-4 py-3 text-sm text-negative-1">
           {errorMessage}
+        </div>
+      ) : null}
+
+      {isUploading && uploadProgress !== null ? (
+        <div className="mt-5">
+          <div className="mb-1.5 flex items-center justify-between text-xs text-text-4">
+            <span>업로드 중...</span>
+            <span>{uploadProgress}%</span>
+          </div>
+          <div className="h-2 overflow-hidden rounded-full bg-background-3">
+            <div
+              className="h-full rounded-full bg-primary-1 transition-all duration-150"
+              style={{ width: `${uploadProgress}%` }}
+            />
+          </div>
         </div>
       ) : null}
 
@@ -182,18 +199,46 @@ function DropArea({
   onFilesAdded: (files: FileList | File[]) => void;
   onPick: () => void;
 }) {
+  const [isDragging, setIsDragging] = useState(false);
+  const dragCounterRef = useRef(0);
+
   return (
     <div
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-label="파일을 드래그하거나 클릭하여 대기열에 추가"
       className={cn(
         "mt-6 rounded-[1.5rem] border border-dashed border-border-3 bg-[radial-gradient(circle_at_top,rgba(0,0,0,0.04),transparent_55%)] px-6 py-10 text-center transition-colors",
-        !disabled && "hover:border-primary-1/60 hover:bg-background-1",
+        !disabled && !isDragging && "hover:border-primary-1/60 hover:bg-background-1",
         disabled && "cursor-not-allowed opacity-60",
+        isDragging && !disabled && "border-primary-1 bg-primary-2/10",
       )}
+      onKeyDown={(event) => {
+        if (!disabled && (event.key === "Enter" || event.key === " ")) {
+          event.preventDefault();
+          onPick();
+        }
+      }}
+      onDragEnter={(event) => {
+        event.preventDefault();
+        if (disabled) return;
+        dragCounterRef.current += 1;
+        setIsDragging(true);
+      }}
+      onDragLeave={() => {
+        if (disabled) return;
+        dragCounterRef.current -= 1;
+        if (dragCounterRef.current === 0) {
+          setIsDragging(false);
+        }
+      }}
       onDragOver={(event) => {
         event.preventDefault();
       }}
       onDrop={(event) => {
         event.preventDefault();
+        dragCounterRef.current = 0;
+        setIsDragging(false);
         if (disabled || event.dataTransfer.files.length === 0) {
           return;
         }
@@ -204,9 +249,15 @@ function DropArea({
       <p className="text-body-xs uppercase tracking-[0.24em] text-text-4">
         Drag and drop
       </p>
-      <h3 className="mt-3 text-lg font-semibold text-text-1">
-        파일을 여기에 놓거나 선택해서 대기열에 추가하세요
-      </h3>
+      {isDragging ? (
+        <h3 className="mt-3 text-lg font-semibold text-primary-1">
+          놓으면 추가됩니다
+        </h3>
+      ) : (
+        <h3 className="mt-3 text-lg font-semibold text-text-1">
+          파일을 여기에 놓거나 선택해서 대기열에 추가하세요
+        </h3>
+      )}
       <p className="mt-2 text-sm text-text-3">
         업로드 버튼을 누르기 전까지 서버에는 전송되지 않습니다.
       </p>


### PR DESCRIPTION
## Summary

Closes #191

Adds upload progress tracking, drag-and-drop visual feedback, and replaces `fetch` with XHR for upload progress events.

## Changes

| File | Change |
|------|--------|
| `src/entities/asset/api.ts` | Replace `fetch` with XHR in `uploadAssets`; add `onProgress` callback |
| `src/features/asset-uploader/ui/upload-zone.tsx` | Add `uploadProgress` prop + progress bar; add drag enter/leave state with visual feedback; add keyboard accessibility to drop area |
| `src/features/asset-uploader/ui/asset-uploader.tsx` | Add `uploadProgress` state; wire `onProgress` to `uploadAssets`; reset on success/error |

## Screenshots

UI changes are in the upload zone component (progress bar below drop area, border highlight on drag-over).
