### PR TITLE
feat: add guestbook header link (#319)

### DIFF
--- a/src/widgets/header/index.tsx
+++ b/src/widgets/header/index.tsx
@@ -101,6 +101,12 @@ const Header: React.FC<HeaderProps> = ({
           </Link>
 
           <div className="flex items-center gap-1">
+            <Link
+              href="/guestbook"
+              className="inline-flex h-9 items-center rounded-lg px-3 text-sm font-medium text-text-2 transition-colors hover:bg-background-3 hover:text-text-1"
+            >
+              방명록
+            </Link>
             <SearchBar />
             <ThemeButton />
             {onHamburgerClick && (


### PR DESCRIPTION
## Summary

Closes #319

공개 헤더에 방명록 진입 링크를 추가해 `/guestbook` 페이지로 이동할 수 있도록 했습니다.

## Changes

| File | Change |
|------|--------|
| `src/widgets/header/index.tsx` | 검색 아이콘 왼쪽에 `/guestbook` 링크를 추가하고 기존 헤더 액션과 같은 정렬/호버 스타일을 적용했습니다. |

## Screenshots

UI change only. Screenshots omitted.
