### PR TITLE
feat: 카테고리 트리 표시 - 재귀 렌더링, 접기/펼치기, 숨김 필터, 글 개수 (#190)

### DIFF
--- a/src/features/category-manager/ui/category-tree.tsx
+++ b/src/features/category-manager/ui/category-tree.tsx
@@ -12,13 +12,19 @@ interface CategoryTreeProps {
   onDelete: (category: Category) => void;
 }
 
-function collectNonLeafIds(categories: Category[]): Set<number> {
+function collectVisibleNonLeafIds(
+  categories: Category[],
+  showHidden: boolean,
+): Set<number> {
   const ids = new Set<number>();
   function traverse(cats: Category[]) {
     for (const cat of cats) {
-      if (cat.children && cat.children.length > 0) {
+      const visible = showHidden
+        ? (cat.children ?? [])
+        : (cat.children ?? []).filter((c) => c.isVisible);
+      if (visible.length > 0) {
         ids.add(cat.id);
-        traverse(cat.children);
+        traverse(visible);
       }
     }
   }
@@ -64,7 +70,8 @@ function CategoryTreeRow({
           type="button"
           onClick={() => onToggle(category.id)}
           disabled={!hasVisibleChildren}
-          aria-label={isExpanded ? "접기" : "펼치기"}
+          aria-label="하위 카테고리 토글"
+          aria-expanded={hasVisibleChildren ? isExpanded : undefined}
           className={cn(
             "flex h-5 w-5 shrink-0 items-center justify-center text-xs text-text-3 transition-colors",
             hasVisibleChildren
@@ -156,8 +163,8 @@ export function CategoryTree({
   }, []);
 
   const handleExpandAll = useCallback(() => {
-    setExpandedIds(collectNonLeafIds(categories));
-  }, [categories]);
+    setExpandedIds(collectVisibleNonLeafIds(categories, showHidden));
+  }, [categories, showHidden]);
 
   const handleCollapseAll = useCallback(() => {
     setExpandedIds(new Set());


### PR DESCRIPTION
## Summary

Closes #190

카테고리 관리 페이지의 카테고리 트리 표시 기능 구현:

- **트리 렌더링**: 재귀 컴포넌트로 계층 구조 표현, depth 당 pl-6(24px) 인덴트
- **접기/펼치기**: 토글 아이콘(▶/▼) 클릭으로 자식 노드 토글, 기본 상태 전체 접힘
- **전체 펼침/접힘 버튼**: 상단 툴바에서 모든 노드 일괄 제어
- **숨김 카테고리 필터**: ToggleSwitch로 ON/OFF, 숨김 행 opacity-50 + "(숨김)" 텍스트
- **글 개수 표시**: 발행 N / 전체 N 형식, publishedPostCount/totalPostCount 필드 사용
- **행 구성**: 토글 아이콘 | 카테고리명 | slug 뱃지 | 글 개수 | 수정/삭제

## Changes

- `src/features/category-manager/ui/category-tree.tsx`: 전면 리팩토링