### PR TITLE
fix: force non-DOM entry for decode-named-character-reference in worker bundle

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,19 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+// decode-named-character-reference 의 "browser" export 는 index.dom.js 로 해석되는데,
+// 이 파일은 module 최상단에서 `document.createElement` 를 호출한다.
+// Next.js 는 Web Worker 번들도 browser condition 으로 빌드하기 때문에
+// markdown-preview.worker.ts 가 로드되는 순간 ReferenceError 가 터진다.
+// remark-parse 체인을 통해 non-DOM 엔트리(index.js)를 찾아 alias 로 고정한다.
+function resolveDecodeNamedCharacterReference() {
+  const remarkParsePath = require.resolve("remark-parse");
+  return createRequire(remarkParsePath).resolve(
+    "decode-named-character-reference",
+  );
+}
+
 export default {
   images: {
     remotePatterns: [
@@ -14,5 +30,13 @@ export default {
   },
   eslint: {
     ignoreDuringBuilds: true,
+  },
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "decode-named-character-reference$":
+        resolveDecodeNamedCharacterReference(),
+    };
+    return config;
   },
 };


### PR DESCRIPTION
## Problem

글 수정 화면에서 마크다운 미리보기가 갱신되지 않고, 콘솔에 다음 에러가 찍힙니다.

```
ReferenceError: document is not defined
    at eval (index.dom.js:9:17)
    at .../decode-named-character-reference/index.dom.js
    ...
    at .../micromark-core-commonmark/dev/lib/character-reference.js
    ...
    at markdown-preview.worker.ts
```

## Root cause

`decode-named-character-reference` 패키지의 exports 에는 두 가지 엔트리가 있습니다.

```json
{
  "worker": "./index.js",
  "browser": "./index.dom.js",
  "default": "./index.js"
}
```

- `index.js`: `character-entities` 정적 테이블을 사용 (DOM 비의존, worker 에서 안전)
- `index.dom.js`: 모듈 로드 시점에 `document.createElement('i')` 를 호출 (브라우저 메인 스레드 전용)

Next.js 는 `new Worker(new URL(...), import.meta.url)` 로 선언된 Web Worker 도 **browser condition** 으로 번들합니다. 그 결과 `markdown-preview.worker.ts` 가 `index.dom.js` 를 로드하려다 모듈 최상단에서 `document` 참조로 즉시 실패하고, 워커가 죽어서 프리뷰가 렌더링되지 않습니다.

## Fix

`next.config.js` 의 webpack 설정에 alias 를 추가해 `decode-named-character-reference` 를 항상 non-DOM 엔트리(`index.js`) 로 해석하게 강제했습니다. alias 타겟은 직접 의존성인 `remark-parse` 체인을 통해 resolve 하므로 pnpm hoisting 에 의존하지 않습니다.

## Verification

- `pnpm compile:types` 통과
- `pnpm build` 통과
- 빌드 산출물 (`.next/static`) 에서 `document.createElement('i')` (index.dom.js 의 고유 시그니처) **0 건** 확인
- `hasOwnProperty` (index.js 의 시그니처) 1 건 포함 확인