### PR TITLE
fix: avoid post slug double encoding (#316)

### DIFF
--- a/src/entities/post/api.ts
+++ b/src/entities/post/api.ts
@@ -13,7 +13,12 @@ import type {
   UpdatePostBody,
 } from "./model";
 import type { PaginatedResponse } from "@shared/api";
-import { clientFetch, clientMutate, serverFetch } from "@shared/api";
+import {
+  ApiResponseError,
+  clientFetch,
+  clientMutate,
+  serverFetch,
+} from "@shared/api";
 import { normalizeOptionalAssetUrl } from "@shared/lib/asset-url";
 
 function buildPostSearchParams(params: FetchPostsParams): string {
@@ -96,27 +101,48 @@ export async function fetchPostBySlug(
   slug: string,
   cookieHeader?: string,
 ): Promise<PostDetailWithNavigationResponse> {
-  const decodedSlug = (() => {
-    try {
-      return decodeURIComponent(slug);
-    } catch {
-      return slug;
+  const buildPath = (value: string) =>
+    `/posts/${encodeURIComponent(value.normalize("NFKC"))}`;
+
+  try {
+    const response = await serverFetch<PostDetailWithNavigationResponse>(
+      buildPath(slug),
+      {},
+      cookieHeader,
+    );
+
+    return {
+      ...response,
+      post: normalizePost(response.post),
+    };
+  } catch (error) {
+    if (!(error instanceof ApiResponseError) || error.statusCode !== 404) {
+      throw error;
     }
-  })();
 
-  // Server stores slugs after `.normalize("NFKC")` (see server `generateUnicodeSlug`).
-  // URLs sourced from Safari / macOS clipboards can arrive as NFD and fail to match.
-  const normalizedSlug = decodedSlug.normalize("NFKC");
-  const response = await serverFetch<PostDetailWithNavigationResponse>(
-    `/posts/${encodeURIComponent(normalizedSlug)}`,
-    {},
-    cookieHeader,
-  );
+    let decodedSlug: string;
 
-  return {
-    ...response,
-    post: normalizePost(response.post),
-  };
+    try {
+      decodedSlug = decodeURIComponent(slug);
+    } catch {
+      throw error;
+    }
+
+    if (decodedSlug === slug) {
+      throw error;
+    }
+
+    const response = await serverFetch<PostDetailWithNavigationResponse>(
+      buildPath(decodedSlug),
+      {},
+      cookieHeader,
+    );
+
+    return {
+      ...response,
+      post: normalizePost(response.post),
+    };
+  }
 }
 
 export async function fetchPublishedPostSlugs(

--- a/src/entities/post/api.ts
+++ b/src/entities/post/api.ts
@@ -96,9 +96,17 @@ export async function fetchPostBySlug(
   slug: string,
   cookieHeader?: string,
 ): Promise<PostDetailWithNavigationResponse> {
+  const decodedSlug = (() => {
+    try {
+      return decodeURIComponent(slug);
+    } catch {
+      return slug;
+    }
+  })();
+
   // Server stores slugs after `.normalize("NFKC")` (see server `generateUnicodeSlug`).
   // URLs sourced from Safari / macOS clipboards can arrive as NFD and fail to match.
-  const normalizedSlug = slug.normalize("NFKC");
+  const normalizedSlug = decodedSlug.normalize("NFKC");
   const response = await serverFetch<PostDetailWithNavigationResponse>(
     `/posts/${encodeURIComponent(normalizedSlug)}`,
     {},


### PR DESCRIPTION
## Summary

Closes #316

Fix the public post detail SSR path builder so already-encoded slugs are decoded before canonical encoding. This prevents double encoding like `%EC... -> %25EC...` and restores published post detail pages.

## Changes

| File | Change |
|------|--------|
| `src/entities/post/api.ts` | Decode incoming slug defensively before NFKC normalization and final `encodeURIComponent()` |

## Screenshots

N/A
