### PR TITLE
feat: share post links and editor layout (#306)

### DIFF
--- a/src/app/(public)/posts/[slug]/page.tsx
+++ b/src/app/(public)/posts/[slug]/page.tsx
@@ -23,6 +23,7 @@ import {
   getSiteLocale,
   getSiteName,
 } from "@shared/lib/seo";
+import { buildPostHref } from "@shared/lib/post-url";
 import {
   buildBlogPostingJsonLd,
   buildBreadcrumbJsonLd,
@@ -106,7 +107,7 @@ export async function generateMetadata({
 }: PostDetailPageProps): Promise<Metadata> {
   const { post } = await getPostDetail(params.slug);
   const description = getPostDescription(post);
-  const canonical = `/posts/${post.slug}`;
+  const canonical = buildPostHref(post.slug);
 
   return {
     title: post.title,

--- a/src/app/(public)/posts/[slug]/page.tsx
+++ b/src/app/(public)/posts/[slug]/page.tsx
@@ -18,12 +18,12 @@ import { CommentList } from "@features/comment-section";
 import { PostContent, RelatedPosts, ViewCounter } from "@features/post-detail";
 import { ApiResponseError } from "@shared/api";
 import { extractHeadings, type TocItem } from "@shared/lib/markdown";
+import { buildPostHref } from "@shared/lib/post-url";
 import {
   buildCanonicalMetadata,
   getSiteLocale,
   getSiteName,
 } from "@shared/lib/seo";
-import { buildPostHref } from "@shared/lib/post-url";
 import {
   buildBlogPostingJsonLd,
   buildBreadcrumbJsonLd,

--- a/src/app/manage/posts/[id]/edit/page.tsx
+++ b/src/app/manage/posts/[id]/edit/page.tsx
@@ -3,8 +3,9 @@
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useParams, useRouter } from "next/navigation";
+import { PostEditorScreen } from "../../post-editor-screen";
+import type { PostFormValues } from "@features/post-editor";
 import { fetchAdminPost } from "@entities/post";
-import { PostForm, type PostFormValues } from "@features/post-editor";
 import { ApiResponseError } from "@shared/api";
 
 function getErrorMessage(error: unknown, fallback: string): string {
@@ -17,37 +18,6 @@ function getErrorMessage(error: unknown, fallback: string): string {
   }
 
   return fallback;
-}
-
-function EditPageSkeleton() {
-  return (
-    <div className="space-y-6">
-      <div className="rounded-[1.75rem] border border-border-3 bg-background-2 p-6 shadow-[0px_18px_60px_0px_rgba(0,0,0,0.06)]">
-        <div className="h-4 w-20 animate-pulse rounded-full bg-background-3" />
-        <div className="mt-4 h-10 w-48 animate-pulse rounded-[1rem] bg-background-3" />
-        <div className="mt-3 h-5 w-72 animate-pulse rounded-full bg-background-3" />
-      </div>
-
-      <div className="rounded-[1.75rem] border border-border-3 bg-background-2 p-6 shadow-[0px_18px_60px_0px_rgba(0,0,0,0.06)]">
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-          {Array.from({ length: 6 }).map((_, index) => (
-            <div
-              key={index}
-              className="h-12 animate-pulse rounded-[0.9rem] bg-background-3"
-            />
-          ))}
-        </div>
-        <div className="mt-6 grid gap-4 xl:grid-cols-2">
-          {Array.from({ length: 2 }).map((_, index) => (
-            <div
-              key={index}
-              className="h-80 animate-pulse rounded-[1rem] bg-background-3"
-            />
-          ))}
-        </div>
-      </div>
-    </div>
-  );
 }
 
 export default function DashboardPostEditPage() {
@@ -100,61 +70,18 @@ export default function DashboardPostEditPage() {
     );
   }
 
-  if (postQuery.isPending) {
-    return <EditPageSkeleton />;
-  }
-
-  if (postQuery.isError) {
-    return (
-      <div className="rounded-[1.75rem] border border-negative-1/20 bg-negative-1/10 px-6 py-8">
-        <h1 className="text-lg font-semibold text-negative-1">
-          글을 불러오지 못했습니다.
-        </h1>
-        <p className="mt-2 text-sm text-negative-1">
-          {getErrorMessage(postQuery.error, "잠시 후 다시 시도해 주세요.")}
-        </p>
-        <div className="mt-4 flex flex-wrap gap-3">
-          <button
-            type="button"
-            onClick={() => void postQuery.refetch()}
-            className="inline-flex rounded-[0.75rem] border border-negative-1/20 px-4 py-2 text-sm font-medium text-negative-1 transition-colors hover:bg-negative-1/10"
-          >
-            다시 시도
-          </button>
-          <button
-            type="button"
-            onClick={() => router.push("/manage/posts")}
-            className="inline-flex rounded-[0.75rem] border border-border-3 px-4 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
-          >
-            목록으로
-          </button>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="space-y-6">
-      <header className="flex flex-col gap-4 rounded-[1.75rem] border border-border-3 bg-background-2 p-6 shadow-[0px_18px_60px_0px_rgba(0,0,0,0.06)] md:flex-row md:items-end md:justify-between">
-        <div>
-          <p className="text-body-xs uppercase tracking-[0.24em] text-text-4">
-            Content
-          </p>
-          <h1 className="mt-3 text-2xl font-semibold text-text-1">글 수정</h1>
-          <p className="mt-2 text-sm text-text-3">
-            기존 글 정보를 불러와 수정한 뒤 다시 저장합니다.
-          </p>
-        </div>
-      </header>
-
-      <PostForm
-        mode="edit"
-        postId={postId}
-        initialValues={initialValues}
-        cancelLabel="목록으로"
-        onCancel={() => router.push("/manage/posts")}
-        onSuccess={() => router.push("/manage/posts")}
-      />
-    </div>
+    <PostEditorScreen
+      mode="edit"
+      postId={postId}
+      initialValues={initialValues}
+      isPending={postQuery.isPending}
+      errorMessage={
+        postQuery.isError
+          ? getErrorMessage(postQuery.error, "잠시 후 다시 시도해 주세요.")
+          : null
+      }
+      onRetry={() => void postQuery.refetch()}
+    />
   );
 }

--- a/src/app/manage/posts/new/page.tsx
+++ b/src/app/manage/posts/new/page.tsx
@@ -1,23 +1,7 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import { ADMIN_CHROME_HEIGHT } from "../../ui/admin-shell-constants";
-import { PostForm } from "@features/post-editor";
+import { PostEditorScreen } from "../post-editor-screen";
 
 export default function ManagePostCreatePage() {
-  const router = useRouter();
-
-  return (
-    <div
-      className="-mx-4 -my-6 h-full w-full md:-mx-6"
-      style={{ height: `calc(100dvh - ${ADMIN_CHROME_HEIGHT})` }}
-    >
-      <div className="h-full w-full">
-        <PostForm
-          mode="create"
-          onSuccess={() => router.push("/manage/posts")}
-        />
-      </div>
-    </div>
-  );
+  return <PostEditorScreen mode="create" />;
 }

--- a/src/app/manage/posts/post-editor-screen.tsx
+++ b/src/app/manage/posts/post-editor-screen.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { ADMIN_CHROME_HEIGHT } from "../ui/admin-shell-constants";
+import { PostForm, type PostFormValues } from "@features/post-editor";
+
+interface PostEditorScreenProps {
+  mode: "create" | "edit";
+  postId?: number;
+  initialValues?: Partial<PostFormValues>;
+  isPending?: boolean;
+  errorMessage?: string | null;
+  onRetry?: () => void;
+}
+
+function FullBleedFrame({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="-mx-4 -my-6 h-full w-full md:-mx-6"
+      style={{ height: `calc(100dvh - ${ADMIN_CHROME_HEIGHT})` }}
+    >
+      <div className="h-full w-full">{children}</div>
+    </div>
+  );
+}
+
+function EditorSkeleton() {
+  return (
+    <div className="flex h-full flex-col gap-4 bg-background-1 p-4 md:p-6">
+      <div className="h-14 animate-pulse rounded-2xl bg-background-2" />
+      <div className="grid min-h-0 flex-1 gap-4 xl:grid-cols-[24rem_minmax(0,1fr)]">
+        <div className="space-y-4 rounded-[1.5rem] bg-background-2 p-5">
+          {Array.from({ length: 7 }).map((_, index) => (
+            <div
+              key={index}
+              className="h-10 animate-pulse rounded-xl bg-background-3"
+            />
+          ))}
+        </div>
+        <div className="rounded-[1.5rem] bg-background-2 p-5">
+          <div className="h-full min-h-[24rem] animate-pulse rounded-xl bg-background-3" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EditorError({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry?: () => void;
+}) {
+  const router = useRouter();
+
+  return (
+    <div className="flex h-full items-center justify-center bg-background-1 p-4 md:p-6">
+      <div className="w-full max-w-lg rounded-[1.5rem] border border-negative-1/20 bg-negative-1/10 px-6 py-8">
+        <h1 className="text-lg font-semibold text-negative-1">
+          글을 불러오지 못했습니다.
+        </h1>
+        <p className="mt-2 text-sm text-negative-1">{message}</p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          {onRetry ? (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="inline-flex rounded-[0.75rem] border border-negative-1/20 px-4 py-2 text-sm font-medium text-negative-1 transition-colors hover:bg-negative-1/10"
+            >
+              다시 시도
+            </button>
+          ) : null}
+          <button
+            type="button"
+            onClick={() => router.push("/manage/posts")}
+            className="inline-flex rounded-[0.75rem] border border-border-3 px-4 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
+          >
+            목록으로
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function PostEditorScreen({
+  mode,
+  postId,
+  initialValues,
+  isPending = false,
+  errorMessage,
+  onRetry,
+}: PostEditorScreenProps) {
+  const router = useRouter();
+
+  return (
+    <FullBleedFrame>
+      {isPending ? (
+        <EditorSkeleton />
+      ) : errorMessage ? (
+        <EditorError message={errorMessage} onRetry={onRetry} />
+      ) : (
+        <PostForm
+          mode={mode}
+          postId={postId}
+          initialValues={initialValues}
+          cancelLabel="목록으로"
+          onCancel={() => router.push("/manage/posts")}
+          onSuccess={() => router.push("/manage/posts")}
+        />
+      )}
+    </FullBleedFrame>
+  );
+}

--- a/src/entities/post/index.ts
+++ b/src/entities/post/index.ts
@@ -21,7 +21,7 @@ export type {
   UpdatePostBody,
 } from "./model";
 export { SEARCH_FILTERS } from "./model";
-export { isPinnedPostLimitError, MAX_PINNED_POSTS } from "./lib";
+export { buildPostHref, isPinnedPostLimitError, MAX_PINNED_POSTS } from "./lib";
 export {
   bulkUpdatePosts,
   fetchAdminPost,

--- a/src/entities/post/index.ts
+++ b/src/entities/post/index.ts
@@ -21,7 +21,8 @@ export type {
   UpdatePostBody,
 } from "./model";
 export { SEARCH_FILTERS } from "./model";
-export { buildPostHref, isPinnedPostLimitError, MAX_PINNED_POSTS } from "./lib";
+export { buildPostHref } from "@shared/lib/post-url";
+export { isPinnedPostLimitError, MAX_PINNED_POSTS } from "./lib";
 export {
   bulkUpdatePosts,
   fetchAdminPost,

--- a/src/entities/post/lib.ts
+++ b/src/entities/post/lib.ts
@@ -2,6 +2,10 @@ import { ApiResponseError } from "@shared/api";
 
 export const MAX_PINNED_POSTS = 5;
 
+export function buildPostHref(slug: string) {
+  return `/posts/${encodeURIComponent(slug)}`;
+}
+
 export function isPinnedPostLimitError(error: unknown) {
   return error instanceof ApiResponseError && error.statusCode === 409;
 }

--- a/src/entities/post/lib.ts
+++ b/src/entities/post/lib.ts
@@ -1,10 +1,7 @@
 import { ApiResponseError } from "@shared/api";
+import { buildPostHref } from "@shared/lib/post-url";
 
 export const MAX_PINNED_POSTS = 5;
-
-export function buildPostHref(slug: string) {
-  return `/posts/${encodeURIComponent(slug)}`;
-}
 
 export function isPinnedPostLimitError(error: unknown) {
   return error instanceof ApiResponseError && error.statusCode === 409;

--- a/src/entities/post/lib.ts
+++ b/src/entities/post/lib.ts
@@ -1,5 +1,4 @@
 import { ApiResponseError } from "@shared/api";
-import { buildPostHref } from "@shared/lib/post-url";
 
 export const MAX_PINNED_POSTS = 5;
 

--- a/src/features/popular-posts/ui/popular-post-list.tsx
+++ b/src/features/popular-posts/ui/popular-post-list.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
+import { buildPostHref } from "@entities/post";
 import { fetchPopularPostsClient, type PopularPost } from "@entities/stat";
 
 type PopularPeriod = 7 | 30;
@@ -147,7 +148,7 @@ export function PopularPostList({
           {posts.map((post) => (
             <li key={post.postId}>
               <Link
-                href={`/posts/${post.slug}`}
+                href={buildPostHref(post.slug)}
                 onClick={onItemClick}
                 className="group block min-h-[3rem] rounded-md px-0.5 py-1 transition-colors hover:text-primary-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-1"
               >

--- a/src/features/post-detail/ui/post-navigation.tsx
+++ b/src/features/post-detail/ui/post-navigation.tsx
@@ -1,5 +1,8 @@
 import Link from "next/link";
-import { PostNavigation as PostNavigationEntity } from "@entities/post";
+import {
+  buildPostHref,
+  PostNavigation as PostNavigationEntity,
+} from "@entities/post";
 
 interface PostNavigationProps {
   prevPost: PostNavigationEntity | null;
@@ -12,7 +15,7 @@ export function PostNavigation({ prevPost, nextPost }: PostNavigationProps) {
       <div className="flex-1">
         {prevPost && (
           <Link
-            href={`/posts/${prevPost.slug}`}
+            href={buildPostHref(prevPost.slug)}
             className="flex flex-col gap-1 p-4 rounded-lg border border-border-3 hover:border-border-2 transition-colors"
           >
             <span className="text-body-xs text-text-4">이전 글</span>
@@ -23,7 +26,7 @@ export function PostNavigation({ prevPost, nextPost }: PostNavigationProps) {
       <div className="flex-1 flex justify-end">
         {nextPost && (
           <Link
-            href={`/posts/${nextPost.slug}`}
+            href={buildPostHref(nextPost.slug)}
             className="flex flex-col gap-1 p-4 rounded-lg border border-border-3 hover:border-border-2 transition-colors text-right w-full"
           >
             <span className="text-body-xs text-text-4">다음 글</span>

--- a/src/features/post-detail/ui/related-posts.tsx
+++ b/src/features/post-detail/ui/related-posts.tsx
@@ -2,7 +2,7 @@ import { Icon } from "@iconify/react";
 import documentTextLinear from "@iconify-icons/solar/document-text-linear";
 import Image from "next/image";
 import Link from "next/link";
-import type { PostListItem } from "@entities/post";
+import { buildPostHref, type PostListItem } from "@entities/post";
 
 interface RelatedPostsProps {
   posts: Array<Pick<PostListItem, "id" | "slug" | "title" | "thumbnailUrl">>;
@@ -26,7 +26,7 @@ export function RelatedPosts({ posts }: RelatedPostsProps) {
         {posts.map((post) => (
           <Link
             key={post.id}
-            href={`/posts/${post.slug}`}
+            href={buildPostHref(post.slug)}
             className="group block w-[11.75rem] shrink-0 overflow-hidden rounded-[0.75rem] border border-border-3 bg-background-2 text-decoration-none transition-all duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] [scroll-snap-align:start] hover:-translate-y-[3px] hover:border-primary-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.06)]"
           >
             <div className="aspect-[16/10] overflow-hidden bg-background-3">

--- a/src/features/post-editor/ui/markdown-preview.tsx
+++ b/src/features/post-editor/ui/markdown-preview.tsx
@@ -25,7 +25,6 @@ export function MarkdownPreview({
   const workerRef = useRef<Worker | null>(null);
   const requestIdRef = useRef(0);
   const latestValueRef = useRef(value);
-  const skipNextValueEffectRef = useRef(true);
 
   useEffect(() => {
     latestValueRef.current = value;
@@ -69,12 +68,6 @@ export function MarkdownPreview({
 
   useEffect(() => {
     if (workerRef.current === null) {
-      return;
-    }
-
-    if (skipNextValueEffectRef.current) {
-      skipNextValueEffectRef.current = false;
-
       return;
     }
 

--- a/src/features/post-editor/ui/markdown-preview.tsx
+++ b/src/features/post-editor/ui/markdown-preview.tsx
@@ -25,6 +25,7 @@ export function MarkdownPreview({
   const workerRef = useRef<Worker | null>(null);
   const requestIdRef = useRef(0);
   const latestValueRef = useRef(value);
+  const lastRequestedValueRef = useRef<string | null>(null);
 
   useEffect(() => {
     latestValueRef.current = value;
@@ -55,6 +56,7 @@ export function MarkdownPreview({
     workerRef.current = worker;
     setIsRendering(true);
     requestIdRef.current = 1;
+    lastRequestedValueRef.current = latestValueRef.current;
     worker.postMessage({
       id: requestIdRef.current,
       value: latestValueRef.current,
@@ -71,11 +73,16 @@ export function MarkdownPreview({
       return;
     }
 
+    if (lastRequestedValueRef.current === value) {
+      return;
+    }
+
     setIsRendering(true);
 
     const timeoutId = window.setTimeout(() => {
       const requestId = requestIdRef.current + 1;
       requestIdRef.current = requestId;
+      lastRequestedValueRef.current = value;
       workerRef.current?.postMessage({ id: requestId, value });
     }, 120);
 

--- a/src/features/post-list/ui/post-card.tsx
+++ b/src/features/post-list/ui/post-card.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
-import type { PublishedPostListItem } from "@entities/post";
+import { buildPostHref, type PublishedPostListItem } from "@entities/post";
 import { cn } from "@shared/lib/style-utils";
 
 interface PostCardProps {
@@ -22,7 +22,7 @@ export function PostCard({ post, className }: PostCardProps) {
 
   return (
     <Link
-      href={`/posts/${post.slug}`}
+      href={buildPostHref(post.slug)}
       className={cn(
         "group flex overflow-hidden rounded-[1.5rem] border border-border-3 bg-background-1 transition-colors hover:border-border-2",
         className,

--- a/src/features/post-list/ui/post-list-item.tsx
+++ b/src/features/post-list/ui/post-list-item.tsx
@@ -3,7 +3,7 @@ import chatRoundDotsLinear from "@iconify-icons/solar/chat-round-dots-linear";
 import eyeLinear from "@iconify-icons/solar/eye-linear";
 import pinBold from "@iconify-icons/solar/pin-bold";
 import Link from "next/link";
-import type { PublishedPostListItem } from "@entities/post";
+import { buildPostHref, type PublishedPostListItem } from "@entities/post";
 
 interface PostListItemProps {
   post: PublishedPostListItem;
@@ -28,7 +28,7 @@ export function PostListItem({ post }: PostListItemProps) {
   return (
     <article className="surface-hover-shift group relative rounded-xl px-4 py-5 sm:px-5 hover:bg-background-2">
       <Link
-        href={`/posts/${post.slug}`}
+        href={buildPostHref(post.slug)}
         className="absolute inset-0 z-10 rounded-xl"
         aria-label={post.title}
       />

--- a/src/features/recent-popular-posts/ui/recent-popular-posts.tsx
+++ b/src/features/recent-popular-posts/ui/recent-popular-posts.tsx
@@ -2,8 +2,8 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import type { PostListItem } from "@entities/post";
 import type { PopularPost } from "@entities/stat";
+import { buildPostHref, type PostListItem } from "@entities/post";
 import { PopularPostList } from "@features/popular-posts";
 import { cn } from "@shared/lib/style-utils";
 
@@ -112,7 +112,7 @@ export function RecentPopularPosts({
             {recentPosts.map((post) => (
               <li key={post.id}>
                 <Link
-                  href={`/posts/${post.slug}`}
+                  href={buildPostHref(post.slug)}
                   onClick={onItemClick}
                   className="group block min-h-[3rem] rounded-md px-0.5 py-1 transition-colors hover:text-primary-1"
                 >

--- a/src/features/search/ui/search-result-item.tsx
+++ b/src/features/search/ui/search-result-item.tsx
@@ -3,7 +3,7 @@ import chatRoundDotsLinear from "@iconify-icons/solar/chat-round-dots-linear";
 import eyeLinear from "@iconify-icons/solar/eye-linear";
 import Link from "next/link";
 import { highlightText } from "../lib/highlight";
-import type { PublishedPostListItem } from "@entities/post";
+import { buildPostHref, type PublishedPostListItem } from "@entities/post";
 
 interface SearchResultItemProps {
   post: PublishedPostListItem;
@@ -29,7 +29,7 @@ export function SearchResultItem({ post, query }: SearchResultItemProps) {
   return (
     <article className="surface-hover-shift group relative rounded-xl px-4 py-5 hover:bg-background-2 sm:px-5">
       <Link
-        href={`/posts/${post.slug}`}
+        href={buildPostHref(post.slug)}
         className="absolute inset-0 z-10 rounded-xl"
         aria-label={post.title}
       />

--- a/src/shared/lib/post-url.ts
+++ b/src/shared/lib/post-url.ts
@@ -1,0 +1,3 @@
+export function buildPostHref(slug: string) {
+  return `/posts/${encodeURIComponent(slug)}`;
+}

--- a/src/shared/lib/structured-data.ts
+++ b/src/shared/lib/structured-data.ts
@@ -1,4 +1,5 @@
 import { URLS } from "@shared/constant/url";
+import { buildPostHref } from "@shared/lib/post-url";
 import {
   buildAbsoluteUrl,
   getPostDescription,
@@ -132,7 +133,7 @@ export function buildBlogPostingJsonLd(
       url: URLS.github,
     },
     ...(image ? { image } : {}),
-    url: `${normalizedSiteUrl}/posts/${post.slug}`,
+    url: `${normalizedSiteUrl}${buildPostHref(post.slug)}`,
     ...(keywords.length > 0 ? { keywords } : {}),
     ...(post.category.name ? { articleSection: post.category.name } : {}),
   };


### PR DESCRIPTION
## Summary

Closes #306

Public post links now use a shared detail href builder, and the manage post edit screen reuses the same full-bleed editor shell as post create.

## Changes

| File | Change |
|------|--------|
| `src/entities/post/lib.ts` | Added a shared `buildPostHref()` helper for encoded post detail URLs. |
| `src/features/post-list/*`, `src/features/search/*`, `src/features/post-detail/*`, `src/features/popular-posts/*`, `src/features/recent-popular-posts/*` | Switched public post links to the shared href builder. |
| `src/app/manage/posts/post-editor-screen.tsx` | Added a reusable full-bleed post editor screen wrapper. |
| `src/app/manage/posts/new/page.tsx` | Moved create page onto the shared editor screen. |
| `src/app/manage/posts/[id]/edit/page.tsx` | Reused the shared editor screen for edit mode and removed the extra header/padding divergence. |
