### PR TITLE
feat: complete admin post controls (#203)

### DIFF
--- a/src/app/manage/posts/page.tsx
+++ b/src/app/manage/posts/page.tsx
@@ -340,6 +340,7 @@ export default function ManagePostsPage() {
     ids: number[],
     categoryId?: number,
     commentStatus?: "open" | "locked" | "disabled",
+    visibility?: "public" | "private",
   ) {
     try {
       await bulkUpdatePosts({
@@ -347,6 +348,7 @@ export default function ManagePostsPage() {
         action: "update",
         categoryId,
         commentStatus,
+        visibility,
       });
       await invalidatePostQueries();
       toast.success(`${ids.length}개 글이 업데이트되었습니다.`);

--- a/src/entities/post/model.ts
+++ b/src/entities/post/model.ts
@@ -93,6 +93,7 @@ export interface BulkPostAction {
   action: "update" | "soft_delete" | "restore" | "hard_delete";
   categoryId?: number;
   commentStatus?: "open" | "locked" | "disabled";
+  visibility?: "public" | "private";
 }
 
 export interface BulkPostErrorDetail {

--- a/src/widgets/admin-post-list/ui/bulk-actions.tsx
+++ b/src/widgets/admin-post-list/ui/bulk-actions.tsx
@@ -19,6 +19,7 @@ interface BulkActionsProps {
     ids: number[],
     categoryId?: number,
     commentStatus?: "open" | "locked" | "disabled",
+    visibility?: "public" | "private",
   ) => Promise<void>;
   onClearSelection: () => void;
 }
@@ -37,6 +38,14 @@ const COMMENT_STATUS_DESC: Record<"open" | "locked" | "disabled", string> = {
   locked: "기존 댓글은 유지되며 새 댓글 작성이 차단됩니다.",
   disabled: "댓글 영역이 완전히 숨겨집니다.",
 };
+
+const VISIBILITY_OPTIONS: Array<{
+  label: string;
+  value: "public" | "private";
+}> = [
+  { label: "공개", value: "public" },
+  { label: "비공개", value: "private" },
+];
 
 function buildCategoryTree(
   categories: Category[],
@@ -69,6 +78,9 @@ export function BulkActions({
   const [commentStatus, setCommentStatus] = useState<
     "open" | "locked" | "disabled" | undefined
   >(undefined);
+  const [visibility, setVisibility] = useState<
+    "public" | "private" | undefined
+  >(undefined);
   const [showApplyDialog, setShowApplyDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showRestoreDialog, setShowRestoreDialog] = useState(false);
@@ -76,7 +88,10 @@ export function BulkActions({
   const [isPending, setIsPending] = useState(false);
 
   const count = selectedIds.length;
-  const hasUpdate = categoryId !== undefined || commentStatus !== undefined;
+  const hasUpdate =
+    categoryId !== undefined ||
+    commentStatus !== undefined ||
+    visibility !== undefined;
   const flatCategories = buildCategoryTree(categories);
 
   if (count === 0) return null;
@@ -84,9 +99,10 @@ export function BulkActions({
   async function handleApply() {
     setIsPending(true);
     try {
-      await onBulkUpdate(selectedIds, categoryId, commentStatus);
+      await onBulkUpdate(selectedIds, categoryId, commentStatus, visibility);
       setCategoryId(undefined);
       setCommentStatus(undefined);
+      setVisibility(undefined);
       setShowApplyDialog(false);
       onClearSelection();
     } catch {
@@ -194,11 +210,32 @@ export function BulkActions({
               </select>
             </div>
 
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-text-4">공개:</span>
+              <select
+                value={visibility ?? ""}
+                onChange={(e) =>
+                  setVisibility(
+                    (e.target.value as "public" | "private") || undefined,
+                  )
+                }
+                className="rounded-[0.6rem] border border-border-3 bg-background-1 px-2 py-1.5 text-sm text-text-1 outline-none focus:border-primary-1"
+              >
+                <option value="">-</option>
+                {VISIBILITY_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
             <button
               type="button"
               onClick={() => {
                 setCategoryId(undefined);
                 setCommentStatus(undefined);
+                setVisibility(undefined);
               }}
               disabled={!hasUpdate}
               className="rounded-[0.6rem] border border-border-3 px-2.5 py-1.5 text-sm text-text-3 transition-colors hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-40"
@@ -298,6 +335,16 @@ export function BulkActions({
               <p className="mt-1 text-xs text-text-4">
                 &quot;{COMMENT_STATUS_DESC[commentStatus]}&quot;
               </p>
+            </li>
+          ) : null}
+          {visibility !== undefined ? (
+            <li>
+              공개 여부: →{" "}
+              <span className="font-medium text-text-1">
+                {VISIBILITY_OPTIONS.find(
+                  (option) => option.value === visibility,
+                )?.label ?? visibility}
+              </span>
             </li>
           ) : null}
         </ul>

--- a/src/widgets/admin-post-preview/ui/post-preview.tsx
+++ b/src/widgets/admin-post-preview/ui/post-preview.tsx
@@ -18,6 +18,20 @@ const dateFormatter = new Intl.DateTimeFormat("ko-KR", {
   day: "2-digit",
 });
 
+function toDatetimeLocalValue(value: string | null): string {
+  if (!value) return "";
+
+  const date = new Date(value);
+  const offset = date.getTimezoneOffset();
+  const localDate = new Date(date.getTime() - offset * 60 * 1000);
+
+  return localDate.toISOString().slice(0, 16);
+}
+
+function fromDatetimeLocalValue(value: string): string {
+  return new Date(value).toISOString();
+}
+
 interface PostPreviewProps {
   post: Post;
   renderedContent: string;
@@ -38,12 +52,16 @@ export function PostPreview({ post, renderedContent }: PostPreviewProps) {
 
   const [currentPost, setCurrentPost] = useState(post);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [modifiedAtInput, setModifiedAtInput] = useState(
+    toDatetimeLocalValue(post.contentModifiedAt),
+  );
 
   const updateMutation = useMutation({
     mutationFn: (body: Parameters<typeof updatePost>[1]) =>
       updatePost(currentPost.id, body),
     onSuccess: (updated) => {
       setCurrentPost(updated);
+      setModifiedAtInput(toDatetimeLocalValue(updated.contentModifiedAt));
       void queryClient.invalidateQueries({ queryKey: ["admin-posts"] });
     },
     onError: (error) => {
@@ -64,6 +82,27 @@ export function PostPreview({ post, renderedContent }: PostPreviewProps) {
   });
 
   const isUpdating = updateMutation.isPending;
+
+  function updateModifiedAt(nextValue: string | null) {
+    const previousValue = currentPost.contentModifiedAt;
+    const previousInput = modifiedAtInput;
+
+    setCurrentPost((prev) => ({ ...prev, contentModifiedAt: nextValue }));
+    setModifiedAtInput(toDatetimeLocalValue(nextValue));
+
+    updateMutation.mutate(
+      { contentModifiedAt: nextValue },
+      {
+        onError: () => {
+          setCurrentPost((prev) => ({
+            ...prev,
+            contentModifiedAt: previousValue,
+          }));
+          setModifiedAtInput(previousInput);
+        },
+      },
+    );
+  }
 
   return (
     <div className="space-y-6">
@@ -167,6 +206,36 @@ export function PostPreview({ post, renderedContent }: PostPreviewProps) {
             ))}
           </select>
         </div>
+
+        <div className="flex flex-wrap items-center gap-2 text-sm text-text-2">
+          <span>수정일</span>
+          <input
+            type="datetime-local"
+            value={modifiedAtInput}
+            disabled={isUpdating}
+            onChange={(event) => setModifiedAtInput(event.target.value)}
+            className="rounded-[0.75rem] border border-border-3 bg-background-1 px-3 py-2 text-sm text-text-1 outline-none transition-colors focus:border-primary-1 disabled:opacity-50"
+            aria-label="수정일 설정"
+          />
+          <button
+            type="button"
+            disabled={isUpdating || !modifiedAtInput}
+            onClick={() =>
+              updateModifiedAt(fromDatetimeLocalValue(modifiedAtInput))
+            }
+            className="inline-flex items-center rounded-[0.75rem] border border-border-3 px-3 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            적용
+          </button>
+          <button
+            type="button"
+            disabled={isUpdating || currentPost.contentModifiedAt === null}
+            onClick={() => updateModifiedAt(null)}
+            className="inline-flex items-center rounded-[0.75rem] border border-border-3 px-3 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            수정일 제거
+          </button>
+        </div>
       </div>
 
       {/* Preview content */}
@@ -180,6 +249,12 @@ export function PostPreview({ post, renderedContent }: PostPreviewProps) {
           {currentPost.publishedAt ? (
             <span>
               {dateFormatter.format(new Date(currentPost.publishedAt))}
+            </span>
+          ) : null}
+          {currentPost.contentModifiedAt ? (
+            <span>
+              수정{" "}
+              {dateFormatter.format(new Date(currentPost.contentModifiedAt))}
             </span>
           ) : null}
           <span>조회 {currentPost.totalPageviews}</span>


### PR DESCRIPTION
## Summary

Closes #203

Completes the remaining client-side admin post controls by wiring bulk visibility into the bulk action payload and adding preview-page `contentModifiedAt` controls.

Note: the client continues to target `PATCH /api/admin/posts/bulk`, but that route is not present in the current local server tree, so bulk actions remain dependent on the server-side issue landing.

## Changes

| File | Change |
|------|--------|
| `src/widgets/admin-post-list/ui/bulk-actions.tsx` | Added bulk visibility selector, reset handling, and confirmation copy |
| `src/app/manage/posts/page.tsx` | Passed bulk visibility through the combined update action |
| `src/entities/post/model.ts` | Extended bulk action payload with `visibility` |
| `src/widgets/admin-post-preview/ui/post-preview.tsx` | Added modified-date set/remove controls and surfaced current modified date in preview metadata |

## Screenshots

UI change only. Not attached in CLI flow.
