### PR TITLE
fix: preserve modal IME focus (#332)

### DIFF
--- a/src/features/category-manager/ui/category-form-modal.tsx
+++ b/src/features/category-manager/ui/category-form-modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type {
   Category,
   CreateCategoryBody,
@@ -290,6 +290,11 @@ export function CategoryFormModal({
   const submitLabel = mode === "create" ? "추가" : "저장";
   const submittingLabel = mode === "create" ? "추가 중" : "저장 중";
   const trimmedName = values.name.normalize("NFC").trim();
+  const handleModalClose = useCallback(() => {
+    if (!isSubmitting) {
+      onClose();
+    }
+  }, [isSubmitting, onClose]);
 
   const handleSubmit = () => {
     if (!trimmedName) {
@@ -310,11 +315,7 @@ export function CategoryFormModal({
   return (
     <Modal
       isOpen={isOpen}
-      onClose={() => {
-        if (!isSubmitting) {
-          onClose();
-        }
-      }}
+      onClose={handleModalClose}
       withBackground
       aria-label={title}
       className="w-[min(100%,40rem)] p-0 text-left"

--- a/src/shared/ui/libs/modal.tsx
+++ b/src/shared/ui/libs/modal.tsx
@@ -24,12 +24,21 @@ const Modal: React.FC<ModalProps> = ({
   "aria-labelledby": ariaLabelledby,
 }) => {
   const dialogRef = useRef<HTMLDivElement>(null);
+  const onCloseRef = useRef(onClose);
+  const previousActiveElementRef = useRef<HTMLElement | null>(null);
+  const wasOpenRef = useRef(false);
 
-  // ESC 키로 닫기
   useEffect(() => {
-    if (!isOpen) return;
+    onCloseRef.current = onClose;
+  }, [onClose]);
 
-    const previousActiveElement = document.activeElement as HTMLElement | null;
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    previousActiveElementRef.current =
+      document.activeElement as HTMLElement | null;
 
     const focusableSelector =
       'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
@@ -53,7 +62,7 @@ const Modal: React.FC<ModalProps> = ({
 
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
-        onClose();
+        onCloseRef.current();
 
         return;
       }
@@ -96,9 +105,17 @@ const Modal: React.FC<ModalProps> = ({
     return () => {
       window.clearTimeout(timer);
       document.removeEventListener("keydown", handleEscape);
-      previousActiveElement?.focus();
     };
-  }, [isOpen, onClose]);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen && wasOpenRef.current) {
+      previousActiveElementRef.current?.focus();
+      previousActiveElementRef.current = null;
+    }
+
+    wasOpenRef.current = isOpen;
+  }, [isOpen]);
 
   // body 스크롤 방지
   useEffect(() => {


### PR DESCRIPTION
## Summary

Closes #332

Prevent modal focus restoration from firing on every rerender so Korean IME composition stays intact while typing in the category form.

## Changes

| File | Change |
|------|--------|
| `src/shared/ui/libs/modal.tsx` | Capture the latest `onClose` in a ref, scope focus trap setup to `isOpen`, and restore focus only when the modal actually closes |
| `src/features/category-manager/ui/category-form-modal.tsx` | Replace the inline modal `onClose` prop with a memoized close handler that still blocks closing while submit is in flight |

