### PR TITLE
fix: keep category controls in empty state (#298)

### DIFF
--- a/src/features/category-manager/ui/category-tree-toolbar.tsx
+++ b/src/features/category-manager/ui/category-tree-toolbar.tsx
@@ -38,6 +38,7 @@ export function CategoryTreeToolbar({
 }: CategoryTreeToolbarProps) {
   const isSelectMode = mode === "select";
   const isEditMode = mode === "edit";
+  const hasCategories = totalCount > 0;
 
   return (
     <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
@@ -91,22 +92,26 @@ export function CategoryTreeToolbar({
 
       {!isSelectMode && !isEditMode ? (
         <div className="flex flex-wrap items-center gap-2">
-          <button
-            type="button"
-            onClick={onEnterSelectMode}
-            className="inline-flex h-10 items-center justify-center gap-1.5 whitespace-nowrap rounded-lg border border-border-3 px-4 text-sm font-normal leading-none text-text-2 transition-colors hover:bg-background-3"
-          >
-            <Icon icon={checkSquareLinear} width="18" aria-hidden="true" />
-            일괄 선택
-          </button>
-          <button
-            type="button"
-            onClick={onEnterEditMode}
-            className="inline-flex h-10 items-center justify-center gap-1.5 whitespace-nowrap rounded-lg border border-border-3 px-4 text-sm font-normal leading-none text-text-2 transition-colors hover:bg-background-3"
-          >
-            <Icon icon={sortVerticalLinear} width="18" aria-hidden="true" />
-            배치 편집
-          </button>
+          {hasCategories ? (
+            <>
+              <button
+                type="button"
+                onClick={onEnterSelectMode}
+                className="inline-flex h-10 items-center justify-center gap-1.5 whitespace-nowrap rounded-lg border border-border-3 px-4 text-sm font-normal leading-none text-text-2 transition-colors hover:bg-background-3"
+              >
+                <Icon icon={checkSquareLinear} width="18" aria-hidden="true" />
+                일괄 선택
+              </button>
+              <button
+                type="button"
+                onClick={onEnterEditMode}
+                className="inline-flex h-10 items-center justify-center gap-1.5 whitespace-nowrap rounded-lg border border-border-3 px-4 text-sm font-normal leading-none text-text-2 transition-colors hover:bg-background-3"
+              >
+                <Icon icon={sortVerticalLinear} width="18" aria-hidden="true" />
+                배치 편집
+              </button>
+            </>
+          ) : null}
           <button
             type="button"
             onClick={onCreate}

--- a/src/features/category-manager/ui/category-tree.tsx
+++ b/src/features/category-manager/ui/category-tree.tsx
@@ -480,11 +480,7 @@ export function CategoryTree({
     };
   }, [clearHoverExpandTimer]);
 
-  if (categories.length === 0) {
-    return (
-      <EmptyState message="카테고리가 없습니다. 새 카테고리를 생성하세요." />
-    );
-  }
+  const isEmpty = categories.length === 0;
 
   return (
     <>
@@ -503,58 +499,64 @@ export function CategoryTree({
           onEnterEditMode={handleEnterEditMode}
         />
 
-        <DndContext
-          sensors={sensors}
-          collisionDetection={collisionDetection}
-          onDragStart={handleDragStart}
-          onDragMove={handleDragMove}
-          onDragEnd={handleDragEnd}
-          onDragCancel={() => {
-            collapseAutoExpandedNodes();
-            clearHoverExpandTimer();
-            prevDropTargetRef.current = null;
-            setActiveDragId(null);
-            setDropTarget(null);
-          }}
-        >
+        {isEmpty ? (
           <div className="overflow-hidden rounded-xl border border-border-4 bg-background-2">
-            <ul>
-              {visibleRows.map(({ category, depth, hasVisibleChildren }) => (
-                <CategoryTreeRow
-                  key={category.id}
-                  category={category}
-                  depth={depth}
-                  mode={mode}
-                  hasVisibleChildren={hasVisibleChildren}
-                  isExpanded={expandedIds.has(category.id)}
-                  isSelected={selectedIds.has(category.id)}
-                  showSlug={showSlug}
-                  changeMarker={changeMarkerMap.get(category.id)}
-                  dropTarget={dropTarget}
-                  onToggle={handleToggle}
-                  onToggleVisibility={(nextCategory) =>
-                    void onToggleVisibility(nextCategory)
-                  }
-                  onSelectToggle={handleToggleSelect}
-                  onEdit={onEdit}
-                  onDelete={onDelete}
-                />
-              ))}
-            </ul>
+            <EmptyState message="카테고리가 없습니다. 새 카테고리를 생성하세요." />
           </div>
+        ) : (
+          <DndContext
+            sensors={sensors}
+            collisionDetection={collisionDetection}
+            onDragStart={handleDragStart}
+            onDragMove={handleDragMove}
+            onDragEnd={handleDragEnd}
+            onDragCancel={() => {
+              collapseAutoExpandedNodes();
+              clearHoverExpandTimer();
+              prevDropTargetRef.current = null;
+              setActiveDragId(null);
+              setDropTarget(null);
+            }}
+          >
+            <div className="overflow-hidden rounded-xl border border-border-4 bg-background-2">
+              <ul>
+                {visibleRows.map(({ category, depth, hasVisibleChildren }) => (
+                  <CategoryTreeRow
+                    key={category.id}
+                    category={category}
+                    depth={depth}
+                    mode={mode}
+                    hasVisibleChildren={hasVisibleChildren}
+                    isExpanded={expandedIds.has(category.id)}
+                    isSelected={selectedIds.has(category.id)}
+                    showSlug={showSlug}
+                    changeMarker={changeMarkerMap.get(category.id)}
+                    dropTarget={dropTarget}
+                    onToggle={handleToggle}
+                    onToggleVisibility={(nextCategory) =>
+                      void onToggleVisibility(nextCategory)
+                    }
+                    onSelectToggle={handleToggleSelect}
+                    onEdit={onEdit}
+                    onDelete={onDelete}
+                  />
+                ))}
+              </ul>
+            </div>
 
-          <DragOverlay>
-            {activeRow ? (
-              <CategoryTreeRowPreview
-                category={activeRow.category}
-                depth={activeRow.depth}
-                changeMarker={changeMarkerMap.get(activeRow.category.id)}
-                dropPosition={dropTarget?.position ?? null}
-                invalidDrop={dropTarget?.invalid ?? false}
-              />
-            ) : null}
-          </DragOverlay>
-        </DndContext>
+            <DragOverlay>
+              {activeRow ? (
+                <CategoryTreeRowPreview
+                  category={activeRow.category}
+                  depth={activeRow.depth}
+                  changeMarker={changeMarkerMap.get(activeRow.category.id)}
+                  dropPosition={dropTarget?.position ?? null}
+                  invalidDrop={dropTarget?.invalid ?? false}
+                />
+              ) : null}
+            </DragOverlay>
+          </DndContext>
+        )}
 
         {mode === "select" ? (
           <div className="fixed bottom-0 left-0 right-0 z-20 md:left-[var(--admin-sidebar-offset)]">


### PR DESCRIPTION
## Summary

Closes #298

카테고리 목록이 비어 있어도 관리 toolbar/control box가 계속 노출되도록 empty state 렌더링 경로를 조정했습니다.

## Changes

| File | Change |
|------|--------|
| `src/features/category-manager/ui/category-tree.tsx` | 빈 카테고리 상태에서도 toolbar를 유지하고, empty state는 콘텐츠 영역으로만 렌더링되도록 변경 |
