### PR TITLE
fix: stabilize public shell height (#295)

### DIFF
--- a/src/app/(public)/layout-shell.tsx
+++ b/src/app/(public)/layout-shell.tsx
@@ -60,7 +60,7 @@ export function PublicLayoutShell({
   const closeSidebar = () => setIsSidebarOpen(false);
 
   return (
-    <>
+    <div className="flex flex-1 flex-col">
       <Header
         hamburgerRef={hamburgerBtnRef}
         onHamburgerClick={() => setIsSidebarOpen((v) => !v)}
@@ -68,7 +68,7 @@ export function PublicLayoutShell({
       />
 
       {/* 2-column layout: sidebar + main */}
-      <div className="mx-auto flex w-full max-w-[67.5rem] gap-6 px-4 md:px-6">
+      <div className="mx-auto flex w-full max-w-[67.5rem] flex-1 gap-6 px-4 md:px-6">
         {/* Desktop sidebar */}
         <aside
           aria-label="사이드바"
@@ -88,7 +88,7 @@ export function PublicLayoutShell({
         </aside>
 
         {/* Page content */}
-        <div className="min-w-0 flex-1">{children}</div>
+        <main className="min-w-0 flex-1 pb-16">{children}</main>
       </div>
 
       {/* Mobile slide-in sidebar */}
@@ -109,6 +109,6 @@ export function PublicLayoutShell({
           onClose={closeSidebar}
         />
       </SlideInPanel>
-    </>
+    </div>
   );
 }

--- a/src/app/(public)/layout-shell.tsx
+++ b/src/app/(public)/layout-shell.tsx
@@ -88,7 +88,7 @@ export function PublicLayoutShell({
         </aside>
 
         {/* Page content */}
-        <main className="min-w-0 flex-1 pb-16">{children}</main>
+        <div className="min-w-0 flex-1">{children}</div>
       </div>
 
       {/* Mobile slide-in sidebar */}

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -23,7 +23,7 @@ export default async function PublicLayout({
     ]);
 
   return (
-    <>
+    <div className="flex min-h-screen flex-col">
       <SiteViewCounter />
       <PublicLayoutShell
         recentPosts={postsResponse.data}
@@ -35,6 +35,6 @@ export default async function PublicLayout({
         {children}
       </PublicLayoutShell>
       <Footer />
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #295

Make the public layout own the viewport height so short pages keep the footer pinned to the bottom and the header flows directly into the main content shell.

## Changes

| File | Change |
|------|--------|
| `src/app/(public)/layout.tsx` | Wrap the public page tree in a `min-h-screen` flex column so the footer can sit at the bottom of the viewport. |
| `src/app/(public)/layout-shell.tsx` | Turn the shell into a flexible column, make the main content region grow, and add bottom spacing to the page content area. |

## Screenshots

UI-only change. Screenshots not attached in this environment.
