### PR TITLE
refactor: remove /api prefix from client API paths (#310)

### DIFF
--- a/src/entities/asset/api.ts
+++ b/src/entities/asset/api.ts
@@ -16,7 +16,7 @@ export async function fetchAssets(
   limit = 20,
 ): Promise<PaginatedResponse<Asset>> {
   const response = await clientFetch<PaginatedResponse<Asset>>(
-    `/api/assets?page=${page}&limit=${limit}`,
+    `/assets?page=${page}&limit=${limit}`,
   );
 
   return {
@@ -74,7 +74,7 @@ export async function uploadAssets(
       reject(new Error("업로드 중 네트워크 오류가 발생했습니다."));
     };
 
-    xhr.open("POST", `${API_URL}/api/assets/upload`);
+    xhr.open("POST", `${API_URL}/assets/upload`);
     xhr.withCredentials = true;
     xhr.setRequestHeader("x-csrf-token", csrfToken);
     xhr.send(formData);
@@ -82,13 +82,13 @@ export async function uploadAssets(
 }
 
 export async function deleteAsset(id: number): Promise<void> {
-  await clientMutate<void>(`/api/assets/${id}`, {
+  await clientMutate<void>(`/assets/${id}`, {
     method: "DELETE",
   });
 }
 
 export async function deleteAssets(ids: number[]): Promise<void> {
-  await clientMutate<void>("/api/assets/bulk", {
+  await clientMutate<void>("/assets/bulk", {
     method: "DELETE",
     body: JSON.stringify({ ids }),
   });

--- a/src/entities/auth/api.ts
+++ b/src/entities/auth/api.ts
@@ -3,7 +3,7 @@ import { clientFetch, clientMutate, serverFetch } from "@shared/api";
 
 export async function login(credentials: LoginCredentials): Promise<AdminUser> {
   const response = await clientFetch<{ admin: AdminUser }>(
-    "/api/auth/admin/login",
+    "/auth/admin/login",
     {
       method: "POST",
       body: JSON.stringify(credentials),
@@ -14,15 +14,15 @@ export async function login(credentials: LoginCredentials): Promise<AdminUser> {
 }
 
 export async function logout(): Promise<void> {
-  return clientMutate<void>("/api/auth/admin/logout");
+  return clientMutate<void>("/auth/admin/logout");
 }
 
 export async function fetchMe(): Promise<CurrentUser> {
-  return clientFetch<CurrentUser>("/api/auth/me");
+  return clientFetch<CurrentUser>("/auth/me");
 }
 
 export async function fetchMeServer(
   cookieHeader: string,
 ): Promise<CurrentUser> {
-  return serverFetch<CurrentUser>("/api/auth/me", {}, cookieHeader);
+  return serverFetch<CurrentUser>("/auth/me", {}, cookieHeader);
 }

--- a/src/entities/category/api.ts
+++ b/src/entities/category/api.ts
@@ -21,7 +21,7 @@ export async function fetchCategories(
   cookieHeader?: string,
 ): Promise<Category[]> {
   const response = await serverFetch<CategoriesResponse>(
-    "/api/categories",
+    "/categories",
     {},
     cookieHeader,
   );
@@ -30,7 +30,7 @@ export async function fetchCategories(
 }
 
 export async function fetchCategoriesClient(): Promise<Category[]> {
-  const response = await clientFetch<CategoriesResponse>("/api/categories");
+  const response = await clientFetch<CategoriesResponse>("/categories");
 
   return response.categories;
 }
@@ -40,13 +40,11 @@ export async function fetchCategoriesAdmin(
 ): Promise<Category[]> {
   const response = cookieHeader
     ? await serverFetch<CategoriesResponse>(
-        "/api/categories?include_hidden=true",
+        "/categories?include_hidden=true",
         {},
         cookieHeader,
       )
-    : await clientFetch<CategoriesResponse>(
-        "/api/categories?include_hidden=true",
-      );
+    : await clientFetch<CategoriesResponse>("/categories?include_hidden=true");
 
   return response.categories;
 }
@@ -54,7 +52,7 @@ export async function fetchCategoriesAdmin(
 export async function createCategory(
   body: CreateCategoryBody,
 ): Promise<Category> {
-  const response = await clientMutate<CategoryResponse>("/api/categories", {
+  const response = await clientMutate<CategoryResponse>("/categories", {
     body: JSON.stringify(body),
   });
 
@@ -65,13 +63,10 @@ export async function updateCategory(
   id: number,
   body: UpdateCategoryBody,
 ): Promise<Category> {
-  const response = await clientMutate<CategoryResponse>(
-    `/api/categories/${id}`,
-    {
-      method: "PATCH",
-      body: JSON.stringify(body),
-    },
-  );
+  const response = await clientMutate<CategoryResponse>(`/categories/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
 
   return response.category;
 }
@@ -79,7 +74,7 @@ export async function updateCategory(
 export async function updateCategoryOrder(
   body: UpdateCategoryOrderBody,
 ): Promise<void> {
-  await clientMutate<void>("/api/categories/order", {
+  await clientMutate<void>("/categories/order", {
     method: "PATCH",
     body: JSON.stringify(body),
   });
@@ -90,7 +85,7 @@ export async function updateCategoryTree(
 ): Promise<void> {
   const body: UpdateCategoryTreeBody = { changes };
 
-  await clientMutate<void>("/api/categories/tree", {
+  await clientMutate<void>("/categories/tree", {
     method: "PATCH",
     body: JSON.stringify(body),
   });
@@ -112,7 +107,7 @@ export async function deleteCategory(
 
   const query = searchParams.toString();
 
-  await clientMutate<void>(`/api/categories/${id}${query ? `?${query}` : ""}`, {
+  await clientMutate<void>(`/categories/${id}${query ? `?${query}` : ""}`, {
     method: "DELETE",
   });
 }

--- a/src/entities/comment/api.ts
+++ b/src/entities/comment/api.ts
@@ -146,8 +146,8 @@ export async function fetchComments(
     options?.limit,
   );
   const path = queryString
-    ? `/api/posts/${postId}/comments?${queryString}`
-    : `/api/posts/${postId}/comments`;
+    ? `/posts/${postId}/comments?${queryString}`
+    : `/posts/${postId}/comments`;
 
   const response = await serverFetch<CommentsResponse | CommentsResponseLegacy>(
     path,
@@ -170,8 +170,8 @@ export async function fetchCommentsClient(
     options?.limit,
   );
   const path = queryString
-    ? `/api/posts/${postId}/comments?${queryString}`
-    : `/api/posts/${postId}/comments`;
+    ? `/posts/${postId}/comments?${queryString}`
+    : `/posts/${postId}/comments`;
   const response = await clientFetch<CommentsResponse | CommentsResponseLegacy>(
     path,
   );
@@ -185,7 +185,7 @@ export async function createComment(
 ): Promise<{ comment: Comment; revealToken: string | null }> {
   const { authorType: _authorType, ...payload } = body;
   const response = await clientMutate<CreateCommentResponse>(
-    `/api/posts/${postId}/comments`,
+    `/posts/${postId}/comments`,
     {
       body: JSON.stringify(payload),
     },
@@ -202,7 +202,7 @@ export async function revealSecretComment(
   revealToken: string,
 ): Promise<Comment> {
   const response = await clientMutate<CommentResponse>(
-    `/api/comments/${commentId}/reveal`,
+    `/comments/${commentId}/reveal`,
     {
       method: "POST",
       body: JSON.stringify({ revealToken }),
@@ -219,7 +219,7 @@ export async function deleteComment(
   const payload =
     body.authorType === "guest" ? { guestPassword: body.guestPassword } : {};
 
-  await clientMutate<void>(`/api/comments/${commentId}`, {
+  await clientMutate<void>(`/comments/${commentId}`, {
     method: "DELETE",
     body: JSON.stringify(payload),
   });
@@ -231,8 +231,8 @@ export async function fetchAdminComments(
 ): Promise<PaginatedResponse<AdminCommentItem>> {
   const queryString = buildAdminCommentSearchParams(params);
   const path = queryString
-    ? `/api/admin/comments?${queryString}`
-    : "/api/admin/comments";
+    ? `/admin/comments?${queryString}`
+    : "/admin/comments";
 
   return cookieHeader
     ? serverFetch<PaginatedResponse<AdminCommentItem>>(path, {}, cookieHeader)
@@ -243,19 +243,19 @@ export async function adminDeleteComment(
   id: number,
   action: AdminCommentDeleteAction = "soft_delete",
 ): Promise<void> {
-  await clientMutate<void>(`/api/admin/comments/${id}?action=${action}`, {
+  await clientMutate<void>(`/admin/comments/${id}?action=${action}`, {
     method: "DELETE",
   });
 }
 
 export async function adminRestoreComment(id: number): Promise<void> {
-  await clientMutate<void>(`/api/admin/comments/${id}/restore`, {
+  await clientMutate<void>(`/admin/comments/${id}/restore`, {
     method: "PUT",
   });
 }
 
 export async function adminHideComment(id: number): Promise<void> {
-  await clientMutate<void>(`/api/admin/comments/${id}/hide`, {
+  await clientMutate<void>(`/admin/comments/${id}/hide`, {
     method: "PUT",
   });
 }
@@ -264,7 +264,7 @@ export async function adminBulkOperateComments(
   ids: number[],
   action: AdminCommentBulkAction,
 ): Promise<void> {
-  await clientMutate<void>("/api/admin/comments/bulk", {
+  await clientMutate<void>("/admin/comments/bulk", {
     method: "DELETE",
     body: JSON.stringify({ ids, action }),
   });
@@ -276,7 +276,7 @@ export async function fetchAdminCommentThread(
   const response = await clientFetch<{
     parent: AdminCommentItem;
     replies: AdminCommentItem[];
-  }>(`/api/admin/comments/${id}/thread`);
+  }>(`/admin/comments/${id}/thread`);
 
   return [response.parent, ...response.replies];
 }

--- a/src/entities/guestbook/api.ts
+++ b/src/entities/guestbook/api.ts
@@ -80,7 +80,7 @@ export async function fetchGuestbook(
   cookieHeader?: string,
 ): Promise<PaginatedResponse<GuestbookEntry>> {
   return serverFetch<PaginatedResponse<GuestbookEntry>>(
-    `/api/guestbook?page=${page}`,
+    `/guestbook?page=${page}`,
     {},
     cookieHeader,
   );
@@ -90,12 +90,9 @@ export async function createGuestbookEntry(
   body: CreateGuestbookBody,
 ): Promise<GuestbookEntry> {
   const { authorType: _authorType, ...payload } = body;
-  const response = await clientMutate<GuestbookEntryResponse>(
-    "/api/guestbook",
-    {
-      body: JSON.stringify(payload),
-    },
-  );
+  const response = await clientMutate<GuestbookEntryResponse>("/guestbook", {
+    body: JSON.stringify(payload),
+  });
 
   return response.data;
 }
@@ -104,7 +101,7 @@ export async function deleteGuestbookEntry(
   id: number,
   body: DeleteGuestbookBody,
 ): Promise<void> {
-  await clientMutate<void>(`/api/guestbook/${id}`, {
+  await clientMutate<void>(`/guestbook/${id}`, {
     method: "DELETE",
     body: JSON.stringify(body),
   });
@@ -116,8 +113,8 @@ export async function fetchAdminGuestbook(
 ): Promise<PaginatedResponse<AdminGuestbookItem>> {
   const queryString = buildAdminGuestbookSearchParams(params);
   const path = queryString
-    ? `/api/admin/guestbook?${queryString}`
-    : "/api/admin/guestbook";
+    ? `/admin/guestbook?${queryString}`
+    : "/admin/guestbook";
 
   return cookieHeader
     ? serverFetch<PaginatedResponse<AdminGuestbookItem>>(path, {}, cookieHeader)
@@ -128,7 +125,7 @@ export async function adminDeleteGuestbookEntry(
   id: number,
   action: AdminGuestbookDeleteAction,
 ): Promise<void> {
-  await clientMutate<void>(`/api/admin/guestbook/${id}?action=${action}`, {
+  await clientMutate<void>(`/admin/guestbook/${id}?action=${action}`, {
     method: "DELETE",
   });
 }
@@ -137,7 +134,7 @@ export async function adminPatchGuestbookEntry(
   id: number,
   action: AdminGuestbookPatchAction,
 ): Promise<void> {
-  await clientMutate<void>(`/api/admin/guestbook/${id}?action=${action}`, {
+  await clientMutate<void>(`/admin/guestbook/${id}?action=${action}`, {
     method: "PATCH",
   });
 }
@@ -146,7 +143,7 @@ export async function adminBulkDeleteGuestbookEntries(
   ids: number[],
   action: AdminGuestbookDeleteAction,
 ): Promise<void> {
-  await clientMutate<void>("/api/admin/guestbook/bulk", {
+  await clientMutate<void>("/admin/guestbook/bulk", {
     method: "DELETE",
     body: JSON.stringify({ ids, action }),
   });
@@ -156,7 +153,7 @@ export async function adminBulkPatchGuestbookEntries(
   ids: number[],
   action: AdminGuestbookPatchAction,
 ): Promise<void> {
-  await clientMutate<void>("/api/admin/guestbook/bulk", {
+  await clientMutate<void>("/admin/guestbook/bulk", {
     method: "PATCH",
     body: JSON.stringify({ ids, action }),
   });
@@ -167,23 +164,20 @@ export async function fetchGuestbookSettings(
 ): Promise<GuestbookSettingsResponse> {
   if (typeof window === "undefined") {
     return serverFetch<GuestbookSettingsResponse>(
-      "/api/settings/guestbook",
+      "/settings/guestbook",
       {},
       cookieHeader,
     );
   }
 
-  return clientFetch<GuestbookSettingsResponse>("/api/settings/guestbook");
+  return clientFetch<GuestbookSettingsResponse>("/settings/guestbook");
 }
 
 export async function updateGuestbookSettings(
   enabled: boolean,
 ): Promise<GuestbookSettingsResponse> {
-  return clientMutate<GuestbookSettingsResponse>(
-    "/api/admin/settings/guestbook",
-    {
-      method: "PATCH",
-      body: JSON.stringify({ enabled }),
-    },
-  );
+  return clientMutate<GuestbookSettingsResponse>("/admin/settings/guestbook", {
+    method: "PATCH",
+    body: JSON.stringify({ enabled }),
+  });
 }

--- a/src/entities/post/api.ts
+++ b/src/entities/post/api.ts
@@ -81,7 +81,7 @@ export async function fetchPosts(
   cookieHeader?: string,
 ): Promise<PaginatedResponse<PublishedPostListItem>> {
   const queryString = buildPostSearchParams(params);
-  const path = queryString ? `/api/posts?${queryString}` : "/api/posts";
+  const path = queryString ? `/posts?${queryString}` : "/posts";
 
   const response = await serverFetch<PaginatedResponse<PublishedPostListItem>>(
     path,
@@ -100,7 +100,7 @@ export async function fetchPostBySlug(
   // URLs sourced from Safari / macOS clipboards can arrive as NFD and fail to match.
   const normalizedSlug = slug.normalize("NFKC");
   const response = await serverFetch<PostDetailWithNavigationResponse>(
-    `/api/posts/${encodeURIComponent(normalizedSlug)}`,
+    `/posts/${encodeURIComponent(normalizedSlug)}`,
     {},
     cookieHeader,
   );
@@ -115,7 +115,7 @@ export async function fetchPublishedPostSlugs(
   cookieHeader?: string,
 ): Promise<PublishedPostSlugsResponse> {
   return serverFetch<PublishedPostSlugsResponse>(
-    "/api/posts/slugs",
+    "/posts/slugs",
     {},
     cookieHeader,
   );
@@ -127,11 +127,11 @@ export async function fetchAdminPost(
 ): Promise<PostDetail> {
   const response = cookieHeader
     ? await serverFetch<PostDetailResponse>(
-        `/api/admin/posts/${id}`,
+        `/admin/posts/${id}`,
         {},
         cookieHeader,
       )
-    : await clientFetch<PostDetailResponse>(`/api/admin/posts/${id}`);
+    : await clientFetch<PostDetailResponse>(`/admin/posts/${id}`);
 
   return normalizePost(response.post);
 }
@@ -141,9 +141,7 @@ export async function fetchAdminPosts(
   cookieHeader?: string,
 ): Promise<PaginatedResponse<PostListItem>> {
   const queryString = buildAdminPostSearchParams(params);
-  const path = queryString
-    ? `/api/admin/posts?${queryString}`
-    : "/api/admin/posts";
+  const path = queryString ? `/admin/posts?${queryString}` : "/admin/posts";
 
   const response = cookieHeader
     ? await serverFetch<PaginatedResponse<PostListItem>>(path, {}, cookieHeader)
@@ -154,14 +152,14 @@ export async function fetchAdminPosts(
 
 export async function fetchPinnedPostCount(): Promise<number> {
   const response = await clientFetch<PinnedPostCountResponse>(
-    "/api/admin/posts/pinned-count",
+    "/admin/posts/pinned-count",
   );
 
   return response.pinnedCount;
 }
 
 export async function createPost(body: CreatePostBody): Promise<PostDetail> {
-  const response = await clientMutate<PostDetailResponse>("/api/admin/posts", {
+  const response = await clientMutate<PostDetailResponse>("/admin/posts", {
     body: JSON.stringify(body),
   });
 
@@ -169,14 +167,14 @@ export async function createPost(body: CreatePostBody): Promise<PostDetail> {
 }
 
 export async function deletePost(id: number): Promise<void> {
-  await clientMutate<void>(`/api/admin/posts/${id}`, {
+  await clientMutate<void>(`/admin/posts/${id}`, {
     method: "DELETE",
   });
 }
 
 export async function restorePost(id: number): Promise<PostDetail> {
   const response = await clientMutate<PostDetailResponse>(
-    `/api/admin/posts/${id}/restore`,
+    `/admin/posts/${id}/restore`,
     {
       method: "PUT",
     },
@@ -186,7 +184,7 @@ export async function restorePost(id: number): Promise<PostDetail> {
 }
 
 export async function hardDeletePost(id: number): Promise<void> {
-  await clientMutate<void>(`/api/admin/posts/${id}/hard`, {
+  await clientMutate<void>(`/admin/posts/${id}/hard`, {
     method: "DELETE",
   });
 }
@@ -196,7 +194,7 @@ export async function updatePost(
   body: UpdatePostBody,
 ): Promise<PostDetail> {
   const response = await clientMutate<PostDetailResponse>(
-    `/api/admin/posts/${id}`,
+    `/admin/posts/${id}`,
     {
       method: "PATCH",
       body: JSON.stringify(body),
@@ -207,7 +205,7 @@ export async function updatePost(
 }
 
 export async function bulkUpdatePosts(action: BulkPostAction): Promise<void> {
-  await clientMutate<void>("/api/admin/posts/bulk", {
+  await clientMutate<void>("/admin/posts/bulk", {
     method: "PATCH",
     body: JSON.stringify(action),
   });

--- a/src/entities/stat/api.ts
+++ b/src/entities/stat/api.ts
@@ -11,11 +11,11 @@ function buildPopularPostsPath(days: number, limit: number) {
     limit: String(limit),
   });
 
-  return `/api/stats/popular?${searchParams.toString()}`;
+  return `/stats/popular?${searchParams.toString()}`;
 }
 
 export async function fetchDashboardStats(): Promise<DashboardStats> {
-  return clientFetch<DashboardStats>("/api/admin/stats/dashboard");
+  return clientFetch<DashboardStats>("/admin/stats/dashboard");
 }
 
 export async function fetchPopularPosts(
@@ -46,9 +46,5 @@ export async function fetchPopularPostsClient(
 export async function fetchTotalViews(
   cookieHeader?: string,
 ): Promise<TotalViewsStats> {
-  return serverFetch<TotalViewsStats>(
-    "/api/stats/total-views",
-    {},
-    cookieHeader,
-  );
+  return serverFetch<TotalViewsStats>("/stats/total-views", {}, cookieHeader);
 }

--- a/src/entities/tag/api.ts
+++ b/src/entities/tag/api.ts
@@ -6,17 +6,13 @@ interface TagsResponse {
 }
 
 export async function fetchTags(cookieHeader?: string): Promise<Tag[]> {
-  const response = await serverFetch<TagsResponse>(
-    "/api/tags",
-    {},
-    cookieHeader,
-  );
+  const response = await serverFetch<TagsResponse>("/tags", {}, cookieHeader);
 
   return response.tags;
 }
 
 export async function fetchTagsClient(): Promise<Tag[]> {
-  const response = await clientFetch<TagsResponse>("/api/tags");
+  const response = await clientFetch<TagsResponse>("/tags");
 
   return response.tags;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -90,7 +90,7 @@ async function isAuthenticated(request: NextRequest): Promise<boolean> {
   }
 
   try {
-    const response = await fetch(`${API_URL}/api/auth/me`, {
+    const response = await fetch(`${API_URL}/auth/me`, {
       headers: {
         Cookie: cookieHeader,
       },

--- a/src/shared/api/csrf.ts
+++ b/src/shared/api/csrf.ts
@@ -4,7 +4,7 @@ let tokenPromise: Promise<string> | null = null;
 
 export async function getCsrfToken(): Promise<string> {
   if (!tokenPromise) {
-    tokenPromise = clientFetch<{ token: string }>("/api/auth/csrf-token")
+    tokenPromise = clientFetch<{ token: string }>("/auth/csrf-token")
       .then((res) => res.token)
       .catch((err) => {
         tokenPromise = null;

--- a/src/shared/hooks/use-site-view-count.ts
+++ b/src/shared/hooks/use-site-view-count.ts
@@ -49,7 +49,7 @@ export function useSiteViewCount(enabled = true): void {
     window.sessionStorage.setItem(PENDING_SITE_VIEW_KEY, String(Date.now()));
 
     // The empty payload tells the backend to record a site-wide visit (postId: null).
-    void clientMutate("/api/stats/view", {
+    void clientMutate("/stats/view", {
       body: JSON.stringify({}),
       keepalive: true,
     })

--- a/src/shared/hooks/use-view-count.ts
+++ b/src/shared/hooks/use-view-count.ts
@@ -101,7 +101,7 @@ export function useViewCount(postId: number): void {
       [postId]: Date.now(),
     });
 
-    void clientMutate("/api/stats/view", {
+    void clientMutate("/stats/view", {
       body: JSON.stringify({ postId }),
       keepalive: true,
     })

--- a/stories/app/guestbook.stories.tsx
+++ b/stories/app/guestbook.stories.tsx
@@ -59,7 +59,7 @@ export const Empty: Story = {
   parameters: {
     msw: {
       handlers: [
-        http.get("/api/guestbook", () =>
+        http.get("/guestbook", () =>
           HttpResponse.json({
             data: [],
             meta: { total: 0, page: 1, limit: 10, totalPages: 0 },

--- a/stories/app/home.stories.tsx
+++ b/stories/app/home.stories.tsx
@@ -58,7 +58,7 @@ export const Empty: Story = {
   parameters: {
     msw: {
       handlers: [
-        http.get("/api/posts", () => {
+        http.get("/posts", () => {
           return HttpResponse.json({ data: [], meta: { total: 0, page: 1, limit: 10, totalPages: 0 } });
         }),
       ],

--- a/stories/app/post-detail.stories.tsx
+++ b/stories/app/post-detail.stories.tsx
@@ -664,7 +664,7 @@ function StorySurface({
 }
 
 const postDetailHandlers = [
-  http.get("/api/stats/popular", ({ request }) => {
+  http.get("/stats/popular", ({ request }) => {
     const url = new URL(request.url);
     const days = url.searchParams.get("days");
 
@@ -672,7 +672,7 @@ const postDetailHandlers = [
       data: days === "30" ? popularPosts30Days : popularPosts7Days,
     });
   }),
-  http.get("/api/posts/:postId/comments", ({ request, params }) => {
+  http.get("/posts/:postId/comments", ({ request, params }) => {
     if (Number(params.postId) !== postDetailPost.id) {
       return HttpResponse.json({ data: [], meta: commentMeta });
     }
@@ -691,7 +691,7 @@ const postDetailHandlers = [
       },
     });
   }),
-  http.post("/api/posts/:postId/comments", async ({ request, params }) => {
+  http.post("/posts/:postId/comments", async ({ request, params }) => {
     if (Number(params.postId) !== postDetailPost.id) {
       return HttpResponse.json(
         { message: "post not found" },
@@ -730,7 +730,7 @@ const postDetailHandlers = [
       revealToken: body.isSecret ? "storybook-token" : null,
     });
   }),
-  http.post("/api/comments/:commentId/reveal", ({ params }) => {
+  http.post("/comments/:commentId/reveal", ({ params }) => {
     return HttpResponse.json({
       data: {
         id: Number(params.commentId),
@@ -748,7 +748,7 @@ const postDetailHandlers = [
       },
     });
   }),
-  http.delete("/api/comments/:commentId", () => {
+  http.delete("/comments/:commentId", () => {
     return new HttpResponse(null, { status: 204 });
   }),
 ];

--- a/stories/features/popular-post-list.stories.tsx
+++ b/stories/features/popular-post-list.stories.tsx
@@ -58,13 +58,13 @@ const lastMonthPosts = [
 ] as const;
 
 const popularHandlers = [
-  http.get("/api/stats/popular", ({ request }) => {
+  http.get("/stats/popular", ({ request }) => {
     const days = new URL(request.url).searchParams.get("days");
     return HttpResponse.json({
       data: days === "30" ? lastMonthPosts : defaultPosts,
     });
   }),
-  http.get("http://localhost:5500/api/stats/popular", ({ request }) => {
+  http.get("http://localhost:5500/stats/popular", ({ request }) => {
     const days = new URL(request.url).searchParams.get("days");
     return HttpResponse.json({
       data: days === "30" ? lastMonthPosts : defaultPosts,

--- a/stories/mocks/dashboard-handlers.ts
+++ b/stories/mocks/dashboard-handlers.ts
@@ -29,7 +29,7 @@ function createDashboardHandlers(options?: {
   const commentsMode = options?.comments ?? "default";
 
   const statsHandlers = [
-    http.get("/api/admin/stats/dashboard", () => {
+    http.get("/admin/stats/dashboard", () => {
       if (statsMode === "error") {
         return new HttpResponse(null, { status: 500 });
       }
@@ -38,7 +38,7 @@ function createDashboardHandlers(options?: {
         statsMode === "empty" ? emptyDashboardStatsPayload : dashboardStatsPayload,
       );
     }),
-    http.get("*/api/admin/stats/dashboard", () => {
+    http.get("*/admin/stats/dashboard", () => {
       if (statsMode === "error") {
         return new HttpResponse(null, { status: 500 });
       }
@@ -50,7 +50,7 @@ function createDashboardHandlers(options?: {
   ];
 
   const commentsHandlers = [
-    http.get("/api/admin/comments", () => {
+    http.get("/admin/comments", () => {
       if (commentsMode === "error") {
         return new HttpResponse(null, { status: 500 });
       }
@@ -69,7 +69,7 @@ function createDashboardHandlers(options?: {
           : mockAdminCommentsResponse,
       );
     }),
-    http.get("*/api/admin/comments", () => {
+    http.get("*/admin/comments", () => {
       if (commentsMode === "error") {
         return new HttpResponse(null, { status: 500 });
       }
@@ -88,21 +88,21 @@ function createDashboardHandlers(options?: {
           : mockAdminCommentsResponse,
       );
     }),
-    http.get("/api/auth/csrf-token", () =>
+    http.get("/auth/csrf-token", () =>
       HttpResponse.json({ token: "storybook-csrf-token" }),
     ),
-    http.get("*/api/auth/csrf-token", () =>
+    http.get("*/auth/csrf-token", () =>
       HttpResponse.json({ token: "storybook-csrf-token" }),
     ),
-    http.delete("/api/admin/comments/:id", () => new HttpResponse(null, { status: 204 })),
-    http.delete("*/api/admin/comments/:id", () =>
+    http.delete("/admin/comments/:id", () => new HttpResponse(null, { status: 204 })),
+    http.delete("*/admin/comments/:id", () =>
       new HttpResponse(null, { status: 204 }),
     ),
-    http.put("/api/admin/comments/:id/restore", () => new HttpResponse(null, { status: 204 })),
-    http.put("*/api/admin/comments/:id/restore", () =>
+    http.put("/admin/comments/:id/restore", () => new HttpResponse(null, { status: 204 })),
+    http.put("*/admin/comments/:id/restore", () =>
       new HttpResponse(null, { status: 204 }),
     ),
-    http.get("/api/admin/comments/:id/thread", ({ params }) => {
+    http.get("/admin/comments/:id/thread", ({ params }) => {
       const id = Number(params.id);
       const payload = mockAdminCommentThreadResponses[id];
 
@@ -112,7 +112,7 @@ function createDashboardHandlers(options?: {
 
       return HttpResponse.json(payload);
     }),
-    http.get("*/api/admin/comments/:id/thread", ({ params }) => {
+    http.get("*/admin/comments/:id/thread", ({ params }) => {
       const id = Number(params.id);
       const payload = mockAdminCommentThreadResponses[id];
 

--- a/stories/mocks/handlers.ts
+++ b/stories/mocks/handlers.ts
@@ -11,10 +11,10 @@ import { mockDashboardStats, mockPopularPosts } from "./data/stats";
 
 export const handlers = [
   // Posts
-  http.get("/api/posts", () => {
+  http.get("/posts", () => {
     return HttpResponse.json({ data: mockPosts, meta: mockMeta });
   }),
-  http.get("/api/posts/:slug", ({ params }) => {
+  http.get("/posts/:slug", ({ params }) => {
     const post = mockPosts.find((p) => p.slug === params.slug) ?? mockPosts[0];
     return HttpResponse.json({
       post,
@@ -27,28 +27,25 @@ export const handlers = [
   }),
 
   // Admin posts
-  http.get("/api/admin/posts", () => {
+  http.get("/admin/posts", () => {
     return HttpResponse.json({ data: mockPosts, meta: mockMeta });
   }),
-  http.get("/api/admin/posts/:id", ({ params }) => {
+  http.get("/admin/posts/:id", ({ params }) => {
     const post =
       mockPosts.find((p) => p.id === Number(params.id)) ?? mockPosts[0];
     return HttpResponse.json({ post });
   }),
 
   // Categories
-  http.get("/api/categories", () => {
-    return HttpResponse.json({ data: mockCategories });
-  }),
-  http.get("/api/admin/categories", () => {
-    return HttpResponse.json({ data: mockCategories });
+  http.get("/categories", () => {
+    return HttpResponse.json({ categories: mockCategories });
   }),
 
   // Comments
-  http.get("/api/posts/:postId/comments", () => {
+  http.get("/posts/:postId/comments", () => {
     return HttpResponse.json({ data: mockComments, meta: mockCommentMeta });
   }),
-  http.get("/api/admin/comments", () => {
+  http.get("/admin/comments", () => {
     return HttpResponse.json({
       data: mockComments,
       meta: { total: mockComments.length, page: 1, limit: 10, totalPages: 1 },
@@ -56,7 +53,7 @@ export const handlers = [
   }),
 
   // Guestbook
-  http.get("/api/guestbook", () => {
+  http.get("/guestbook", () => {
     return HttpResponse.json({
       data: mockGuestbookEntries,
       meta: {
@@ -67,7 +64,7 @@ export const handlers = [
       },
     });
   }),
-  http.get("/api/admin/guestbook", () => {
+  http.get("/admin/guestbook", () => {
     return HttpResponse.json({
       data: mockAdminGuestbookEntries,
       meta: {
@@ -78,22 +75,22 @@ export const handlers = [
       },
     });
   }),
-  http.delete("/api/admin/guestbook/:id", () => {
+  http.delete("/admin/guestbook/:id", () => {
     return new HttpResponse(null, { status: 204 });
   }),
-  http.delete("/api/admin/guestbook/bulk", () => {
+  http.delete("/admin/guestbook/bulk", () => {
     return new HttpResponse(null, { status: 204 });
   }),
-  http.get("/api/settings/guestbook", () => {
+  http.get("/settings/guestbook", () => {
     return HttpResponse.json({ enabled: true });
   }),
-  http.patch("/api/admin/settings/guestbook", async ({ request }) => {
+  http.patch("/admin/settings/guestbook", async ({ request }) => {
     const body = (await request.json()) as { enabled: boolean };
     return HttpResponse.json({ enabled: body.enabled });
   }),
 
   // Assets
-  http.get("/api/admin/assets", () => {
+  http.get("/assets", () => {
     return HttpResponse.json({
       data: mockAssets,
       meta: { total: mockAssets.length, page: 1, limit: 10, totalPages: 1 },
@@ -101,15 +98,15 @@ export const handlers = [
   }),
 
   // Stats
-  http.get("/api/admin/stats/dashboard", () => {
+  http.get("/admin/stats/dashboard", () => {
     return HttpResponse.json(mockDashboardStats);
   }),
-  http.get("/api/stats/popular", () => {
+  http.get("/stats/popular", () => {
     return HttpResponse.json({ data: mockPopularPosts });
   }),
 
   // Auth
-  http.get("/api/auth/me", () => {
+  http.get("/auth/me", () => {
     return HttpResponse.json({
       type: "admin",
       id: 1,

--- a/stories/mocks/manage-page-handlers.ts
+++ b/stories/mocks/manage-page-handlers.ts
@@ -111,14 +111,14 @@ function jsonMutation(
 
 function sharedAdminHandlers() {
   return [
-    ...jsonGet("/api/auth/csrf-token", () =>
+    ...jsonGet("/auth/csrf-token", () =>
       HttpResponse.json({ token: "storybook-csrf-token" }),
     ),
-    ...jsonGet("/api/auth/me", () => HttpResponse.json(mockCurrentAdminUser)),
-    ...withBaseUrl("/api/auth/admin/logout").map((url) =>
+    ...jsonGet("/auth/me", () => HttpResponse.json(mockCurrentAdminUser)),
+    ...withBaseUrl("/auth/admin/logout").map((url) =>
       http.post(url, () => new HttpResponse(null, { status: 204 })),
     ),
-    ...jsonGet("/api/admin/posts", () =>
+    ...jsonGet("/admin/posts", () =>
       HttpResponse.json({
         data: mockPosts,
         meta: {
@@ -140,14 +140,14 @@ export function createManageCategoriesHandlers(options?: {
 
   return [
     ...sharedAdminHandlers(),
-    ...jsonGet("/api/categories", () => {
+    ...jsonGet("/categories", () => {
       if (mode === "error") {
         return new HttpResponse(null, { status: 500 });
       }
 
       return HttpResponse.json({ categories: categoriesPayload });
     }),
-    ...jsonMutation("post", "/api/categories", async ({ request }) => {
+    ...jsonMutation("post", "/categories", async ({ request }) => {
       const body = (await request.json()) as {
         name?: string;
         parentId?: number | null;
@@ -175,9 +175,9 @@ export function createManageCategoriesHandlers(options?: {
         },
       });
     }),
-    ...emptyMutation("patch", "/api/categories/tree"),
-    ...emptyMutation("patch", "/api/categories/order"),
-    ...withBaseUrl("/api/categories/:id").flatMap((url) => [
+    ...emptyMutation("patch", "/categories/tree"),
+    ...emptyMutation("patch", "/categories/order"),
+    ...withBaseUrl("/categories/:id").flatMap((url) => [
       http.patch(url, () =>
         HttpResponse.json({ category: categoriesPayload[0] }),
       ),
@@ -193,7 +193,7 @@ export function createManageCommentsHandlers(options?: {
 
   return [
     ...sharedAdminHandlers(),
-    ...jsonGet("/api/admin/comments", () => {
+    ...jsonGet("/admin/comments", () => {
       if (mode === "error") {
         return new HttpResponse(null, { status: 500 });
       }
@@ -204,7 +204,7 @@ export function createManageCommentsHandlers(options?: {
           : mockAdminCommentsResponse,
       );
     }),
-    ...withBaseUrl("/api/admin/comments/:id/thread").map((url) =>
+    ...withBaseUrl("/admin/comments/:id/thread").map((url) =>
       http.get(url, ({ params }) => {
         const id = Number(params.id);
         const payload = mockAdminCommentThreadResponses[id];
@@ -219,9 +219,9 @@ export function createManageCommentsHandlers(options?: {
         return HttpResponse.json(payload);
       }),
     ),
-    ...emptyMutation("delete", "/api/admin/comments/bulk"),
-    ...emptyMutation("delete", "/api/admin/comments/:id"),
-    ...emptyMutation("put", "/api/admin/comments/:id/restore"),
+    ...emptyMutation("delete", "/admin/comments/bulk"),
+    ...emptyMutation("delete", "/admin/comments/:id"),
+    ...emptyMutation("put", "/admin/comments/:id/restore"),
   ];
 }
 
@@ -232,14 +232,14 @@ export function createManageGuestbookHandlers(options?: {
 
   return [
     ...sharedAdminHandlers(),
-    ...jsonGet("/api/settings/guestbook", () => {
+    ...jsonGet("/settings/guestbook", () => {
       if (mode === "error") {
         return new HttpResponse(null, { status: 500 });
       }
 
       return HttpResponse.json({ enabled: mode !== "disabled" });
     }),
-    ...jsonGet("/api/admin/guestbook", () => {
+    ...jsonGet("/admin/guestbook", () => {
       if (mode === "error") {
         return new HttpResponse(null, { status: 500 });
       }
@@ -250,15 +250,15 @@ export function createManageGuestbookHandlers(options?: {
     }),
     ...jsonMutation(
       "patch",
-      "/api/admin/settings/guestbook",
+      "/admin/settings/guestbook",
       async ({ request }) => {
         const body = (await request.json()) as { enabled?: boolean };
 
         return HttpResponse.json({ enabled: body.enabled ?? false });
       },
     ),
-    ...emptyMutation("delete", "/api/admin/guestbook/bulk"),
-    ...emptyMutation("delete", "/api/admin/guestbook/:id"),
+    ...emptyMutation("delete", "/admin/guestbook/bulk"),
+    ...emptyMutation("delete", "/admin/guestbook/:id"),
   ];
 }
 
@@ -269,7 +269,7 @@ export function createManageAssetsHandlers(options?: {
 
   return [
     ...sharedAdminHandlers(),
-    ...jsonGet("/api/assets", () => {
+    ...jsonGet("/assets", () => {
       if (mode === "error") {
         return new HttpResponse(null, { status: 500 });
       }
@@ -278,9 +278,9 @@ export function createManageAssetsHandlers(options?: {
         mode === "empty" ? adminAssetsEmptyResponse : adminAssetsResponse,
       );
     }),
-    ...emptyMutation("delete", "/api/assets/bulk"),
-    ...emptyMutation("delete", "/api/assets/:id"),
-    ...withBaseUrl("/api/assets/upload").map((url) =>
+    ...emptyMutation("delete", "/assets/bulk"),
+    ...emptyMutation("delete", "/assets/:id"),
+    ...withBaseUrl("/assets/upload").map((url) =>
       http.post(url, () =>
         HttpResponse.json({ assets: mockAssets.slice(0, 1) }),
       ),

--- a/stories/mocks/post-create-handlers.ts
+++ b/stories/mocks/post-create-handlers.ts
@@ -46,11 +46,11 @@ function buildPostFromCreateBody(body: CreatePostBody): Post {
 }
 
 export const postCreateHandlers = [
-  http.get(`${API_BASE_URL}/api/auth/csrf-token`, () => {
+  http.get(`${API_BASE_URL}/auth/csrf-token`, () => {
     return HttpResponse.json({ token: "storybook-csrf-token" });
   }),
 
-  http.get(`${API_BASE_URL}/api/categories`, ({ request }) => {
+  http.get(`${API_BASE_URL}/categories`, ({ request }) => {
     const url = new URL(request.url);
     const includeHidden = url.searchParams.get("include_hidden");
 
@@ -61,11 +61,11 @@ export const postCreateHandlers = [
     return HttpResponse.json({ categories: mockCategories });
   }),
 
-  http.get(`${API_BASE_URL}/api/tags`, () => {
+  http.get(`${API_BASE_URL}/tags`, () => {
     return HttpResponse.json({ tags: mockTags });
   }),
 
-  http.get(`${API_BASE_URL}/api/assets`, ({ request }) => {
+  http.get(`${API_BASE_URL}/assets`, ({ request }) => {
     const url = new URL(request.url);
     const page = Number(url.searchParams.get("page") ?? "1");
     const limit = Number(url.searchParams.get("limit") ?? "18");
@@ -81,7 +81,7 @@ export const postCreateHandlers = [
     });
   }),
 
-  http.post(`${API_BASE_URL}/api/assets/upload`, () => {
+  http.post(`${API_BASE_URL}/assets/upload`, () => {
     return HttpResponse.json({
       assets: mockAssets.slice(0, 1).map((asset) => ({
         id: asset.id,
@@ -94,7 +94,7 @@ export const postCreateHandlers = [
     });
   }),
 
-  http.post(`${API_BASE_URL}/api/admin/posts`, async ({ request }) => {
+  http.post(`${API_BASE_URL}/admin/posts`, async ({ request }) => {
     const body = (await request.json()) as CreatePostBody;
 
     return HttpResponse.json({
@@ -102,7 +102,7 @@ export const postCreateHandlers = [
     });
   }),
 
-  http.get(`${API_BASE_URL}/api/admin/posts`, () => {
+  http.get(`${API_BASE_URL}/admin/posts`, () => {
     return HttpResponse.json({
       data: mockPosts,
       meta: {

--- a/stories/mocks/post-list-handlers.ts
+++ b/stories/mocks/post-list-handlers.ts
@@ -134,21 +134,21 @@ export function createPostListHandlers(options?: {
   }
 
   return [
-    http.get(`${API_BASE_URL}/api/auth/csrf-token`, () =>
+    http.get(`${API_BASE_URL}/auth/csrf-token`, () =>
       HttpResponse.json({ token: "storybook-csrf-token" }),
     ),
 
-    http.get(`${API_BASE_URL}/api/categories`, () =>
+    http.get(`${API_BASE_URL}/categories`, () =>
       HttpResponse.json({ categories: mockCategories }),
     ),
 
-    http.get(`${API_BASE_URL}/api/admin/posts/pinned-count`, () =>
+    http.get(`${API_BASE_URL}/admin/posts/pinned-count`, () =>
       HttpResponse.json({
         pinnedCount: activePosts.filter((post) => post.isPinned).length,
       }),
     ),
 
-    http.get(`${API_BASE_URL}/api/admin/posts`, ({ request }) => {
+    http.get(`${API_BASE_URL}/admin/posts`, ({ request }) => {
       if (mode === "error") {
         return HttpResponse.json(
           { statusCode: 500, message: "스토리북 글 목록 로딩 실패" },
@@ -165,7 +165,7 @@ export function createPostListHandlers(options?: {
       return HttpResponse.json(paginatePosts(sorted, url.searchParams));
     }),
 
-    http.patch(`${API_BASE_URL}/api/admin/posts/bulk`, async ({ request }) => {
+    http.patch(`${API_BASE_URL}/admin/posts/bulk`, async ({ request }) => {
       const body = (await request.json()) as BulkPostAction;
 
       if (body.action === "soft_delete") {
@@ -223,7 +223,7 @@ export function createPostListHandlers(options?: {
     }),
 
     http.patch(
-      `${API_BASE_URL}/api/admin/posts/:id`,
+      `${API_BASE_URL}/admin/posts/:id`,
       async ({ params, request }) => {
         const id = Number(params.id);
         const body = (await request.json()) as UpdatePostBody;
@@ -246,7 +246,7 @@ export function createPostListHandlers(options?: {
       },
     ),
 
-    http.delete(`${API_BASE_URL}/api/admin/posts/:id`, ({ params }) => {
+    http.delete(`${API_BASE_URL}/admin/posts/:id`, ({ params }) => {
       const id = Number(params.id);
       const target = activePosts.find((post) => post.id === id);
 
@@ -265,7 +265,7 @@ export function createPostListHandlers(options?: {
       return new HttpResponse(null, { status: 204 });
     }),
 
-    http.put(`${API_BASE_URL}/api/admin/posts/:id/restore`, ({ params }) => {
+    http.put(`${API_BASE_URL}/admin/posts/:id/restore`, ({ params }) => {
       const id = Number(params.id);
       const target = trashPosts.find((post) => post.id === id);
 
@@ -279,7 +279,7 @@ export function createPostListHandlers(options?: {
       });
     }),
 
-    http.delete(`${API_BASE_URL}/api/admin/posts/:id/hard`, ({ params }) => {
+    http.delete(`${API_BASE_URL}/admin/posts/:id/hard`, ({ params }) => {
       const id = Number(params.id);
       trashPosts = trashPosts.filter((post) => post.id !== id);
 

--- a/stories/widgets/admin/asset-gallery.stories.tsx
+++ b/stories/widgets/admin/asset-gallery.stories.tsx
@@ -27,7 +27,7 @@ export const Default: Story = {
   parameters: {
     msw: {
       handlers: [
-        http.get("*/api/assets", () =>
+        http.get("*/assets", () =>
           HttpResponse.json({
             data: assets,
             meta: { total: 6, page: 1, limit: 18, totalPages: 1 },
@@ -42,7 +42,7 @@ export const Empty: Story = {
   parameters: {
     msw: {
       handlers: [
-        http.get("*/api/assets", () =>
+        http.get("*/assets", () =>
           HttpResponse.json({
             data: [],
             meta: { total: 0, page: 1, limit: 18, totalPages: 0 },
@@ -57,7 +57,7 @@ export const Error: Story = {
   parameters: {
     msw: {
       handlers: [
-        http.get("*/api/assets", () => new HttpResponse(null, { status: 500 })),
+        http.get("*/assets", () => new HttpResponse(null, { status: 500 })),
       ],
     },
   },

--- a/stories/widgets/admin/category-tree.stories.tsx
+++ b/stories/widgets/admin/category-tree.stories.tsx
@@ -19,8 +19,8 @@ export const Empty: Story = {
   parameters: {
     msw: {
       handlers: [
-        http.get("/api/admin/categories", () => {
-          return HttpResponse.json({ data: [] });
+        http.get("/categories", () => {
+          return HttpResponse.json({ categories: [] });
         }),
       ],
     },
@@ -31,7 +31,7 @@ export const Error: Story = {
   parameters: {
     msw: {
       handlers: [
-        http.get("/api/admin/categories", () => {
+        http.get("/categories", () => {
           return new HttpResponse(null, { status: 500 });
         }),
       ],

--- a/stories/widgets/admin/comment-manager.stories.tsx
+++ b/stories/widgets/admin/comment-manager.stories.tsx
@@ -19,7 +19,7 @@ export const Empty: Story = {
   parameters: {
     msw: {
       handlers: [
-        http.get("/api/admin/comments", () => {
+        http.get("/admin/comments", () => {
           return HttpResponse.json({ data: [], meta: { total: 0, page: 1, limit: 10, totalPages: 0 } });
         }),
       ],
@@ -31,7 +31,7 @@ export const Error: Story = {
   parameters: {
     msw: {
       handlers: [
-        http.get("/api/admin/comments", () => {
+        http.get("/admin/comments", () => {
           return new HttpResponse(null, { status: 500 });
         }),
       ],

--- a/stories/widgets/admin/guestbook-manager.stories.tsx
+++ b/stories/widgets/admin/guestbook-manager.stories.tsx
@@ -19,7 +19,7 @@ export const Empty: Story = {
   parameters: {
     msw: {
       handlers: [
-        http.get("/api/admin/guestbook", () => {
+        http.get("/admin/guestbook", () => {
           return HttpResponse.json({
             data: [],
             meta: { total: 0, page: 1, limit: 10, totalPages: 0 },
@@ -40,7 +40,7 @@ export const Disabled: Story = {
   parameters: {
     msw: {
       handlers: [
-        http.get("/api/settings/guestbook", () => {
+        http.get("/settings/guestbook", () => {
           return HttpResponse.json({ enabled: false });
         }),
       ],

--- a/stories/widgets/admin/post-editor.stories.tsx
+++ b/stories/widgets/admin/post-editor.stories.tsx
@@ -40,7 +40,7 @@ export const Error: Story = {
   parameters: {
     msw: {
       handlers: [
-        http.get("/api/admin/categories", () => {
+        http.get("/categories", () => {
           return new HttpResponse(null, { status: 500 });
         }),
       ],


### PR DESCRIPTION
## Summary

Closes #310

Align client API calls and Storybook mocks with the server-side removal of the `/api` prefix.

## Changes

| File | Change |
|------|--------|
| `src/entities/*/api.ts` | Updated public/admin API paths from `/api/...` to `/...` |
| `src/shared/api/csrf.ts`, `src/shared/hooks/use-*-count.ts`, `src/middleware.ts` | Aligned auth, CSRF, stats, and middleware auth check paths |
| `stories/**/*` | Updated MSW handlers and story mocks to match the new API paths and category/assets mock contracts |
