### PR TITLE
feat: block preview indexing (#313)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,6 +4,7 @@ const MANAGE_LOGIN_PATH = "/manage/login";
 const MANAGE_HOME_PATH = "/manage";
 const API_URL = process.env.API_URL ?? "http://localhost:5500";
 const NEXT_PUBLIC_API_URL = process.env.NEXT_PUBLIC_API_URL?.trim() ?? "";
+const NOINDEX_HEADER_VALUE = "noindex, nofollow";
 
 function joinSources(...sources: Array<string | false | null | undefined>) {
   return sources.filter(Boolean).join(" ");
@@ -38,6 +39,10 @@ function buildCspDirectives(nonce: string): string {
   ].join("; ");
 }
 
+function isProductionDeployment() {
+  return process.env.VERCEL_ENV === "production";
+}
+
 function nextWithCsp(request: NextRequest, nonce: string): NextResponse {
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set("x-nonce", nonce);
@@ -49,6 +54,10 @@ function nextWithCsp(request: NextRequest, nonce: string): NextResponse {
     "Content-Security-Policy-Report-Only",
     buildCspDirectives(nonce),
   );
+
+  if (!isProductionDeployment()) {
+    response.headers.set("X-Robots-Tag", NOINDEX_HEADER_VALUE);
+  }
 
   return response;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,6 +5,7 @@ const MANAGE_HOME_PATH = "/manage";
 const API_URL = process.env.API_URL ?? "http://localhost:5500";
 const NEXT_PUBLIC_API_URL = process.env.NEXT_PUBLIC_API_URL?.trim() ?? "";
 const NOINDEX_HEADER_VALUE = "noindex, nofollow";
+const PRODUCTION_HOSTS = new Set(["pyosh.com", "www.pyosh.com"]);
 
 function joinSources(...sources: Array<string | false | null | undefined>) {
   return sources.filter(Boolean).join(" ");
@@ -39,8 +40,18 @@ function buildCspDirectives(nonce: string): string {
   ].join("; ");
 }
 
-function isProductionDeployment() {
-  return process.env.VERCEL_ENV === "production";
+function shouldBlockIndexing(request: NextRequest) {
+  if (process.env.NODE_ENV !== "production") {
+    return true;
+  }
+
+  if (PRODUCTION_HOSTS.has(request.nextUrl.hostname.toLowerCase())) {
+    return false;
+  }
+
+  const vercelEnv = process.env.VERCEL_ENV?.trim();
+
+  return Boolean(vercelEnv && vercelEnv !== "production");
 }
 
 function nextWithCsp(request: NextRequest, nonce: string): NextResponse {
@@ -55,7 +66,7 @@ function nextWithCsp(request: NextRequest, nonce: string): NextResponse {
     buildCspDirectives(nonce),
   );
 
-  if (!isProductionDeployment()) {
+  if (shouldBlockIndexing(request)) {
     response.headers.set("X-Robots-Tag", NOINDEX_HEADER_VALUE);
   }
 


### PR DESCRIPTION
## Summary

Closes #313

Block search indexing on non-production Vercel deployments by adding an `X-Robots-Tag: noindex, nofollow` header in middleware. Also verified that `sitemap.xml` and `robots.txt` already point at the current live paths and do not reference the removed `/api` prefix.

## Changes

| File | Change |
|------|--------|
| `src/middleware.ts` | Add non-production `X-Robots-Tag` response header while keeping production deployments indexable |
| `src/app/sitemap.ts` | Verified current sitemap output uses live routes; no code change needed |
| `src/app/robots.ts` | Verified current robots output and sitemap URL are already correct; no code change needed |
