### PR TITLE
fix: align guestbook email optional type (#334)

### DIFF
--- a/src/entities/guestbook/model.ts
+++ b/src/entities/guestbook/model.ts
@@ -33,7 +33,7 @@ interface BaseCreateGuestbookBody {
 interface CreateGuestbookGuestBody extends BaseCreateGuestbookBody {
   authorType: "guest";
   guestName: string;
-  guestEmail: string;
+  guestEmail?: string;
   guestPassword: string;
 }
 


### PR DESCRIPTION
## Summary

Closes #334

Align the guestbook client-side create payload type with the UI and server contract so guest submissions can omit the email field.

## Changes

| File | Change |
|------|--------|
| `src/entities/guestbook/model.ts` | Make guestbook create payload `guestEmail` optional |

## Screenshots

N/A
