### PR TITLE
feat: simplify public sidebar category navigation (#340)

### DIFF
--- a/src/app/(public)/categories/[slug]/page.tsx
+++ b/src/app/(public)/categories/[slug]/page.tsx
@@ -20,6 +20,8 @@ import {
   ScrollToTop,
 } from "@shared/ui/libs";
 
+const SIDEBAR_CATEGORY_PATH_DATA_ID = "sidebar-category-path-data";
+
 interface CategoryPageProps {
   params: {
     slug: string;
@@ -124,6 +126,10 @@ export default async function CategoryPage({
           { label: activeCategory.name },
         ]
       : undefined;
+  const sidebarCategoryPathSlugs = [
+    ...ancestors.map((ancestor) => ancestor.slug),
+    activeCategory.slug,
+  ];
 
   return (
     <main className="flex min-h-screen flex-col pt-8 pb-16">
@@ -135,6 +141,14 @@ export default async function CategoryPage({
         title={activeCategory.name}
         count={meta.total}
         breadcrumbs={breadcrumbLinks}
+      />
+
+      <script
+        id={SIDEBAR_CATEGORY_PATH_DATA_ID}
+        type="application/json"
+        dangerouslySetInnerHTML={{
+          __html: serializeCategoryPathSlugs(sidebarCategoryPathSlugs),
+        }}
       />
 
       {posts.length > 0 ? (
@@ -171,4 +185,8 @@ export default async function CategoryPage({
       <ScrollToTop />
     </main>
   );
+}
+
+function serializeCategoryPathSlugs(categoryPathSlugs: string[]) {
+  return JSON.stringify(categoryPathSlugs).replace(/</g, "\\u003c");
 }

--- a/src/app/(public)/posts/[slug]/page.tsx
+++ b/src/app/(public)/posts/[slug]/page.tsx
@@ -33,6 +33,8 @@ import {
 import { JsonLd } from "@shared/ui/json-ld";
 import { ScrollToTop } from "@shared/ui/libs";
 
+const SIDEBAR_CATEGORY_PATH_DATA_ID = "sidebar-category-path-data";
+
 interface PostDetailPageProps {
   params: {
     slug: string;
@@ -194,6 +196,9 @@ export default async function PostDetailPage({ params }: PostDetailPageProps) {
   const viewer = await getCurrentViewer();
   const publishedAt = post.publishedAt ?? post.createdAt;
   const formattedViews = (post.totalPageviews ?? 0).toLocaleString("ko-KR");
+  const sidebarCategoryPathSlugs = category
+    ? [...categoryAncestors.map((ancestor) => ancestor.slug), category.slug]
+    : [];
 
   return (
     <main className="w-full pt-8 pb-16">
@@ -279,6 +284,16 @@ export default async function PostDetailPage({ params }: PostDetailPageProps) {
             />
           )}
 
+          {sidebarCategoryPathSlugs.length > 0 && (
+            <script
+              id={SIDEBAR_CATEGORY_PATH_DATA_ID}
+              type="application/json"
+              dangerouslySetInnerHTML={{
+                __html: serializeCategoryPathSlugs(sidebarCategoryPathSlugs),
+              }}
+            />
+          )}
+
           <PostContent contentMd={post.contentMd} />
 
           {relatedPosts.length > 0 ? (
@@ -306,4 +321,8 @@ export default async function PostDetailPage({ params }: PostDetailPageProps) {
 
 function serializeTocItems(headings: TocItem[]) {
   return JSON.stringify(headings).replace(/</g, "\\u003c");
+}
+
+function serializeCategoryPathSlugs(categoryPathSlugs: string[]) {
+  return JSON.stringify(categoryPathSlugs).replace(/</g, "\\u003c");
 }

--- a/src/features/category-tree/ui/category-tree.tsx
+++ b/src/features/category-tree/ui/category-tree.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import type { Category } from "@entities/category";
 import { cn } from "@shared/lib/style-utils";
@@ -9,6 +9,7 @@ interface CategoryTreeProps {
   categories: Category[];
   onItemClick?: () => void;
   showOverviewLink?: boolean;
+  initialExpandedSlugs?: string[];
 }
 
 function countTotal(categories: Category[]): number {
@@ -22,15 +23,19 @@ function countTotal(categories: Category[]): number {
 function CategoryItem({
   category,
   depth,
+  expandedSlugs,
+  onToggle,
   onItemClick,
 }: {
   category: Category;
   depth: number;
+  expandedSlugs: Set<string>;
+  onToggle: (categorySlug: string) => void;
   onItemClick?: () => void;
 }) {
-  const [isOpen, setIsOpen] = useState(false);
   const hasChildren = category.children && category.children.length > 0;
   const postCount = category.publishedPostCount ?? category.totalPostCount;
+  const isOpen = expandedSlugs.has(category.slug);
 
   return (
     <li>
@@ -41,7 +46,7 @@ function CategoryItem({
         {hasChildren ? (
           <button
             type="button"
-            onClick={() => setIsOpen((v) => !v)}
+            onClick={() => onToggle(category.slug)}
             aria-expanded={isOpen}
             aria-label={`${category.name} ${isOpen ? "접기" : "펼치기"}`}
             className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-text-4 transition-colors hover:text-text-1"
@@ -77,6 +82,8 @@ function CategoryItem({
               key={child.id}
               category={child}
               depth={depth + 1}
+              expandedSlugs={expandedSlugs}
+              onToggle={onToggle}
               onItemClick={onItemClick}
             />
           ))}
@@ -90,12 +97,33 @@ export function CategoryTree({
   categories,
   onItemClick,
   showOverviewLink = true,
+  initialExpandedSlugs = [],
 }: CategoryTreeProps) {
   const visible = categories.filter((c) => c.isVisible);
+  const [expandedSlugs, setExpandedSlugs] = useState(
+    () => new Set(initialExpandedSlugs),
+  );
+
+  useEffect(() => {
+    setExpandedSlugs(new Set(initialExpandedSlugs));
+  }, [initialExpandedSlugs]);
 
   if (visible.length === 0) return null;
 
   const totalCount = countTotal(visible);
+  const handleToggle = (categorySlug: string) => {
+    setExpandedSlugs((current) => {
+      const next = new Set(current);
+
+      if (next.has(categorySlug)) {
+        next.delete(categorySlug);
+      } else {
+        next.add(categorySlug);
+      }
+
+      return next;
+    });
+  };
 
   return (
     <div>
@@ -115,6 +143,8 @@ export function CategoryTree({
             key={category.id}
             category={category}
             depth={0}
+            expandedSlugs={expandedSlugs}
+            onToggle={handleToggle}
             onItemClick={onItemClick}
           />
         ))}

--- a/src/features/category-tree/ui/category-tree.tsx
+++ b/src/features/category-tree/ui/category-tree.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import type { Category } from "@entities/category";
 import { cn } from "@shared/lib/style-utils";
 
+const EMPTY_EXPANDED_SLUGS: string[] = [];
+
 interface CategoryTreeProps {
   categories: Category[];
   onItemClick?: () => void;
@@ -97,7 +99,7 @@ export function CategoryTree({
   categories,
   onItemClick,
   showOverviewLink = true,
-  initialExpandedSlugs = [],
+  initialExpandedSlugs = EMPTY_EXPANDED_SLUGS,
 }: CategoryTreeProps) {
   const visible = categories.filter((c) => c.isVisible);
   const [expandedSlugs, setExpandedSlugs] = useState(

--- a/src/widgets/public-sidebar/ui/public-sidebar.tsx
+++ b/src/widgets/public-sidebar/ui/public-sidebar.tsx
@@ -37,6 +37,7 @@ interface PublicSidebarPanelProps extends PublicSidebarContentProps {
 }
 
 const POST_TOC_DATA_ID = "post-toc-data";
+const SIDEBAR_CATEGORY_PATH_DATA_ID = "sidebar-category-path-data";
 
 function SidebarSection({
   title,
@@ -80,6 +81,8 @@ export function PublicSidebarContent({
 }: PublicSidebarContentProps) {
   const pathname = usePathname();
   const [pageHeadings, setPageHeadings] = useState<TocItem[]>([]);
+  const [initialExpandedCategorySlugs, setInitialExpandedCategorySlugs] =
+    useState<string[]>([]);
 
   useEffect(() => {
     if (headings) {
@@ -96,6 +99,24 @@ export function PublicSidebarContent({
 
     setPageHeadings(readTocDataFromDocument());
   }, [headings, pathname]);
+
+  useEffect(() => {
+    if (!pathname) {
+      setInitialExpandedCategorySlugs([]);
+
+      return;
+    }
+
+    if (pathname.startsWith("/categories/") || pathname.startsWith("/posts/")) {
+      const categoryPathSlugs = readCategoryPathDataFromDocument();
+
+      setInitialExpandedCategorySlugs(categoryPathSlugs.slice(0, -1));
+
+      return;
+    }
+
+    setInitialExpandedCategorySlugs([]);
+  }, [pathname]);
 
   const tocHeadings = headings ?? pageHeadings;
   const visibleCategoryCount = countVisibleCategories(categories);
@@ -118,13 +139,24 @@ export function PublicSidebarContent({
 
       {categories.some((c) => c.isVisible) && (
         <SidebarSection
-          title={`분류 전체보기 (${visibleCategoryCount})`}
+          title={`카테고리 (${visibleCategoryCount})`}
           icon={<Icon icon={folder2Linear} width="13" aria-hidden="true" />}
+          action={
+            <Link
+              href="/categories"
+              onClick={onItemClick}
+              className="inline-flex items-center gap-0.5 text-ui-xs font-medium text-primary-1 underline-offset-4 hover:underline"
+            >
+              전체보기
+              <Icon icon={altArrowRightLinear} width="10" aria-hidden="true" />
+            </Link>
+          }
         >
           <CategoryTree
             categories={categories}
             onItemClick={onItemClick}
             showOverviewLink={false}
+            initialExpandedSlugs={initialExpandedCategorySlugs}
           />
         </SidebarSection>
       )}
@@ -217,6 +249,26 @@ function readTocDataFromDocument(): TocItem[] {
         typeof item?.text === "string" &&
         (item?.level === 1 || item?.level === 2 || item?.level === 3),
     );
+  } catch {
+    return [];
+  }
+}
+
+function readCategoryPathDataFromDocument(): string[] {
+  const element = document.getElementById(SIDEBAR_CATEGORY_PATH_DATA_ID);
+
+  if (!element?.textContent) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(element.textContent) as string[];
+
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.filter((item): item is string => typeof item === "string");
   } catch {
     return [];
   }


### PR DESCRIPTION
## Summary

Closes #340

Simplify the public sidebar category section and auto-expand only the active category path on category and post detail pages.

## Changes

| File | Change |
|------|--------|
| `src/widgets/public-sidebar/ui/public-sidebar.tsx` | Rename the category section, add the `/categories` overview link, and seed tree expansion from page JSON data without clobbering later user toggles. |
| `src/features/category-tree/ui/category-tree.tsx` | Move expand/collapse state into the tree root and support route-seeded initial expanded slugs shared by desktop and mobile sidebars. |
| `src/app/(public)/posts/[slug]/page.tsx` | Publish the current post category path as serialized sidebar data. |
| `src/app/(public)/categories/[slug]/page.tsx` | Publish the active category path as serialized sidebar data. |

## Screenshots

N/A
