### PR TITLE
feat: simplify admin login screen (#296)

### DIFF
--- a/src/app/manage/login/layout.tsx
+++ b/src/app/manage/login/layout.tsx
@@ -3,13 +3,5 @@ export default function DashboardLoginLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <div className="relative min-h-screen overflow-hidden bg-background-1">
-      <div className="absolute inset-x-0 top-0 h-80 bg-[radial-gradient(circle_at_top,rgba(138,111,224,0.18),transparent_60%)]" />
-      <div className="absolute inset-x-0 bottom-0 h-64 bg-[radial-gradient(circle_at_bottom,rgba(16,198,125,0.12),transparent_60%)]" />
-      <div className="relative mx-auto flex min-h-screen w-full max-w-6xl items-center px-6 py-12">
-        {children}
-      </div>
-    </div>
-  );
+  return <div className="min-h-screen bg-background-1">{children}</div>;
 }

--- a/src/app/manage/login/page.tsx
+++ b/src/app/manage/login/page.tsx
@@ -1,24 +1,5 @@
 import { LoginForm } from "@features/admin-login";
 
 export default function ManageLoginPage() {
-  return (
-    <main className="grid w-full gap-10 lg:grid-cols-[minmax(0,1.1fr)_minmax(360px,440px)] lg:items-center">
-      <section className="max-w-2xl">
-        <p className="text-body-xs uppercase tracking-[0.28em] text-text-4">
-          Pyosh Blog Admin
-        </p>
-        <h1 className="mt-4 text-display-xs text-text-1">
-          콘텐츠 운영을 위한
-          <br />
-          관리자 로그인
-        </h1>
-        <p className="mt-5 max-w-xl text-body-md text-text-3">
-          대시보드, 글 관리, 통계 화면은 관리자 인증 후에만 접근할 수 있습니다.
-          로그인 후 즉시 `/manage`로 이동합니다.
-        </p>
-      </section>
-
-      <LoginForm />
-    </main>
-  );
+  return <LoginForm />;
 }

--- a/src/features/admin-login/ui/login-form.tsx
+++ b/src/features/admin-login/ui/login-form.tsx
@@ -44,15 +44,12 @@ export function LoginForm() {
   return (
     <form
       onSubmit={handleSubmit}
-      className="rounded-[2rem] border border-border-3 bg-background-2 p-8 shadow-[0px_24px_80px_0px_rgba(0,0,0,0.08)]"
+      className="mx-auto flex min-h-screen w-full max-w-md flex-col justify-center px-6 py-12"
     >
       <div>
-        <p className="text-body-xs uppercase tracking-[0.24em] text-text-4">
-          Admin access
-        </p>
-        <h2 className="mt-3 text-h2 text-text-1">관리자 로그인</h2>
+        <h1 className="text-h2 text-text-1">관리자 로그인</h1>
         <p className="mt-3 text-body-sm text-text-3">
-          관리자 계정으로 로그인해 대시보드와 글 관리 기능에 접근합니다.
+          관리자 계정으로 로그인해 대시보드로 이동합니다.
         </p>
       </div>
 


### PR DESCRIPTION
## Summary

Closes #296

단순 중앙 정렬 로그인 화면으로 `/manage/login`을 재구성하고, 배경 장식 및 소개 레이아웃을 제거했습니다.

## Changes

| File | Change |
|------|--------|
| `src/app/manage/login/layout.tsx` | 로그인 레이아웃에서 그라데이션 장식 레이어와 넓은 컨테이너 래퍼를 제거하고 단색 배경만 유지 |
| `src/app/manage/login/page.tsx` | 소개 섹션을 제거하고 페이지가 로그인 폼만 렌더링하도록 단순화 |
| `src/features/admin-login/ui/login-form.tsx` | 로그인 폼을 화면 중앙 정렬 구조로 변경하고 헤더 카피를 간결하게 조정 |
