### PR TITLE
fix: normalize dev asset urls (#299)

### DIFF
--- a/src/entities/asset/api.ts
+++ b/src/entities/asset/api.ts
@@ -50,7 +50,7 @@ export async function uploadAssets(
       if (xhr.status >= 200 && xhr.status < 300) {
         try {
           const data = JSON.parse(xhr.responseText) as UploadAssetsResponse;
-          resolve(data.assets.map(normalizeAsset));
+          resolve(data.assets);
         } catch {
           reject(new Error("응답을 파싱할 수 없습니다."));
         }

--- a/src/entities/asset/api.ts
+++ b/src/entities/asset/api.ts
@@ -7,6 +7,7 @@ import {
   clientMutate,
   getCsrfToken,
 } from "@shared/api";
+import { normalizeAssetUrl } from "@shared/lib/asset-url";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5500";
 
@@ -14,9 +15,14 @@ export async function fetchAssets(
   page = 1,
   limit = 20,
 ): Promise<PaginatedResponse<Asset>> {
-  return clientFetch<PaginatedResponse<Asset>>(
+  const response = await clientFetch<PaginatedResponse<Asset>>(
     `/api/assets?page=${page}&limit=${limit}`,
   );
+
+  return {
+    ...response,
+    data: response.data.map(normalizeAsset),
+  };
 }
 
 export async function uploadAssets(
@@ -44,7 +50,7 @@ export async function uploadAssets(
       if (xhr.status >= 200 && xhr.status < 300) {
         try {
           const data = JSON.parse(xhr.responseText) as UploadAssetsResponse;
-          resolve(data.assets);
+          resolve(data.assets.map(normalizeAsset));
         } catch {
           reject(new Error("응답을 파싱할 수 없습니다."));
         }
@@ -86,4 +92,11 @@ export async function deleteAssets(ids: number[]): Promise<void> {
     method: "DELETE",
     body: JSON.stringify({ ids }),
   });
+}
+
+function normalizeAsset<T extends UploadedAsset>(asset: T): T {
+  return {
+    ...asset,
+    url: normalizeAssetUrl(asset.url),
+  };
 }

--- a/src/entities/asset/lib.ts
+++ b/src/entities/asset/lib.ts
@@ -1,4 +1,5 @@
 import type { Asset } from "./model";
+import { toCanonicalAssetUrl } from "@shared/lib/asset-url";
 
 const assetDateFormatter = new Intl.DateTimeFormat("ko-KR", {
   year: "numeric",
@@ -43,5 +44,7 @@ export function formatAssetDate(createdAt: string): string {
 }
 
 export function buildAssetMarkdown(asset: Pick<Asset, "url">): string {
-  return `![${getAssetFilename(asset.url)}](${asset.url})`;
+  const canonicalUrl = toCanonicalAssetUrl(asset.url);
+
+  return `![${getAssetFilename(canonicalUrl)}](${canonicalUrl})`;
 }

--- a/src/entities/post/api.ts
+++ b/src/entities/post/api.ts
@@ -14,6 +14,7 @@ import type {
 } from "./model";
 import type { PaginatedResponse } from "@shared/api";
 import { clientFetch, clientMutate, serverFetch } from "@shared/api";
+import { normalizeOptionalAssetUrl } from "@shared/lib/asset-url";
 
 function buildPostSearchParams(params: FetchPostsParams): string {
   return buildSearchParams(params);
@@ -82,22 +83,29 @@ export async function fetchPosts(
   const queryString = buildPostSearchParams(params);
   const path = queryString ? `/api/posts?${queryString}` : "/api/posts";
 
-  return serverFetch<PaginatedResponse<PublishedPostListItem>>(
+  const response = await serverFetch<PaginatedResponse<PublishedPostListItem>>(
     path,
     {},
     cookieHeader,
   );
+
+  return normalizePostListResponse(response);
 }
 
 export async function fetchPostBySlug(
   slug: string,
   cookieHeader?: string,
 ): Promise<PostDetailWithNavigationResponse> {
-  return serverFetch<PostDetailWithNavigationResponse>(
+  const response = await serverFetch<PostDetailWithNavigationResponse>(
     `/api/posts/${encodeURIComponent(slug)}`,
     {},
     cookieHeader,
   );
+
+  return {
+    ...response,
+    post: normalizePost(response.post),
+  };
 }
 
 export async function fetchPublishedPostSlugs(
@@ -122,7 +130,7 @@ export async function fetchAdminPost(
       )
     : await clientFetch<PostDetailResponse>(`/api/admin/posts/${id}`);
 
-  return response.post;
+  return normalizePost(response.post);
 }
 
 export async function fetchAdminPosts(
@@ -134,9 +142,11 @@ export async function fetchAdminPosts(
     ? `/api/admin/posts?${queryString}`
     : "/api/admin/posts";
 
-  return cookieHeader
-    ? serverFetch<PaginatedResponse<PostListItem>>(path, {}, cookieHeader)
-    : clientFetch<PaginatedResponse<PostListItem>>(path);
+  const response = cookieHeader
+    ? await serverFetch<PaginatedResponse<PostListItem>>(path, {}, cookieHeader)
+    : await clientFetch<PaginatedResponse<PostListItem>>(path);
+
+  return normalizePostListResponse(response);
 }
 
 export async function fetchPinnedPostCount(): Promise<number> {
@@ -152,7 +162,7 @@ export async function createPost(body: CreatePostBody): Promise<PostDetail> {
     body: JSON.stringify(body),
   });
 
-  return response.post;
+  return normalizePost(response.post);
 }
 
 export async function deletePost(id: number): Promise<void> {
@@ -169,7 +179,7 @@ export async function restorePost(id: number): Promise<PostDetail> {
     },
   );
 
-  return response.post;
+  return normalizePost(response.post);
 }
 
 export async function hardDeletePost(id: number): Promise<void> {
@@ -190,7 +200,7 @@ export async function updatePost(
     },
   );
 
-  return response.post;
+  return normalizePost(response.post);
 }
 
 export async function bulkUpdatePosts(action: BulkPostAction): Promise<void> {
@@ -198,4 +208,20 @@ export async function bulkUpdatePosts(action: BulkPostAction): Promise<void> {
     method: "PATCH",
     body: JSON.stringify(action),
   });
+}
+
+function normalizePost<T extends PostListItem | PostDetail>(post: T): T {
+  return {
+    ...post,
+    thumbnailUrl: normalizeOptionalAssetUrl(post.thumbnailUrl),
+  };
+}
+
+function normalizePostListResponse<T extends PostListItem>(
+  response: PaginatedResponse<T>,
+): PaginatedResponse<T> {
+  return {
+    ...response,
+    data: response.data.map(normalizePost),
+  };
 }

--- a/src/features/asset-uploader/ui/asset-uploader.tsx
+++ b/src/features/asset-uploader/ui/asset-uploader.tsx
@@ -14,6 +14,7 @@ import {
   uploadAssets,
   type Asset,
 } from "@entities/asset";
+import { toCanonicalAssetUrl } from "@shared/lib/asset-url";
 import { getErrorMessage } from "@shared/lib/get-error-message";
 import { Modal, Spinner } from "@shared/ui/libs";
 
@@ -329,7 +330,10 @@ export function AssetUploader() {
   }
 
   async function handleCopy(asset: Asset, type: "url" | "markdown") {
-    const text = type === "url" ? asset.url : buildAssetMarkdown(asset);
+    const text =
+      type === "url"
+        ? toCanonicalAssetUrl(asset.url)
+        : buildAssetMarkdown(asset);
 
     try {
       await navigator.clipboard.writeText(text);

--- a/src/features/post-editor/ui/post-card-preview.tsx
+++ b/src/features/post-editor/ui/post-card-preview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { PostDetail } from "@entities/post";
+import { normalizeAssetUrl } from "@shared/lib/asset-url";
 
 interface PostCardPreviewProps {
   title: string;
@@ -24,6 +25,9 @@ export function PostCardPreview({
   compact = false,
 }: PostCardPreviewProps) {
   const effectiveSummary = summary.trim();
+  const displayThumbnailUrl = thumbnailUrl
+    ? normalizeAssetUrl(thumbnailUrl)
+    : thumbnailUrl;
   const statusLabel =
     status === "published" ? "발행" : status === "archived" ? "보관" : "작성중";
 
@@ -32,10 +36,10 @@ export function PostCardPreview({
       {compact ? (
         <div className="overflow-hidden rounded-[1rem] border border-border-3 bg-background-1">
           <div className="overflow-hidden bg-background-3">
-            {thumbnailUrl ? (
+            {displayThumbnailUrl ? (
               // eslint-disable-next-line @next/next/no-img-element -- arbitrary admin preview URLs are allowed
               <img
-                src={thumbnailUrl}
+                src={displayThumbnailUrl}
                 alt={title || "썸네일 미리보기"}
                 className="aspect-[8/5] w-full object-cover"
               />
@@ -62,10 +66,10 @@ export function PostCardPreview({
         <div className="rounded-[1rem] border border-border-3 bg-background-1 p-4">
           <div className="flex gap-4">
             <div className="w-[11rem] shrink-0 overflow-hidden rounded-[0.9rem] bg-background-3">
-              {thumbnailUrl ? (
+              {displayThumbnailUrl ? (
                 // eslint-disable-next-line @next/next/no-img-element -- arbitrary admin preview URLs are allowed
                 <img
-                  src={thumbnailUrl}
+                  src={displayThumbnailUrl}
                   alt={title || "썸네일 미리보기"}
                   className="aspect-[4/3] w-full object-cover"
                 />

--- a/src/features/post-editor/ui/post-form.tsx
+++ b/src/features/post-editor/ui/post-form.tsx
@@ -140,7 +140,7 @@ function buildPayload(values: PostFormValues): CreatePostBody {
     title: values.title.trim(),
     categoryId: values.categoryId ?? 0,
     contentMd: values.contentMd,
-    thumbnailUrl: values.thumbnailUrl.trim() || null,
+    thumbnailUrl: toCanonicalAssetUrl(values.thumbnailUrl.trim()) || null,
     status: values.status,
     visibility: values.visibility,
     commentStatus: values.commentStatus,

--- a/src/features/post-editor/ui/post-form.tsx
+++ b/src/features/post-editor/ui/post-form.tsx
@@ -47,6 +47,7 @@ import {
   type CreatePostBody,
   type PostDetail,
 } from "@entities/post";
+import { normalizeAssetUrl, toCanonicalAssetUrl } from "@shared/lib/asset-url";
 import { getErrorMessage } from "@shared/lib/get-error-message";
 import { cn } from "@shared/lib/style-utils";
 import { Spinner } from "@shared/ui/libs";
@@ -822,12 +823,13 @@ export function PostForm({
       return;
     }
 
+    const canonicalUrl = toCanonicalAssetUrl(asset.url);
     const alt =
-      asset.url
+      canonicalUrl
         .split("/")
         .pop()
         ?.replace(/\.[^./\\]+$/, "") || "이미지";
-    insertMarkdownImage(editorView, alt, asset.url);
+    insertMarkdownImage(editorView, alt, canonicalUrl);
     setShowImageGallery(false);
   }
 
@@ -1032,7 +1034,7 @@ export function PostForm({
                       {values.thumbnailUrl ? (
                         // eslint-disable-next-line @next/next/no-img-element -- arbitrary admin preview URLs are allowed
                         <img
-                          src={values.thumbnailUrl}
+                          src={normalizeAssetUrl(values.thumbnailUrl)}
                           alt="썸네일 미리보기"
                           className="h-9 w-12 object-cover"
                         />
@@ -1407,7 +1409,7 @@ export function PostForm({
         isOpen={showThumbnailPicker}
         onClose={() => setShowThumbnailPicker(false)}
         onSelect={(url) => {
-          handleFieldChange("thumbnailUrl", url);
+          handleFieldChange("thumbnailUrl", toCanonicalAssetUrl(url));
           setShowThumbnailPicker(false);
           toast.success("에셋 갤러리에서 썸네일을 선택했습니다.");
         }}

--- a/src/features/post-editor/ui/thumbnail-uploader.tsx
+++ b/src/features/post-editor/ui/thumbnail-uploader.tsx
@@ -7,6 +7,7 @@ import galleryWideLinear from "@iconify-icons/solar/gallery-wide-linear";
 import linkMinimalistic2Linear from "@iconify-icons/solar/link-minimalistic-2-linear";
 import { toast } from "sonner";
 import { AssetPickerModal, uploadAssets } from "@entities/asset";
+import { normalizeAssetUrl, toCanonicalAssetUrl } from "@shared/lib/asset-url";
 import { cn } from "@shared/lib/style-utils";
 import { Spinner } from "@shared/ui/libs";
 
@@ -124,7 +125,7 @@ export function ThumbnailUploader({ value, onChange }: ThumbnailUploaderProps) {
 
     try {
       const [asset] = await uploadAssets([file]);
-      onChange(asset.url);
+      onChange(toCanonicalAssetUrl(asset.url));
       setPendingFile(null);
       toast.success("썸네일을 업로드했습니다.");
     } catch {
@@ -225,7 +226,7 @@ export function ThumbnailUploader({ value, onChange }: ThumbnailUploaderProps) {
         {previewUrl || value ? (
           // eslint-disable-next-line @next/next/no-img-element -- arbitrary remote hosts are allowed for admin preview
           <img
-            src={previewUrl ?? value}
+            src={previewUrl ?? normalizeAssetUrl(value)}
             alt="썸네일 미리보기"
             className="max-h-44 rounded-[0.85rem] object-cover shadow-[0px_18px_40px_0px_rgba(0,0,0,0.08)]"
           />
@@ -292,7 +293,7 @@ export function ThumbnailUploader({ value, onChange }: ThumbnailUploaderProps) {
         isOpen={isPickerOpen}
         onClose={() => setIsPickerOpen(false)}
         onSelect={(url) => {
-          onChange(url);
+          onChange(toCanonicalAssetUrl(url));
           setPendingFile(null);
           setIsAwaitingPaste(false);
           setIsPickerOpen(false);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,22 +3,38 @@ import { NextResponse, type NextRequest } from "next/server";
 const MANAGE_LOGIN_PATH = "/manage/login";
 const MANAGE_HOME_PATH = "/manage";
 const API_URL = process.env.API_URL ?? "http://localhost:5500";
+const NEXT_PUBLIC_API_URL = process.env.NEXT_PUBLIC_API_URL?.trim() ?? "";
+
+function joinSources(...sources: Array<string | false | null | undefined>) {
+  return sources.filter(Boolean).join(" ");
+}
 
 function buildCspDirectives(nonce: string): string {
   const isDev = process.env.NODE_ENV === "development";
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "";
 
   return [
     "default-src 'self'",
     isDev
       ? "img-src 'self' http: https: data: blob:"
       : "img-src 'self' https: data: blob:",
-    `script-src 'nonce-${nonce}' 'strict-dynamic'`,
+    [
+      "script-src",
+      `'nonce-${nonce}'`,
+      "'strict-dynamic'",
+      ...(isDev ? ["'unsafe-eval'"] : []),
+    ].join(" "),
     "object-src 'none'",
     // Phase 2 prerequisite: replace 'unsafe-inline' with nonce-based styles before enforcement
-    "style-src 'self' 'unsafe-inline'",
+    joinSources(
+      "style-src 'self' 'unsafe-inline'",
+      "https://fonts.googleapis.com",
+    ),
     "font-src 'self' https://fonts.gstatic.com",
-    apiUrl ? `connect-src 'self' ${apiUrl}` : "connect-src 'self'",
+    joinSources(
+      "connect-src 'self'",
+      NEXT_PUBLIC_API_URL,
+      isDev ? "ws: wss:" : "",
+    ),
   ].join("; ");
 }
 

--- a/src/shared/lib/asset-url.ts
+++ b/src/shared/lib/asset-url.ts
@@ -1,6 +1,7 @@
 const FALLBACK_API_URL = "http://localhost:5500";
-const PUBLIC_API_URL =
-  process.env.NEXT_PUBLIC_API_URL?.trim() || FALLBACK_API_URL;
+const PUBLIC_API_URL = normalizeApiUrl(
+  process.env.NEXT_PUBLIC_API_URL?.trim() || FALLBACK_API_URL,
+);
 
 export function normalizeAssetUrl(url: string): string {
   const trimmedUrl = url.trim();
@@ -22,4 +23,31 @@ export function normalizeOptionalAssetUrl(url: string | null): string | null {
   }
 
   return normalizeAssetUrl(url);
+}
+
+export function toCanonicalAssetUrl(url: string): string {
+  const trimmedUrl = url.trim();
+
+  if (!trimmedUrl || !PUBLIC_API_URL) {
+    return trimmedUrl;
+  }
+
+  try {
+    const absoluteUrl = new URL(trimmedUrl);
+
+    if (
+      absoluteUrl.origin === new URL(PUBLIC_API_URL).origin &&
+      absoluteUrl.pathname.startsWith("/uploads/")
+    ) {
+      return `${absoluteUrl.pathname}${absoluteUrl.search}${absoluteUrl.hash}`;
+    }
+  } catch {
+    return trimmedUrl;
+  }
+
+  return trimmedUrl;
+}
+
+function normalizeApiUrl(url: string): string {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
 }

--- a/src/shared/lib/asset-url.ts
+++ b/src/shared/lib/asset-url.ts
@@ -1,7 +1,4 @@
-const FALLBACK_API_URL = "http://localhost:5500";
-const PUBLIC_API_URL = normalizeApiUrl(
-  process.env.NEXT_PUBLIC_API_URL?.trim() || FALLBACK_API_URL,
-);
+const PUBLIC_API_URL = normalizeApiUrl(process.env.NEXT_PUBLIC_API_URL?.trim());
 
 export function normalizeAssetUrl(url: string): string {
   const trimmedUrl = url.trim();
@@ -11,6 +8,10 @@ export function normalizeAssetUrl(url: string): string {
   }
 
   if (!trimmedUrl.startsWith("/uploads/")) {
+    return trimmedUrl;
+  }
+
+  if (!PUBLIC_API_URL) {
     return trimmedUrl;
   }
 
@@ -48,6 +49,10 @@ export function toCanonicalAssetUrl(url: string): string {
   return trimmedUrl;
 }
 
-function normalizeApiUrl(url: string): string {
+function normalizeApiUrl(url: string | undefined): string {
+  if (!url) {
+    return "";
+  }
+
   return url.endsWith("/") ? url.slice(0, -1) : url;
 }

--- a/src/shared/lib/asset-url.ts
+++ b/src/shared/lib/asset-url.ts
@@ -1,0 +1,25 @@
+const FALLBACK_API_URL = "http://localhost:5500";
+const PUBLIC_API_URL =
+  process.env.NEXT_PUBLIC_API_URL?.trim() || FALLBACK_API_URL;
+
+export function normalizeAssetUrl(url: string): string {
+  const trimmedUrl = url.trim();
+
+  if (!trimmedUrl) {
+    return trimmedUrl;
+  }
+
+  if (!trimmedUrl.startsWith("/uploads/")) {
+    return trimmedUrl;
+  }
+
+  return `${PUBLIC_API_URL}${trimmedUrl}`;
+}
+
+export function normalizeOptionalAssetUrl(url: string | null): string | null {
+  if (!url) {
+    return url;
+  }
+
+  return normalizeAssetUrl(url);
+}

--- a/src/shared/lib/markdown.ts
+++ b/src/shared/lib/markdown.ts
@@ -10,6 +10,7 @@ import remarkParse from "remark-parse";
 import remarkRehype from "remark-rehype";
 import { unified } from "unified";
 import { visit } from "unist-util-visit";
+import { normalizeAssetUrl } from "./asset-url";
 import type { Element, Root } from "hast";
 
 export interface TocItem {
@@ -28,6 +29,24 @@ function rehypeLazyImages() {
         node.properties.loading = "lazy";
         node.properties.decoding = "async";
       }
+    });
+  };
+}
+
+function rehypeNormalizeAssetImages() {
+  return (tree: Root) => {
+    visit(tree, "element", (node: Element) => {
+      if (node.tagName !== "img") {
+        return;
+      }
+
+      const src = node.properties.src;
+
+      if (typeof src !== "string") {
+        return;
+      }
+
+      node.properties.src = normalizeAssetUrl(src);
     });
   };
 }
@@ -76,6 +95,7 @@ const processor = unified()
     target: "_blank",
     rel: ["noopener", "noreferrer"],
   })
+  .use(rehypeNormalizeAssetImages)
   .use(rehypeLazyImages)
   .use(rehypeSlug, { prefix: HEADING_ID_PREFIX })
   .use(rehypeSanitize, sanitizeSchema)


### PR DESCRIPTION
## Summary

Closes #299

Normalize relative `/uploads/...` asset URLs against `NEXT_PUBLIC_API_URL` and split dev CSP allowances so local asset previews and markdown images render without noisy report-only violations.

## Changes

| File | Change |
|------|--------|
| `src/shared/lib/asset-url.ts` | Add shared asset URL normalization helper for API-origin `/uploads/...` paths. |
| `src/entities/asset/api.ts` | Normalize uploaded asset and asset-list URLs from API responses. |
| `src/entities/post/api.ts` | Normalize post thumbnail URLs across public/admin fetch and mutation responses. |
| `src/shared/lib/markdown.ts` | Rewrite rendered markdown image `src` values for legacy relative upload paths. |
| `src/middleware.ts` | Split CSP directives for dev/prod and allow required dev font/style/script/connect exceptions. |

## Screenshots

<!-- Attach screenshots for UI changes. Remove this section otherwise. -->
