### PR TITLE
fix: stabilize Korean IME inputs (#328)

### DIFF
--- a/src/features/category-manager/ui/category-form-modal.tsx
+++ b/src/features/category-manager/ui/category-form-modal.tsx
@@ -7,6 +7,7 @@ import type {
   CreateCategoryBody,
   UpdateCategoryBody,
 } from "@entities/category";
+import { useImeSafeText } from "@shared/hooks/use-ime-safe-text";
 import { cn } from "@shared/lib/style-utils";
 import { Modal, Spinner } from "@shared/ui/libs";
 import { ToggleSwitch } from "@shared/ui/toggle-switch";
@@ -260,8 +261,20 @@ export function CategoryFormModal({
   const [values, setValues] = useState<CategoryFormValues>(() =>
     getInitialValues(category),
   );
-  const [isNameComposing, setIsNameComposing] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
+  const {
+    handleChange: handleNameChange,
+    handleCompositionStart: handleNameCompositionStart,
+    handleCompositionEnd: handleNameCompositionEnd,
+    resetComposition: resetNameComposition,
+  } = useImeSafeText<HTMLInputElement>({
+    onCommit: (name) =>
+      setValues((current) => ({
+        ...current,
+        name,
+      })),
+    transform: (value) => value.normalize("NFC"),
+  });
 
   useEffect(() => {
     if (!isOpen) {
@@ -269,9 +282,9 @@ export function CategoryFormModal({
     }
 
     setValues(getInitialValues(category));
-    setIsNameComposing(false);
+    resetNameComposition();
     setValidationError(null);
-  }, [category, isOpen]);
+  }, [category, isOpen, resetNameComposition]);
 
   const title = mode === "create" ? "카테고리 추가" : "카테고리 수정";
   const submitLabel = mode === "create" ? "추가" : "저장";
@@ -316,22 +329,9 @@ export function CategoryFormModal({
           <input
             type="text"
             value={values.name}
-            onChange={(event) =>
-              setValues((current) => ({
-                ...current,
-                name: isNameComposing
-                  ? event.target.value
-                  : event.target.value.normalize("NFC"),
-              }))
-            }
-            onCompositionStart={() => setIsNameComposing(true)}
-            onCompositionEnd={(event) => {
-              setIsNameComposing(false);
-              setValues((current) => ({
-                ...current,
-                name: event.currentTarget.value.normalize("NFC"),
-              }));
-            }}
+            onChange={handleNameChange}
+            onCompositionStart={handleNameCompositionStart}
+            onCompositionEnd={handleNameCompositionEnd}
             placeholder="카테고리 이름"
             maxLength={50}
             disabled={isSubmitting}

--- a/src/features/post-editor/ui/tag-chip-input.tsx
+++ b/src/features/post-editor/ui/tag-chip-input.tsx
@@ -4,6 +4,7 @@ import type { KeyboardEvent } from "react";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { fetchTagsClient } from "@entities/tag/api";
+import { useImeSafeText } from "@shared/hooks/use-ime-safe-text";
 import { getErrorMessage } from "@shared/lib/get-error-message";
 
 interface TagChipInputProps {
@@ -29,7 +30,15 @@ export function TagChipInput({
   const [inputValue, setInputValue] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
   const [isFocused, setIsFocused] = useState(false);
-  const [isComposing, setIsComposing] = useState(false);
+  const {
+    isComposingRef,
+    handleChange: handleInputChange,
+    handleCompositionStart,
+    handleCompositionEnd,
+  } = useImeSafeText<HTMLInputElement>({
+    onCommit: setInputValue,
+    transform: (value) => value.slice(0, MAX_TAG_LENGTH),
+  });
 
   const tagsQuery = useQuery({
     queryKey: ["tags"],
@@ -116,7 +125,7 @@ export function TagChipInput({
     }
 
     if (event.key === "Enter") {
-      if (isComposing) {
+      if (isComposingRef.current) {
         return;
       }
 
@@ -169,18 +178,13 @@ export function TagChipInput({
             name="tags"
             type="text"
             value={inputValue}
-            onChange={(event) =>
-              setInputValue(event.target.value.slice(0, MAX_TAG_LENGTH))
-            }
-            onCompositionStart={() => setIsComposing(true)}
-            onCompositionEnd={(event) => {
-              setIsComposing(false);
-              setInputValue(event.currentTarget.value.slice(0, MAX_TAG_LENGTH));
-            }}
+            onChange={handleInputChange}
+            onCompositionStart={handleCompositionStart}
+            onCompositionEnd={handleCompositionEnd}
             onFocus={() => setIsFocused(true)}
             onBlur={() => {
               setIsFocused(false);
-              if (!isComposing) {
+              if (!isComposingRef.current) {
                 commitTag(inputValue);
               }
             }}

--- a/src/shared/hooks/use-ime-safe-text.ts
+++ b/src/shared/hooks/use-ime-safe-text.ts
@@ -13,22 +13,31 @@ export function useImeSafeText<
 >({ onCommit, transform = (value) => value }: UseImeSafeTextOptions) {
   const isComposingRef = useRef(false);
 
-  const commitValue = useCallback(
+  const commitTransformedValue = useCallback(
     (value: string) => {
       onCommit(transform(value));
     },
     [onCommit, transform],
   );
 
+  const commitRawValue = useCallback(
+    (value: string) => {
+      onCommit(value);
+    },
+    [onCommit],
+  );
+
   const handleChange = useCallback(
     (event: ChangeEvent<T>) => {
       if (isComposingRef.current) {
+        commitRawValue(event.target.value);
+
         return;
       }
 
-      commitValue(event.target.value);
+      commitTransformedValue(event.target.value);
     },
-    [commitValue],
+    [commitRawValue, commitTransformedValue],
   );
 
   const handleCompositionStart = useCallback(() => {
@@ -38,9 +47,9 @@ export function useImeSafeText<
   const handleCompositionEnd = useCallback(
     (event: CompositionEvent<T>) => {
       isComposingRef.current = false;
-      commitValue(event.currentTarget.value);
+      commitTransformedValue(event.currentTarget.value);
     },
-    [commitValue],
+    [commitTransformedValue],
   );
 
   const resetComposition = useCallback(() => {

--- a/src/shared/hooks/use-ime-safe-text.ts
+++ b/src/shared/hooks/use-ime-safe-text.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import type { ChangeEvent, CompositionEvent } from "react";
+import { useCallback, useRef } from "react";
+
+interface UseImeSafeTextOptions {
+  onCommit: (value: string) => void;
+  transform?: (value: string) => string;
+}
+
+export function useImeSafeText<
+  T extends HTMLInputElement | HTMLTextAreaElement,
+>({ onCommit, transform = (value) => value }: UseImeSafeTextOptions) {
+  const isComposingRef = useRef(false);
+
+  const commitValue = useCallback(
+    (value: string) => {
+      onCommit(transform(value));
+    },
+    [onCommit, transform],
+  );
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<T>) => {
+      if (isComposingRef.current) {
+        return;
+      }
+
+      commitValue(event.target.value);
+    },
+    [commitValue],
+  );
+
+  const handleCompositionStart = useCallback(() => {
+    isComposingRef.current = true;
+  }, []);
+
+  const handleCompositionEnd = useCallback(
+    (event: CompositionEvent<T>) => {
+      isComposingRef.current = false;
+      commitValue(event.currentTarget.value);
+    },
+    [commitValue],
+  );
+
+  const resetComposition = useCallback(() => {
+    isComposingRef.current = false;
+  }, []);
+
+  return {
+    isComposingRef,
+    handleChange,
+    handleCompositionStart,
+    handleCompositionEnd,
+    resetComposition,
+  };
+}


### PR DESCRIPTION
## Summary

Closes #328

Stabilizes Korean IME handling in admin category and tag text inputs by deferring React state writes until composition ends and normalizing committed text safely.

## Changes

| File | Change |
|------|--------|
| `src/shared/hooks/use-ime-safe-text.ts` | Add a shared ref-based IME-safe text input hook that skips controlled updates during composition and commits once composition ends. |
| `src/features/category-manager/ui/category-form-modal.tsx` | Replace state-based composition tracking with the shared hook so category names no longer re-render into the input mid-composition. |
| `src/features/post-editor/ui/tag-chip-input.tsx` | Reuse the same IME-safe composition handling for tag input to avoid the same stale-closure pattern. |

## Screenshots

N/A
