### PR TITLE
refactor: handle null post categories in restore flow (#324)

### DIFF
--- a/src/app/(public)/posts/[slug]/page.tsx
+++ b/src/app/(public)/posts/[slug]/page.tsx
@@ -133,6 +133,7 @@ export async function generateMetadata({
 
 export default async function PostDetailPage({ params }: PostDetailPageProps) {
   const { post } = await getPostDetail(params.slug);
+  const category = post.category;
   const headings = extractHeadings(post.contentMd);
   let comments: Comment[] = [];
   let commentMeta: CommentListMeta = {
@@ -148,10 +149,8 @@ export default async function PostDetailPage({ params }: PostDetailPageProps) {
 
   const [relatedPostsData, fetchedComments, categoryAncestors] =
     await Promise.all([
-      post.category
-        ? fetchPosts({ categoryId: post.category.id, limit: 7 }).catch(
-            () => null,
-          )
+      category
+        ? fetchPosts({ categoryId: category.id, limit: 7 }).catch(() => null)
         : Promise.resolve(null),
       post.commentStatus === "disabled"
         ? Promise.resolve(null)
@@ -161,11 +160,11 @@ export default async function PostDetailPage({ params }: PostDetailPageProps) {
 
             return null;
           }),
-      post.category.ancestors
-        ? Promise.resolve(post.category.ancestors)
+      category?.ancestors
+        ? Promise.resolve(category.ancestors)
         : fetchCategories()
             .then((categories) =>
-              getCategoryAncestors(categories, post.category.id),
+              category ? getCategoryAncestors(categories, category.id) : [],
             )
             .catch(() => []),
     ]);
@@ -181,10 +180,14 @@ export default async function PostDetailPage({ params }: PostDetailPageProps) {
       name: ancestor.name,
       href: `/categories/${ancestor.slug}`,
     })),
-    {
-      name: post.category.name,
-      href: `/categories/${post.category.slug}`,
-    },
+    ...(category
+      ? [
+          {
+            name: category.name,
+            href: `/categories/${category.slug}`,
+          },
+        ]
+      : []),
     { name: post.title },
   ];
 
@@ -218,12 +221,14 @@ export default async function PostDetailPage({ params }: PostDetailPageProps) {
         <div className="flex flex-col">
           <header className="mb-8">
             <div className="mb-3 flex flex-wrap items-center gap-3">
-              <Link
-                href={`/categories/${post.category.slug}`}
-                className="inline-flex items-center rounded-md bg-primary-1/12 px-2.5 py-1 text-ui-xs font-semibold text-primary-1 transition-colors hover:bg-primary-1/16"
-              >
-                {post.category.name}
-              </Link>
+              {category ? (
+                <Link
+                  href={`/categories/${category.slug}`}
+                  className="inline-flex items-center rounded-md bg-primary-1/12 px-2.5 py-1 text-ui-xs font-semibold text-primary-1 transition-colors hover:bg-primary-1/16"
+                >
+                  {category.name}
+                </Link>
+              ) : null}
               <time dateTime={publishedAt} className="text-ui-xs text-text-4">
                 {formatDate(post.publishedAt, post.createdAt)}
               </time>

--- a/src/app/manage/posts/page.tsx
+++ b/src/app/manage/posts/page.tsx
@@ -20,6 +20,7 @@ import {
   type PostListItem,
 } from "@entities/post";
 import { getErrorMessage } from "@shared/lib/get-error-message";
+import { Modal, Spinner } from "@shared/ui/libs";
 import {
   BulkActions,
   PostFilters,
@@ -32,6 +33,12 @@ import {
 } from "@widgets/admin-post-list";
 
 const PAGE_SIZE = 10;
+const UNCATEGORIZED_LABEL = "(카테고리 없음)";
+
+interface RestoreSelection {
+  ids: number[];
+  orphanIds: number[];
+}
 
 function hasBulkDetails(
   err: unknown,
@@ -67,6 +74,16 @@ function getQueryKey(
   ] as const;
 }
 
+function flattenCategories(
+  categories: Category[],
+  depth = 0,
+): Array<{ id: number; name: string; depth: number }> {
+  return categories.flatMap((category) => [
+    { id: category.id, name: category.name, depth },
+    ...flattenCategories(category.children ?? [], depth + 1),
+  ]);
+}
+
 export default function ManagePostsPage() {
   const queryClient = useQueryClient();
 
@@ -84,6 +101,13 @@ export default function ManagePostsPage() {
     new Set(),
   );
   const [deleteId, setDeleteId] = useState<number | null>(null);
+  const [restoreSelection, setRestoreSelection] =
+    useState<RestoreSelection | null>(null);
+  const [restoreCategoryId, setRestoreCategoryId] = useState<number | null>(
+    null,
+  );
+  const [isRestoreCategoryPending, setIsRestoreCategoryPending] =
+    useState(false);
 
   const queryKey = getQueryKey(
     tab,
@@ -126,6 +150,10 @@ export default function ManagePostsPage() {
   const rows = data?.data ?? [];
   const meta = data?.meta;
   const trashCount = tab === "trash" && meta ? meta.total : undefined;
+  const flatCategories = useMemo(
+    () => flattenCategories(categories),
+    [categories],
+  );
 
   useEffect(() => {
     if (meta && meta.totalPages > 0 && page > meta.totalPages) {
@@ -292,6 +320,72 @@ export default function ManagePostsPage() {
     ]);
   }
 
+  function getRestoreSelection(posts: PostListItem[]): RestoreSelection {
+    return {
+      ids: posts.map((post) => post.id),
+      orphanIds: posts
+        .filter((post) => post.categoryId === null)
+        .map((post) => post.id),
+    };
+  }
+
+  function closeRestoreModal() {
+    if (isRestoreCategoryPending) {
+      return;
+    }
+
+    setRestoreSelection(null);
+    setRestoreCategoryId(null);
+  }
+
+  async function restorePosts({
+    ids,
+    orphanIds,
+    categoryId,
+  }: RestoreSelection & { categoryId?: number }) {
+    if (orphanIds.length > 0) {
+      const nextCategoryId = categoryId ?? restoreCategoryId;
+
+      if (nextCategoryId === null || nextCategoryId === undefined) {
+        throw new Error("카테고리를 선택해 주세요.");
+      }
+
+      await Promise.all(
+        orphanIds.map((id) => updatePost(id, { categoryId: nextCategoryId })),
+      );
+    }
+
+    if (ids.length === 1) {
+      await restorePost(ids[0]);
+
+      return;
+    }
+
+    await bulkUpdatePosts({ ids, action: "restore" });
+  }
+
+  async function handleSingleRestore(post: PostListItem) {
+    const nextSelection = getRestoreSelection([post]);
+
+    if (nextSelection.orphanIds.length > 0) {
+      setRestoreSelection(nextSelection);
+      setRestoreCategoryId(null);
+
+      return;
+    }
+
+    try {
+      setDeleteId(post.id);
+      await restorePosts(nextSelection);
+      await invalidatePostQueries();
+      toast.success("글이 복원되었습니다.");
+    } catch (err) {
+      toast.error(getErrorMessage(err, "글 복원에 실패했습니다."));
+    } finally {
+      setDeleteId(null);
+    }
+  }
+
   const deleteMutation = useMutation({
     mutationFn: deletePost,
     onMutate: (id) => setDeleteId(id),
@@ -301,19 +395,6 @@ export default function ManagePostsPage() {
     },
     onError: (err) => {
       toast.error(getErrorMessage(err, "글 삭제에 실패했습니다."));
-    },
-    onSettled: () => setDeleteId(null),
-  });
-
-  const restoreMutation = useMutation({
-    mutationFn: restorePost,
-    onMutate: (id) => setDeleteId(id),
-    onSuccess: async () => {
-      await invalidatePostQueries();
-      toast.success("글이 복원되었습니다.");
-    },
-    onError: (err) => {
-      toast.error(getErrorMessage(err, "글 복원에 실패했습니다."));
     },
     onSettled: () => setDeleteId(null),
   });
@@ -350,8 +431,18 @@ export default function ManagePostsPage() {
   }
 
   async function handleBulkRestore(ids: number[]) {
+    const selectedPosts = rows.filter((post) => ids.includes(post.id));
+    const nextSelection = getRestoreSelection(selectedPosts);
+
     try {
-      await bulkUpdatePosts({ ids, action: "restore" });
+      if (nextSelection.orphanIds.length > 0) {
+        setRestoreSelection(nextSelection);
+        setRestoreCategoryId(null);
+
+        return;
+      }
+
+      await restorePosts(nextSelection);
       await invalidatePostQueries();
       toast.success(`${ids.length}개 글이 복원되었습니다.`);
     } catch (err) {
@@ -415,119 +506,250 @@ export default function ManagePostsPage() {
 
   const allSelected =
     rows.length > 0 && rows.every((post) => selectedIds.includes(post.id));
+  const restoreTargetCount = restoreSelection?.ids.length ?? 0;
+  const orphanRestoreCount = restoreSelection?.orphanIds.length ?? 0;
 
   return (
-    <div className="space-y-4">
-      <PostFilters
-        tab={tab}
-        trashCount={trashCount}
-        status={status}
-        visibility={visibility}
-        categoryId={categoryId}
-        categories={categories}
-        searchQuery={searchQuery}
-        onTabChange={handleTabChange}
-        onStatusChange={(value) => {
-          setStatus(value);
-          resetPage();
-        }}
-        onVisibilityChange={(value) => {
-          setVisibility(value);
-          resetPage();
-        }}
-        onCategoryChange={(value) => {
-          setCategoryId(value);
-          resetPage();
-        }}
-        onSearch={(value) => {
-          setSearchQuery(value);
-          resetPage();
-        }}
-        action={
-          <Link
-            href="/manage/posts/new"
-            className="inline-flex items-center justify-center rounded-lg bg-primary-1 px-4 py-2.5 text-body-sm font-semibold text-white transition-opacity hover:opacity-90"
-          >
-            새 글 작성
-          </Link>
-        }
-      />
-
-      {selectedIds.length > 0 ? (
-        <BulkActions
+    <>
+      <div className="space-y-4">
+        <PostFilters
           tab={tab}
-          selectedIds={selectedIds}
-          allSelected={allSelected}
+          trashCount={trashCount}
+          status={status}
+          visibility={visibility}
+          categoryId={categoryId}
           categories={categories}
-          onSelectAll={handleToggleSelectAll}
-          onBulkDelete={handleBulkDelete}
-          onBulkRestore={handleBulkRestore}
-          onBulkHardDelete={handleBulkHardDelete}
-          onBulkUpdate={handleBulkUpdate}
-          onClearSelection={() => setSelectedIds([])}
+          searchQuery={searchQuery}
+          onTabChange={handleTabChange}
+          onStatusChange={(value) => {
+            setStatus(value);
+            resetPage();
+          }}
+          onVisibilityChange={(value) => {
+            setVisibility(value);
+            resetPage();
+          }}
+          onCategoryChange={(value) => {
+            setCategoryId(value);
+            resetPage();
+          }}
+          onSearch={(value) => {
+            setSearchQuery(value);
+            resetPage();
+          }}
+          action={
+            <Link
+              href="/manage/posts/new"
+              className="inline-flex items-center justify-center rounded-lg bg-primary-1 px-4 py-2.5 text-body-sm font-semibold text-white transition-opacity hover:opacity-90"
+            >
+              새 글 작성
+            </Link>
+          }
         />
-      ) : null}
 
-      <PostTable
-        tab={tab}
-        posts={rows}
-        isPending={isPending}
-        isError={isError}
-        errorMessage={getErrorMessage(error, "글 목록을 불러오지 못했습니다.")}
-        selectedIds={selectedIds}
-        sort={sort}
-        order={order}
-        onRetry={() => void refetch()}
-        onToggleSelect={handleToggleSelect}
-        onToggleSelectAll={handleToggleSelectAll}
-        onSortChange={handleSortChange}
-        onToggleVisibility={handleToggleVisibility}
-        onTogglePin={handleTogglePin}
-        onDelete={(id) => deleteMutation.mutateAsync(id)}
-        onRestore={(id) => restoreMutation.mutate(id)}
-        onHardDelete={(id) => hardDeleteMutation.mutateAsync(id)}
-        pendingToggleIds={pendingToggleIds}
-        deleteId={deleteId}
-      />
-
-      <div className="flex flex-col gap-4 border-t border-border-3 pt-5 sm:flex-row sm:items-center sm:justify-between">
-        <p className="text-body-sm text-text-4">
-          {isFetching && !isPending
-            ? "목록을 새로 불러오는 중..."
-            : paginationLabel}
-        </p>
-
-        {meta && meta.totalPages > 1 ? (
-          <nav
-            aria-label="관리자 글 페이지네이션"
-            className="flex items-center gap-2"
-          >
-            <button
-              type="button"
-              onClick={() => setPage((value) => Math.max(1, value - 1))}
-              disabled={page === 1}
-              className="inline-flex rounded-lg border border-border-3 px-3 py-2 text-body-sm text-text-2 transition-colors hover:bg-background-3 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              이전
-            </button>
-
-            <span className="min-w-20 text-center text-body-sm text-text-2">
-              {page} / {meta.totalPages}
-            </span>
-
-            <button
-              type="button"
-              onClick={() =>
-                setPage((value) => Math.min(meta.totalPages, value + 1))
-              }
-              disabled={page === meta.totalPages}
-              className="inline-flex rounded-lg border border-border-3 px-3 py-2 text-body-sm text-text-2 transition-colors hover:bg-background-3 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              다음
-            </button>
-          </nav>
+        {selectedIds.length > 0 ? (
+          <BulkActions
+            tab={tab}
+            selectedIds={selectedIds}
+            allSelected={allSelected}
+            categories={categories}
+            onSelectAll={handleToggleSelectAll}
+            onBulkDelete={handleBulkDelete}
+            onBulkRestore={handleBulkRestore}
+            onBulkHardDelete={handleBulkHardDelete}
+            onBulkUpdate={handleBulkUpdate}
+            onClearSelection={() => setSelectedIds([])}
+          />
         ) : null}
+
+        <PostTable
+          tab={tab}
+          posts={rows}
+          isPending={isPending}
+          isError={isError}
+          errorMessage={getErrorMessage(
+            error,
+            "글 목록을 불러오지 못했습니다.",
+          )}
+          selectedIds={selectedIds}
+          sort={sort}
+          order={order}
+          onRetry={() => void refetch()}
+          onToggleSelect={handleToggleSelect}
+          onToggleSelectAll={handleToggleSelectAll}
+          onSortChange={handleSortChange}
+          onToggleVisibility={handleToggleVisibility}
+          onTogglePin={handleTogglePin}
+          onDelete={(id) => deleteMutation.mutateAsync(id)}
+          onRestore={(id) => {
+            const post = rows.find((item) => item.id === id);
+
+            if (!post) {
+              toast.error("복원할 글 정보를 찾지 못했습니다.");
+
+              return;
+            }
+
+            void handleSingleRestore(post);
+          }}
+          onHardDelete={(id) => hardDeleteMutation.mutateAsync(id)}
+          pendingToggleIds={pendingToggleIds}
+          deleteId={deleteId}
+        />
+
+        <div className="flex flex-col gap-4 border-t border-border-3 pt-5 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-body-sm text-text-4">
+            {isFetching && !isPending
+              ? "목록을 새로 불러오는 중..."
+              : paginationLabel}
+          </p>
+
+          {meta && meta.totalPages > 1 ? (
+            <nav
+              aria-label="관리자 글 페이지네이션"
+              className="flex items-center gap-2"
+            >
+              <button
+                type="button"
+                onClick={() => setPage((value) => Math.max(1, value - 1))}
+                disabled={page === 1}
+                className="inline-flex rounded-lg border border-border-3 px-3 py-2 text-body-sm text-text-2 transition-colors hover:bg-background-3 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                이전
+              </button>
+
+              <span className="min-w-20 text-center text-body-sm text-text-2">
+                {page} / {meta.totalPages}
+              </span>
+
+              <button
+                type="button"
+                onClick={() =>
+                  setPage((value) => Math.min(meta.totalPages, value + 1))
+                }
+                disabled={page === meta.totalPages}
+                className="inline-flex rounded-lg border border-border-3 px-3 py-2 text-body-sm text-text-2 transition-colors hover:bg-background-3 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                다음
+              </button>
+            </nav>
+          ) : null}
+        </div>
       </div>
-    </div>
+
+      <Modal
+        isOpen={restoreSelection !== null}
+        onClose={closeRestoreModal}
+        withBackground
+        aria-label="복원 카테고리 선택"
+      >
+        <div className="w-full max-w-xl rounded-[1.5rem] bg-background-1 p-6 text-left">
+          <div className="space-y-2">
+            <p className="text-xs uppercase tracking-[0.24em] text-text-4">
+              Restore
+            </p>
+            <h2 className="text-xl font-semibold text-text-1">
+              카테고리를 다시 지정한 뒤 복원합니다.
+            </h2>
+            <p className="text-sm leading-6 text-text-3">
+              선택한 {restoreTargetCount}개 글 중 {orphanRestoreCount}개는
+              카테고리가 없습니다. 복원 전에 새 카테고리를 지정해야 합니다.
+            </p>
+          </div>
+
+          <div className="mt-5 space-y-2">
+            <label
+              htmlFor="restore-category"
+              className="block text-sm font-medium text-text-2"
+            >
+              복원할 카테고리
+            </label>
+            <select
+              id="restore-category"
+              value={restoreCategoryId ?? ""}
+              onChange={(event) =>
+                setRestoreCategoryId(
+                  event.target.value ? Number(event.target.value) : null,
+                )
+              }
+              disabled={isRestoreCategoryPending}
+              className="w-full rounded-[0.9rem] border border-border-3 bg-background-1 px-4 py-3 text-sm text-text-1 outline-none transition-colors focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <option value="">
+                {UNCATEGORIZED_LABEL} 글의 카테고리를 선택하세요
+              </option>
+              {flatCategories.map((category) => (
+                <option key={category.id} value={category.id}>
+                  {`${"— ".repeat(category.depth)}${category.name}`}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-text-4">
+              선택한 카테고리가 카테고리 없는 글에 일괄 적용된 뒤 복원이
+              진행됩니다.
+            </p>
+          </div>
+
+          <div className="mt-6 flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={closeRestoreModal}
+              disabled={isRestoreCategoryPending}
+              className="rounded-[0.9rem] border border-border-3 px-4 py-3 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              취소
+            </button>
+            <button
+              type="button"
+              disabled={
+                isRestoreCategoryPending ||
+                restoreSelection === null ||
+                restoreCategoryId === null
+              }
+              onClick={async () => {
+                if (!restoreSelection || restoreCategoryId === null) {
+                  return;
+                }
+
+                setDeleteId(restoreSelection.ids[0] ?? null);
+                setIsRestoreCategoryPending(true);
+
+                try {
+                  await restorePosts({
+                    ...restoreSelection,
+                    categoryId: restoreCategoryId,
+                  });
+                  await invalidatePostQueries();
+                  toast.success(
+                    restoreSelection.ids.length === 1
+                      ? "글이 복원되었습니다."
+                      : `${restoreSelection.ids.length}개 글이 복원되었습니다.`,
+                  );
+                  setRestoreSelection(null);
+                  setRestoreCategoryId(null);
+                  setSelectedIds((current) =>
+                    current.filter((id) => !restoreSelection.ids.includes(id)),
+                  );
+                } catch (err) {
+                  toast.error(
+                    getErrorMessage(
+                      err,
+                      "카테고리를 다시 지정한 뒤 복원하지 못했습니다.",
+                    ),
+                  );
+                } finally {
+                  setIsRestoreCategoryPending(false);
+                  setDeleteId(null);
+                }
+              }}
+              className="inline-flex items-center justify-center gap-2 rounded-[0.9rem] bg-primary-1 px-4 py-3 text-sm font-semibold text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isRestoreCategoryPending ? <Spinner size="sm" /> : null}
+              복원
+            </button>
+          </div>
+        </div>
+      </Modal>
+    </>
   );
 }

--- a/src/entities/post/model.ts
+++ b/src/entities/post/model.ts
@@ -24,7 +24,7 @@ export interface MatchedComment {
 
 interface PostBase {
   id: number;
-  categoryId: number;
+  categoryId: number | null;
   title: string;
   slug: string;
   thumbnailUrl: string | null;
@@ -41,16 +41,16 @@ interface PostBase {
   totalPageviews: number;
   commentCount: number;
   contentModifiedAt: string | null;
-  category: PostCategory;
   tags: PostTag[];
   matchedComment?: MatchedComment;
 }
 
 export interface PostListItem extends PostBase {
-  category: PostCategory;
+  category: PostCategory | null;
 }
 
 export interface PublishedPostListItem extends PostListItem {
+  category: PostCategory;
   status: "published";
   visibility: "public";
   publishedAt: string;
@@ -60,7 +60,7 @@ export interface PublishedPostListItem extends PostListItem {
 
 export interface PostDetail extends PostBase {
   contentMd: string;
-  category: PostDetailCategory;
+  category: PostDetailCategory | null;
 }
 
 export type SearchFilter =

--- a/src/features/category-manager/ui/category-delete-modal.tsx
+++ b/src/features/category-manager/ui/category-delete-modal.tsx
@@ -195,7 +195,8 @@ export function CategoryDeleteModal({
                     글을 휴지통으로 이동
                   </span>
                   <span className="mt-1 block text-sm leading-6 text-text-3">
-                    현재 글을 휴지통으로 보낸 뒤 카테고리를 삭제합니다.
+                    현재 글을 휴지통으로 보낸 뒤 카테고리를 삭제합니다. 복원할
+                    때는 카테고리를 다시 지정해야 합니다.
                   </span>
                 </span>
               </label>

--- a/src/shared/lib/structured-data.ts
+++ b/src/shared/lib/structured-data.ts
@@ -86,7 +86,7 @@ interface StructuredDataPost {
   contentModifiedAt: string | null;
   thumbnailUrl: string | null;
   tags: StructuredDataTag[];
-  category: StructuredDataCategory;
+  category: StructuredDataCategory | null;
 }
 
 export function buildWebSiteJsonLd(siteUrl: string): WebSiteJsonLd {
@@ -135,7 +135,7 @@ export function buildBlogPostingJsonLd(
     ...(image ? { image } : {}),
     url: `${normalizedSiteUrl}${buildPostHref(post.slug)}`,
     ...(keywords.length > 0 ? { keywords } : {}),
-    ...(post.category.name ? { articleSection: post.category.name } : {}),
+    ...(post.category?.name ? { articleSection: post.category.name } : {}),
   };
 }
 

--- a/src/widgets/admin-post-list/ui/post-table.tsx
+++ b/src/widgets/admin-post-list/ui/post-table.tsx
@@ -405,7 +405,7 @@ export function PostTable({
                         </span>
                       ) : (
                         <span className="whitespace-nowrap text-[14px] leading-4 text-text-4">
-                          -
+                          (카테고리 없음)
                         </span>
                       )}
                     </td>
@@ -631,7 +631,14 @@ export function PostTable({
                               <Badge tone="category" className="shrink-0">
                                 {post.category.name}
                               </Badge>
-                            ) : null}
+                            ) : (
+                              <Badge
+                                tone="archived"
+                                className="shrink-0 text-text-4"
+                              >
+                                (카테고리 없음)
+                              </Badge>
+                            )}
                           </div>
                           {post.summary ? (
                             <p className="mt-0.5 line-clamp-1 whitespace-nowrap text-[12px] leading-4 text-text-4">


### PR DESCRIPTION
## Summary

Closes #324

Handle nullable post categories after category deletion so admin trash screens, restore flows, and defensive public post rendering no longer assume `post.category` is always present.

## Changes

| File | Change |
|------|--------|
| `src/entities/post/model.ts` | Make admin post `categoryId` nullable and allow nullable `category` on admin post list/detail types while keeping published list items narrowed. |
| `src/app/manage/posts/page.tsx` | Add restore flow that requires category reassignment before restoring orphaned posts, including bulk restore support. |
| `src/widgets/admin-post-list/ui/post-table.tsx` | Show `(카테고리 없음)` for trashed/orphaned posts in admin tables. |
| `src/app/(public)/posts/[slug]/page.tsx` | Guard public post detail rendering and breadcrumb/category fetches with optional category access. |
| `src/shared/lib/structured-data.ts` | Avoid assuming blog posting category metadata is always present. |
| `src/features/category-manager/ui/category-delete-modal.tsx` | Clarify that trashed posts must be recategorized before restore. |

## Screenshots

Not included. UI change is limited to null-category labels and restore modal flow.
