### PR TITLE
fix: scope public header to public layout (#297)

### DIFF
--- a/src/app-layer/provider/index.tsx
+++ b/src/app-layer/provider/index.tsx
@@ -4,7 +4,6 @@ import { PropsWithChildren, useEffect } from "react";
 import { QueryProvider } from "@app-layer/provider/query-provider";
 import { ToastProvider } from "@app-layer/provider/toast-provider";
 import { ThemeProvider } from "@app-layer/theme";
-import { Header } from "@widgets/header";
 
 interface IProps extends PropsWithChildren {
   initialTheme: string;
@@ -32,7 +31,6 @@ export default function Providers({ children, initialTheme }: IProps) {
   return (
     <QueryProvider>
       <ThemeProvider initialTheme={initialTheme}>
-        <Header />
         {children}
         <ToastProvider />
       </ThemeProvider>


### PR DESCRIPTION
## Summary

Closes #297

Remove the public header from the global app provider so admin routes only render the admin shell chrome.

## Changes

| File | Change |
|------|--------|
| `src/app-layer/provider/index.tsx` | Stop rendering the public `Header` at the provider level so route-specific layouts own their own header chrome. |

