### PR TITLE
feat: support hidden comment restore (#254)

### DIFF
--- a/src/entities/asset/ui/asset-picker-modal.tsx
+++ b/src/entities/asset/ui/asset-picker-modal.tsx
@@ -58,6 +58,7 @@ export function AssetPickerModal({
       isOpen={isOpen}
       onClose={onClose}
       withBackground
+      aria-label="에셋 선택"
       className="w-[min(94vw,72rem)] p-0 text-left"
     >
       <div className="flex h-[min(88vh,56rem)] flex-col overflow-hidden rounded-[1.5rem] bg-background-1">

--- a/src/features/asset-uploader/ui/asset-detail-modal.tsx
+++ b/src/features/asset-uploader/ui/asset-detail-modal.tsx
@@ -75,6 +75,7 @@ export function AssetDetailModal({
       isOpen={Boolean(asset)}
       onClose={onClose}
       withBackground
+      aria-label="에셋 상세 보기"
       className="w-[min(94vw,72rem)] p-0 text-left"
     >
       <div className="flex max-h-[90vh] flex-col overflow-hidden rounded-[1.5rem] bg-background-1">

--- a/src/features/asset-uploader/ui/asset-uploader.tsx
+++ b/src/features/asset-uploader/ui/asset-uploader.tsx
@@ -472,6 +472,7 @@ function DeleteAssetsModal({
       isOpen={ids.length > 0}
       onClose={onCancel}
       withBackground
+      aria-label={ids.length === 1 ? "에셋 삭제 확인" : "에셋 일괄 삭제 확인"}
       className="w-[min(100%,30rem)] p-0 text-left"
     >
       <div className="border-b border-border-3 px-6 py-5">

--- a/src/features/category-manager/ui/category-delete-modal.tsx
+++ b/src/features/category-manager/ui/category-delete-modal.tsx
@@ -70,6 +70,7 @@ export function CategoryDeleteModal({
         }
       }}
       withBackground
+      aria-label="카테고리 삭제"
       className="w-[min(100%,34rem)] p-0 text-left"
     >
       <div className="border-b border-border-3 px-6 py-5">

--- a/src/features/category-manager/ui/category-form-modal.tsx
+++ b/src/features/category-manager/ui/category-form-modal.tsx
@@ -89,6 +89,7 @@ export function CategoryFormModal({
         }
       }}
       withBackground
+      aria-label={title}
       className="w-[min(100%,40rem)] p-0 text-left"
     >
       <div className="border-b border-border-3 px-6 py-5">

--- a/src/features/comment-section/ui/comment-list.tsx
+++ b/src/features/comment-section/ui/comment-list.tsx
@@ -798,6 +798,7 @@ export function CommentList({
           setDeleteError(null);
         }}
         withBackground
+        aria-label="댓글 삭제"
       >
         <div className="p-6 text-left">
           <p className="text-body-xs uppercase tracking-[0.2em] text-text-4">

--- a/src/features/guestbook-form/ui/guestbook-page-content.tsx
+++ b/src/features/guestbook-form/ui/guestbook-page-content.tsx
@@ -356,6 +356,7 @@ export function GuestbookPageContent({
           setDeleteError(null);
         }}
         withBackground
+        aria-label="방명록 삭제"
       >
         <div className="p-6 text-left">
           <p className="text-body-xs uppercase tracking-[0.2em] text-text-4">

--- a/src/features/guestbook-manager/ui/guestbook-action-modal.tsx
+++ b/src/features/guestbook-manager/ui/guestbook-action-modal.tsx
@@ -74,6 +74,7 @@ export function GuestbookActionModal({
       isOpen={isOpen}
       onClose={handleClose}
       withBackground
+      aria-label={title}
       className="w-full max-w-[34rem]"
     >
       <div className="flex flex-col gap-5 p-6 text-left">

--- a/src/features/guestbook-manager/ui/guestbook-detail-modal.tsx
+++ b/src/features/guestbook-manager/ui/guestbook-detail-modal.tsx
@@ -102,6 +102,7 @@ export function GuestbookDetailModal({
       isOpen={isOpen}
       onClose={onClose}
       withBackground
+      aria-label="방명록 상세 보기"
       className="w-full max-w-[44rem]"
     >
       <div className="flex max-h-[80vh] flex-col text-left">

--- a/src/features/post-editor/ui/image-gallery-modal.tsx
+++ b/src/features/post-editor/ui/image-gallery-modal.tsx
@@ -25,7 +25,12 @@ export function ImageGalleryModal({
   });
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} withBackground>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      withBackground
+      aria-label="이미지 삽입"
+    >
       <div className="flex h-[min(88vh,52rem)] w-[min(92vw,64rem)] flex-col overflow-hidden rounded-[1.5rem] bg-background-1 text-left">
         <div className="border-b border-border-3 px-6 py-5">
           <p className="text-xs uppercase tracking-[0.24em] text-text-4">

--- a/src/features/post-editor/ui/preview-modal.tsx
+++ b/src/features/post-editor/ui/preview-modal.tsx
@@ -11,7 +11,12 @@ interface PreviewModalProps {
 
 export function PreviewModal({ isOpen, value, onClose }: PreviewModalProps) {
   return (
-    <Modal isOpen={isOpen} onClose={onClose} withBackground>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      withBackground
+      aria-label="마크다운 미리보기"
+    >
       <div className="flex h-[min(88vh,60rem)] w-[min(92vw,72rem)] flex-col overflow-hidden rounded-[1.5rem] bg-background-1 text-left">
         <div className="flex items-center justify-between border-b border-border-3 px-6 py-4">
           <div>

--- a/src/features/post-editor/ui/publish-confirm-modal.tsx
+++ b/src/features/post-editor/ui/publish-confirm-modal.tsx
@@ -16,7 +16,12 @@ export function PublishConfirmModal({
   onConfirm,
 }: PublishConfirmModalProps) {
   return (
-    <Modal isOpen={isOpen} onClose={onClose} withBackground>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      withBackground
+      aria-label="게시글 발행 확인"
+    >
       <div className="w-full max-w-xl rounded-[1.5rem] bg-background-1 p-6">
         <div className="space-y-2">
           <p className="text-xs uppercase tracking-[0.24em] text-text-4">

--- a/src/shared/ui/confirm-dialog.tsx
+++ b/src/shared/ui/confirm-dialog.tsx
@@ -26,7 +26,7 @@ export function ConfirmDialog({
   isPending,
 }: ConfirmDialogProps) {
   return (
-    <Modal isOpen={isOpen} onClose={onClose} withBackground>
+    <Modal isOpen={isOpen} onClose={onClose} withBackground aria-label={title}>
       <div className="flex flex-col gap-5 p-6 text-left">
         <h2 className="text-base font-semibold text-text-1">{title}</h2>
 

--- a/src/shared/ui/libs/modal.tsx
+++ b/src/shared/ui/libs/modal.tsx
@@ -10,6 +10,8 @@ type ModalProps = {
   withBackground?: boolean;
   className?: string;
   children?: React.ReactNode;
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
 };
 
 const Modal: React.FC<ModalProps> = ({
@@ -18,6 +20,8 @@ const Modal: React.FC<ModalProps> = ({
   withBackground = false,
   className,
   children,
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledby,
 }) => {
   const dialogRef = useRef<HTMLDivElement>(null);
 
@@ -123,8 +127,6 @@ const Modal: React.FC<ModalProps> = ({
         withBackground && "bg-grey-2/50",
       )}
       onClick={onClose}
-      role="dialog"
-      aria-modal="true"
     >
       <div
         ref={dialogRef}
@@ -138,6 +140,10 @@ const Modal: React.FC<ModalProps> = ({
         )}
         onClick={(e) => e.stopPropagation()}
         tabIndex={-1}
+        role="dialog"
+        aria-modal="true"
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledby}
       >
         {children}
       </div>

--- a/src/widgets/admin-comments/ui/admin-comments-page.tsx
+++ b/src/widgets/admin-comments/ui/admin-comments-page.tsx
@@ -51,7 +51,7 @@ type ActionContext =
   | null;
 
 function getAllowedActionsForStatus(status: AdminCommentItem["status"]) {
-  if (status === "deleted") {
+  if (status === "deleted" || status === "hidden") {
     return ["restore", "hard_delete"] as const;
   }
 
@@ -384,11 +384,11 @@ export function AdminCommentsPage() {
   }, [actionContext]);
 
   const actionModalTitle =
-    actionContext?.type === "bulk" ? "일괄 삭제" : "댓글 삭제";
+    actionContext?.type === "bulk" ? "댓글 일괄 작업" : "댓글 작업";
   const actionModalDescription =
     actionContext?.type === "bulk"
-      ? `${actionContext.items.length}개 댓글을 처리합니다.`
-      : "삭제 방식을 선택하세요.";
+      ? `${actionContext.items.length}개 댓글에 적용할 작업을 선택하세요.`
+      : "댓글에 적용할 작업을 선택하세요.";
   const actionModalCount =
     actionContext?.type === "bulk" ? actionContext.items.length : 1;
   const actionModalActions =

--- a/src/widgets/admin-comments/ui/comment-delete-modal.tsx
+++ b/src/widgets/admin-comments/ui/comment-delete-modal.tsx
@@ -35,7 +35,7 @@ interface ActionOption {
 const OPTION_MAP: Record<CommentManageAction, Omit<ActionOption, "value">> = {
   restore: {
     label: "복원",
-    description: "삭제된 댓글을 다시 정상 상태로 되돌립니다.",
+    description: "숨김 또는 삭제된 댓글을 다시 정상 상태로 되돌립니다.",
   },
   soft_delete: {
     label: "소프트 삭제",
@@ -124,6 +124,7 @@ export function CommentDeleteModal({
       isOpen={isOpen}
       onClose={handleClose}
       withBackground
+      aria-label={title}
       className="w-full max-w-[34rem]"
     >
       <div className="flex flex-col gap-5 p-6 text-left">

--- a/src/widgets/admin-comments/ui/comment-detail-modal.tsx
+++ b/src/widgets/admin-comments/ui/comment-detail-modal.tsx
@@ -190,6 +190,7 @@ export function CommentDetailModal({
       isOpen={isOpen}
       onClose={onClose}
       withBackground
+      aria-label={mode === "thread" ? "댓글 스레드 보기" : "댓글 상세 보기"}
       className="w-full max-w-xl overflow-hidden rounded-[1.5rem] border border-border-3 bg-background-2"
     >
       <div className="relative flex max-h-[85vh] flex-col">
@@ -266,7 +267,7 @@ function DetailView({
 }: DetailViewProps) {
   const isReply = comment.depth > 0;
   const actionButtons =
-    comment.status === "deleted"
+    comment.status === "deleted" || comment.status === "hidden"
       ? [
           {
             value: "restore" as const,

--- a/src/widgets/admin-comments/ui/comment-table.tsx
+++ b/src/widgets/admin-comments/ui/comment-table.tsx
@@ -190,14 +190,14 @@ export function CommentTable({
                       onClick={() => onManage(item)}
                       className={cn(
                         "inline-flex items-center justify-center rounded-[0.75rem] border px-3 py-2 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
-                        item.status === "deleted"
+                        item.status === "deleted" || item.status === "hidden"
                           ? "border-border-3 text-text-2 hover:border-border-2 hover:text-text-1"
                           : "border-negative-1/30 text-negative-1 hover:bg-negative-1/10",
                       )}
                     >
                       {deletingId === item.id
                         ? "처리 중"
-                        : item.status === "deleted"
+                        : item.status === "deleted" || item.status === "hidden"
                           ? "관리"
                           : "삭제"}
                     </button>


### PR DESCRIPTION
## Summary

Closes #254

Admin 댓글 관리에서 `hidden` 상태 복원 흐름을 연결하고, 공용 `Modal` 컴포넌트에 explicit accessible name 전달 경로를 추가했습니다.

## Changes

| File | Change |
|------|--------|
| `src/widgets/admin-comments/ui/admin-comments-page.tsx` | `hidden` 상태를 복원 가능 상태로 포함하고 작업 모달 카피를 일반 작업 흐름으로 조정 |
| `src/widgets/admin-comments/ui/comment-detail-modal.tsx` | `hidden` 댓글 상세 모달에서 복원 액션을 노출하고 모달 accessible name 추가 |
| `src/widgets/admin-comments/ui/comment-delete-modal.tsx` | 복원 설명을 `hidden | deleted -> active` 계약에 맞게 수정하고 accessible name 전달 |
| `src/widgets/admin-comments/ui/comment-table.tsx` | `hidden` 댓글 행에서도 관리 액션을 노출 |
| `src/shared/ui/libs/modal.tsx` | `aria-label` / `aria-labelledby` 전달을 지원하고 dialog semantics를 실제 dialog element로 이동 |
| `src/features/**`, `src/entities/asset/ui/asset-picker-modal.tsx`, `src/shared/ui/confirm-dialog.tsx` | 모든 `Modal` 사용처에 explicit accessible name 추가 |

## Screenshots

UI wording and accessibility wiring changes only.
