### PR TITLE
fix: handle Korean category/tag slugs and IME input (#326)

### DIFF
--- a/src/app/(public)/tags/[slug]/page.tsx
+++ b/src/app/(public)/tags/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { fetchPosts } from "@entities/post";
 import { fetchTags } from "@entities/tag";
 import { PostListItem } from "@features/post-list";
 import { buildCanonicalMetadata } from "@shared/lib/seo";
+import { normalizeRouteSlug, normalizeSlug } from "@shared/lib/slug";
 import { buildBreadcrumbJsonLd, getSiteUrl } from "@shared/lib/structured-data";
 import { JsonLd } from "@shared/ui/json-ld";
 import {
@@ -52,11 +53,14 @@ function isOutOfRangePage(page: number, totalPages: number) {
 }
 
 const getTagPageData = cache(async (slug: string, page: number) => {
+  const normalizedSlug = normalizeRouteSlug(slug);
   const [tags, response] = await Promise.all([
     fetchTags(),
-    fetchPosts({ tagSlug: slug, page }),
+    fetchPosts({ tagSlug: normalizedSlug, page }),
   ]);
-  const activeTag = tags.find((tag) => tag.slug === slug);
+  const activeTag = tags.find(
+    (tag) => normalizeSlug(tag.slug) === normalizedSlug,
+  );
 
   if (!activeTag || isOutOfRangePage(page, response.meta.totalPages)) {
     notFound();

--- a/src/entities/category/lib.ts
+++ b/src/entities/category/lib.ts
@@ -1,15 +1,28 @@
 import type { Category } from "./model";
+import { normalizeRouteSlug, normalizeSlug } from "@shared/lib/slug";
 
 export function findCategoryBySlug(
   categories: Category[],
   slug: string,
 ): Category | undefined {
+  const normalizedSlug = normalizeRouteSlug(slug);
+
+  return findCategoryByNormalizedSlug(categories, normalizedSlug);
+}
+
+function findCategoryByNormalizedSlug(
+  categories: Category[],
+  slug: string,
+): Category | undefined {
   for (const category of categories) {
-    if (category.slug === slug) {
+    if (normalizeSlug(category.slug) === slug) {
       return category;
     }
 
-    const childCategory = findCategoryBySlug(category.children ?? [], slug);
+    const childCategory = findCategoryByNormalizedSlug(
+      category.children ?? [],
+      slug,
+    );
 
     if (childCategory) {
       return childCategory;

--- a/src/entities/post/api.ts
+++ b/src/entities/post/api.ts
@@ -20,6 +20,7 @@ import {
   serverFetch,
 } from "@shared/api";
 import { normalizeOptionalAssetUrl } from "@shared/lib/asset-url";
+import { decodeSlug, encodeSlugPathSegment } from "@shared/lib/slug";
 
 function buildPostSearchParams(params: FetchPostsParams): string {
   return buildSearchParams(params);
@@ -101,8 +102,7 @@ export async function fetchPostBySlug(
   slug: string,
   cookieHeader?: string,
 ): Promise<PostDetailWithNavigationResponse> {
-  const buildPath = (value: string) =>
-    `/posts/${encodeURIComponent(value.normalize("NFKC"))}`;
+  const buildPath = (value: string) => `/posts/${encodeSlugPathSegment(value)}`;
 
   try {
     const response = await serverFetch<PostDetailWithNavigationResponse>(
@@ -120,13 +120,7 @@ export async function fetchPostBySlug(
       throw error;
     }
 
-    let decodedSlug: string;
-
-    try {
-      decodedSlug = decodeURIComponent(slug);
-    } catch {
-      throw error;
-    }
+    const decodedSlug = decodeSlug(slug);
 
     if (decodedSlug === slug) {
       throw error;

--- a/src/features/category-manager/ui/category-form-modal.tsx
+++ b/src/features/category-manager/ui/category-form-modal.tsx
@@ -260,6 +260,7 @@ export function CategoryFormModal({
   const [values, setValues] = useState<CategoryFormValues>(() =>
     getInitialValues(category),
   );
+  const [isNameComposing, setIsNameComposing] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -268,13 +269,14 @@ export function CategoryFormModal({
     }
 
     setValues(getInitialValues(category));
+    setIsNameComposing(false);
     setValidationError(null);
   }, [category, isOpen]);
 
   const title = mode === "create" ? "카테고리 추가" : "카테고리 수정";
   const submitLabel = mode === "create" ? "추가" : "저장";
   const submittingLabel = mode === "create" ? "추가 중" : "저장 중";
-  const trimmedName = values.name.trim();
+  const trimmedName = values.name.normalize("NFC").trim();
 
   const handleSubmit = () => {
     if (!trimmedName) {
@@ -315,8 +317,21 @@ export function CategoryFormModal({
             type="text"
             value={values.name}
             onChange={(event) =>
-              setValues((current) => ({ ...current, name: event.target.value }))
+              setValues((current) => ({
+                ...current,
+                name: isNameComposing
+                  ? event.target.value
+                  : event.target.value.normalize("NFC"),
+              }))
             }
+            onCompositionStart={() => setIsNameComposing(true)}
+            onCompositionEnd={(event) => {
+              setIsNameComposing(false);
+              setValues((current) => ({
+                ...current,
+                name: event.currentTarget.value.normalize("NFC"),
+              }));
+            }}
             placeholder="카테고리 이름"
             maxLength={50}
             disabled={isSubmitting}

--- a/src/shared/lib/slug.ts
+++ b/src/shared/lib/slug.ts
@@ -1,0 +1,19 @@
+export function normalizeSlug(value: string): string {
+  return value.normalize("NFKC");
+}
+
+export function decodeSlug(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+export function normalizeRouteSlug(value: string): string {
+  return normalizeSlug(decodeSlug(value));
+}
+
+export function encodeSlugPathSegment(value: string): string {
+  return encodeURIComponent(normalizeSlug(value));
+}


### PR DESCRIPTION
## Summary

Closes #326

Fixes Korean slug routing for category and tag pages by normalizing route params before matching or querying posts, and prevents category names entered with Korean IME from being kept in decomposed form.

## Changes

| File | Change |
|------|--------|
| `src/shared/lib/slug.ts` | Added shared slug decode/normalize/encode helpers for route and API usage |
| `src/entities/post/api.ts` | Reused shared slug helpers for post detail fetch path building and decode fallback |
| `src/entities/category/lib.ts` | Normalized category slug lookup so encoded or non-composed route params still match saved categories |
| `src/app/(public)/tags/[slug]/page.tsx` | Normalized tag route params before fetching tagged posts and resolving the active tag |
| `src/features/category-manager/ui/category-form-modal.tsx` | Added composition-aware NFC normalization for category name input and submit payload |
