### PR TITLE
fix: normalize korean post slug to NFKC on lookup

### DIFF
--- a/src/entities/post/api.ts
+++ b/src/entities/post/api.ts
@@ -96,8 +96,11 @@ export async function fetchPostBySlug(
   slug: string,
   cookieHeader?: string,
 ): Promise<PostDetailWithNavigationResponse> {
+  // Server stores slugs after `.normalize("NFKC")` (see server `generateUnicodeSlug`).
+  // URLs sourced from Safari / macOS clipboards can arrive as NFD and fail to match.
+  const normalizedSlug = slug.normalize("NFKC");
   const response = await serverFetch<PostDetailWithNavigationResponse>(
-    `/api/posts/${encodeURIComponent(slug)}`,
+    `/api/posts/${encodeURIComponent(normalizedSlug)}`,
     {},
     cookieHeader,
   );


### PR DESCRIPTION
## 원인

서버는 `generateUnicodeSlug`에서 `normalize("NFKC")`로 정규화된 한글 slug를 DB에 저장한다. 반면 클라이언트 `fetchPostBySlug`는 Next.js가 디코드한 `params.slug`를 그대로 서버에 전달한다.

Safari, macOS 클립보드 등에서 유입된 URL이 NFD 분해 형태의 한글을 담고 있으면 DB의 NFC 조합형과 바이트가 달라 정상적으로 저장된 post임에도 404가 발생한다.

## 변경

- `src/entities/post/api.ts`의 `fetchPostBySlug`에서 요청 전 `slug.normalize("NFKC")` 적용
- 서버 저장 규칙과 동일해져 기존에 저장 가능한 모든 slug가 URL로 조회 가능

## 검증

- `pnpm compile:types` 통과
- `pnpm lint` 통과 (기존 warning 2건은 이 PR과 무관)
