### PR TITLE
fix: align public sidebar shell (#336)

### DIFF
--- a/src/app/(public)/layout-shell.tsx
+++ b/src/app/(public)/layout-shell.tsx
@@ -68,11 +68,11 @@ export function PublicLayoutShell({
       />
 
       {/* 2-column layout: sidebar + main */}
-      <div className="mx-auto flex w-full max-w-[67.5rem] flex-1 gap-6 px-4 md:px-6">
+      <div className="mx-auto flex w-full max-w-[67.5rem] flex-1 px-4 md:px-6">
         {/* Desktop sidebar */}
         <aside
           aria-label="사이드바"
-          className="hidden w-[234px] shrink-0 pr-6 lg:block"
+          className="hidden w-[234px] shrink-0 border-r border-border-3 pr-8 lg:block"
         >
           <StickySidebarWrapper>
             <div className="pt-8 pb-16">
@@ -88,7 +88,7 @@ export function PublicLayoutShell({
         </aside>
 
         {/* Page content */}
-        <div className="min-w-0 flex-1">{children}</div>
+        <div className="min-w-0 flex-1 lg:pl-8">{children}</div>
       </div>
 
       {/* Mobile slide-in sidebar */}
@@ -98,6 +98,7 @@ export function PublicLayoutShell({
         id="public-sidebar-panel"
         label="사이드바 내비게이션"
         className="w-[min(320px,85vw)] border-l-0 shadow-[-4px_0_24px_rgba(0,0,0,0.1)]"
+        topOffset="var(--site-header-height, 3.5rem)"
       >
         <PublicSidebarPanel
           recentPosts={recentPosts}

--- a/src/shared/ui/libs/slide-in-panel.tsx
+++ b/src/shared/ui/libs/slide-in-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, type CSSProperties } from "react";
 import { cn } from "@shared/lib/style-utils";
 
 const FOCUSABLE_SELECTOR =
@@ -13,6 +13,7 @@ interface SlideInPanelProps {
   label?: string;
   children: React.ReactNode;
   className?: string;
+  topOffset?: string;
 }
 
 export function SlideInPanel({
@@ -22,8 +23,12 @@ export function SlideInPanel({
   label = "사이드 패널",
   children,
   className,
+  topOffset,
 }: SlideInPanelProps) {
   const panelRef = useRef<HTMLElement>(null);
+  const panelStyle: CSSProperties | undefined = topOffset
+    ? { top: topOffset }
+    : undefined;
 
   // Focus trap
   useEffect(() => {
@@ -87,8 +92,10 @@ export function SlideInPanel({
         role="dialog"
         aria-modal="true"
         aria-label={label}
+        style={panelStyle}
         className={cn(
-          "fixed inset-y-0 right-0 z-50 w-80 max-w-[85vw]",
+          "fixed right-0 z-50 w-80 max-w-[85vw] bottom-0",
+          topOffset ? undefined : "top-0",
           "bg-background-1 border-l border-border-3",
           "overflow-y-auto",
           "animate-[var(--animate-slide-in-right)]",

--- a/src/widgets/header/index.tsx
+++ b/src/widgets/header/index.tsx
@@ -50,7 +50,12 @@ const Header: React.FC<HeaderProps> = ({
     if (!headerRef.current) return;
 
     const updateHeight = () => {
-      setHeaderHeight(headerRef.current?.clientHeight ?? 0);
+      const nextHeight = headerRef.current?.clientHeight ?? 0;
+      setHeaderHeight(nextHeight);
+      document.documentElement.style.setProperty(
+        "--site-header-height",
+        `${nextHeight}px`,
+      );
     };
 
     updateHeight();
@@ -63,6 +68,7 @@ const Header: React.FC<HeaderProps> = ({
     return () => {
       observer.disconnect();
       window.removeEventListener("resize", updateHeight);
+      document.documentElement.style.removeProperty("--site-header-height");
     };
   }, []);
 


### PR DESCRIPTION
## Summary

Closes #336

Adjust the public sidebar layout so the mobile slide-in panel starts below the fixed header, and reorganize the desktop sidebar spacing so a right divider can sit in a natural position.

## Changes

| File | Change |
|------|--------|
| `src/app/(public)/layout-shell.tsx` | Removed the desktop gap-based spacing, added a real sidebar divider, moved main-content spacing to left padding, and passed the header offset into the mobile panel. |
| `src/shared/ui/libs/slide-in-panel.tsx` | Added an optional `topOffset` prop so slide-in panels can respect fixed headers without changing existing callers. |
| `src/widgets/header/index.tsx` | Exposed the measured header height through a CSS variable used by the mobile public sidebar panel. |

## Screenshots

UI-only change. Screenshots were not captured in this pipeline run.
