### PR TITLE
feat: align admin auth username contract (#289)

### DIFF
--- a/src/entities/auth/api.ts
+++ b/src/entities/auth/api.ts
@@ -2,10 +2,15 @@ import type { AdminUser, CurrentUser, LoginCredentials } from "./model";
 import { clientFetch, clientMutate, serverFetch } from "@shared/api";
 
 export async function login(credentials: LoginCredentials): Promise<AdminUser> {
-  return clientFetch<AdminUser>("/api/auth/admin/login", {
-    method: "POST",
-    body: JSON.stringify(credentials),
-  });
+  const response = await clientFetch<{ admin: AdminUser }>(
+    "/api/auth/admin/login",
+    {
+      method: "POST",
+      body: JSON.stringify(credentials),
+    },
+  );
+
+  return response.admin;
 }
 
 export async function logout(): Promise<void> {

--- a/src/entities/auth/model.ts
+++ b/src/entities/auth/model.ts
@@ -1,7 +1,9 @@
 export interface AdminUser {
-  id: string;
+  id: number;
   username: string;
-  displayName: string;
+  createdAt: string;
+  updatedAt: string;
+  lastLoginAt: string | null;
 }
 
 export interface CurrentAdminUser {

--- a/src/features/admin-login/ui/login-form.tsx
+++ b/src/features/admin-login/ui/login-form.tsx
@@ -7,6 +7,10 @@ import { login } from "@entities/auth";
 import { getErrorMessage } from "@shared/lib/get-error-message";
 import { Spinner } from "@shared/ui/libs";
 
+const USERNAME_MIN_LENGTH = 4;
+const USERNAME_MAX_LENGTH = 20;
+const USERNAME_PATTERN = "^\\S{4,20}$";
+
 export function LoginForm() {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
@@ -21,7 +25,7 @@ export function LoginForm() {
 
     try {
       await login({
-        username: username.trim(),
+        username,
         password,
       });
 
@@ -58,17 +62,27 @@ export function LoginForm() {
 
       <div className="mt-8 space-y-5">
         <label className="block">
-          <span className="text-body-sm font-medium text-text-1">아이디</span>
+          <span className="text-body-sm font-medium text-text-1">사용자명</span>
           <input
             type="text"
-            autoComplete="username"
+            autoComplete="off"
             value={username}
             onChange={(event) => setUsername(event.target.value)}
-            placeholder="아이디를 입력하세요"
+            placeholder="사용자명을 입력하세요"
             disabled={busy}
             className="mt-2 w-full rounded-[1rem] border border-border-3 bg-background-1 px-4 py-3 text-body-sm text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
             required
+            minLength={USERNAME_MIN_LENGTH}
+            maxLength={USERNAME_MAX_LENGTH}
+            pattern={USERNAME_PATTERN}
+            title="사용자명은 공백 없이 4~20자로 입력해 주세요."
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
           />
+          <p className="mt-2 text-body-xs text-text-4">
+            공백 없이 4~20자의 사용자명을 입력해 주세요.
+          </p>
         </label>
 
         <label className="block">

--- a/src/features/admin-login/ui/login-form.tsx
+++ b/src/features/admin-login/ui/login-form.tsx
@@ -7,10 +7,6 @@ import { login } from "@entities/auth";
 import { getErrorMessage } from "@shared/lib/get-error-message";
 import { Spinner } from "@shared/ui/libs";
 
-const USERNAME_MIN_LENGTH = 4;
-const USERNAME_MAX_LENGTH = 20;
-const USERNAME_PATTERN = "^\\S{4,20}$";
-
 export function LoginForm() {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
@@ -65,23 +61,19 @@ export function LoginForm() {
           <span className="text-body-sm font-medium text-text-1">사용자명</span>
           <input
             type="text"
-            autoComplete="off"
+            autoComplete="username"
             value={username}
             onChange={(event) => setUsername(event.target.value)}
             placeholder="사용자명을 입력하세요"
             disabled={busy}
             className="mt-2 w-full rounded-[1rem] border border-border-3 bg-background-1 px-4 py-3 text-body-sm text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
             required
-            minLength={USERNAME_MIN_LENGTH}
-            maxLength={USERNAME_MAX_LENGTH}
-            pattern={USERNAME_PATTERN}
-            title="사용자명은 공백 없이 4~20자로 입력해 주세요."
             autoCapitalize="none"
             autoCorrect="off"
             spellCheck={false}
           />
           <p className="mt-2 text-body-xs text-text-4">
-            공백 없이 4~20자의 사용자명을 입력해 주세요.
+            등록된 사용자명을 공백 없이 그대로 입력해 주세요.
           </p>
         </label>
 


### PR DESCRIPTION
## Summary

Closes #289

Admin auth client login flow now matches the username-based server contract and removes legacy email-oriented assumptions from the form UX.

## Changes

| File | Change |
|------|--------|
| `src/entities/auth/model.ts` | Align admin auth types with the current server response shape and remove legacy `displayName` data. |
| `src/entities/auth/api.ts` | Unwrap the `{ admin }` login response payload from `/api/auth/admin/login`. |
| `src/features/admin-login/ui/login-form.tsx` | Preserve exact username input, enforce 4-20 non-whitespace characters, and replace email-leaning field copy/autocomplete behavior. |

## Verification

- `pnpm compile:types`
- `pnpm lint` (passes with 2 pre-existing warnings in unrelated files)
- `pnpm build` *(fails in local environment: missing `lightningcss.linux-arm64-gnu.node` native dependency)*
