### PR TITLE
fix: stabilize category overview page (#342)

### DIFF
--- a/src/app/(public)/categories/page.tsx
+++ b/src/app/(public)/categories/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next";
 import { fetchCategories } from "@entities/category";
-import { CategoryTree, countVisibleCategories } from "@features/category-tree";
+import {
+  CategoryTree,
+  countVisibleCategories,
+  countVisibleCategoryNodes,
+} from "@features/category-tree";
 import { buildCanonicalMetadata } from "@shared/lib/seo";
 import { EmptyState, ScrollToTop } from "@shared/ui/libs";
 
@@ -11,18 +15,6 @@ export const metadata: Metadata = {
   description: "모든 카테고리 목록",
   ...buildCanonicalMetadata("/categories"),
 };
-
-function countVisibleCategoryNodes(
-  categories: Awaited<ReturnType<typeof fetchCategories>>,
-): number {
-  return categories.reduce((count, category) => {
-    if (!category.isVisible) {
-      return count;
-    }
-
-    return count + 1 + countVisibleCategoryNodes(category.children ?? []);
-  }, 0);
-}
 
 export default async function CategoriesPage() {
   const categories = await fetchCategories();

--- a/src/app/(public)/layout-shell.tsx
+++ b/src/app/(public)/layout-shell.tsx
@@ -72,10 +72,10 @@ export function PublicLayoutShell({
         {/* Desktop sidebar */}
         <aside
           aria-label="사이드바"
-          className="hidden w-[234px] shrink-0 border-r border-border-3 pr-8 lg:block"
+          className="hidden w-[234px] shrink-0 pr-8 lg:block"
         >
           <StickySidebarWrapper>
-            <div className="pt-8 pb-16">
+            <div className="border-r border-border-3 pt-8 pb-16 pr-8">
               <PublicSidebarContent
                 recentPosts={recentPosts}
                 popularPosts={popularPosts}

--- a/src/app/(public)/layout-shell.tsx
+++ b/src/app/(public)/layout-shell.tsx
@@ -72,7 +72,7 @@ export function PublicLayoutShell({
         {/* Desktop sidebar */}
         <aside
           aria-label="사이드바"
-          className="hidden w-[234px] shrink-0 pr-8 lg:block"
+          className="hidden w-[234px] shrink-0 lg:block"
         >
           <StickySidebarWrapper>
             <div className="border-r border-border-3 pt-8 pb-16 pr-8">

--- a/src/features/category-tree/index.ts
+++ b/src/features/category-tree/index.ts
@@ -1,1 +1,5 @@
-export { CategoryTree, countVisibleCategories } from "./ui/category-tree";
+export {
+  countVisibleCategories,
+  countVisibleCategoryNodes,
+} from "./lib/category-counts";
+export { CategoryTree } from "./ui/category-tree";

--- a/src/features/category-tree/lib/category-counts.ts
+++ b/src/features/category-tree/lib/category-counts.ts
@@ -1,0 +1,25 @@
+import type { Category } from "@entities/category";
+
+export function countVisibleCategoryNodes(categories: Category[]): number {
+  return categories.reduce((count, category) => {
+    if (!category.isVisible) {
+      return count;
+    }
+
+    return count + 1 + countVisibleCategoryNodes(category.children ?? []);
+  }, 0);
+}
+
+export function countVisibleCategories(categories: Category[]): number {
+  return categories.reduce((sum, category) => {
+    if (!category.isVisible) {
+      return sum;
+    }
+
+    return (
+      sum +
+      (category.publishedPostCount ?? 0) +
+      countVisibleCategories(category.children ?? [])
+    );
+  }, 0);
+}

--- a/src/features/category-tree/ui/category-tree.tsx
+++ b/src/features/category-tree/ui/category-tree.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { countVisibleCategories } from "../lib/category-counts";
 import type { Category } from "@entities/category";
 import { cn } from "@shared/lib/style-utils";
 
@@ -12,14 +13,6 @@ interface CategoryTreeProps {
   onItemClick?: () => void;
   showOverviewLink?: boolean;
   initialExpandedSlugs?: string[];
-}
-
-function countTotal(categories: Category[]): number {
-  return categories.reduce((sum, cat) => {
-    const childCount = cat.children ? countTotal(cat.children) : 0;
-
-    return sum + (cat.publishedPostCount ?? 0) + childCount;
-  }, 0);
 }
 
 function CategoryItem({
@@ -112,7 +105,7 @@ export function CategoryTree({
 
   if (visible.length === 0) return null;
 
-  const totalCount = countTotal(visible);
+  const totalCount = countVisibleCategories(visible);
   const handleToggle = (categorySlug: string) => {
     setExpandedSlugs((current) => {
       const next = new Set(current);
@@ -153,10 +146,6 @@ export function CategoryTree({
       </ul>
     </div>
   );
-}
-
-export function countVisibleCategories(categories: Category[]) {
-  return countTotal(categories.filter((category) => category.isVisible));
 }
 
 function ChevronIcon({ className }: { className?: string }) {


### PR DESCRIPTION
## Summary

Closes #342

Fixes the `/categories` overview page crash by moving category counting helpers out of the client-only `CategoryTree` module so the server route can use them safely. Also moves the desktop sidebar divider from the `aside` shell to the inner wrapper to match the requested visual treatment.

## Changes

| File | Change |
|------|--------|
| `src/features/category-tree/lib/category-counts.ts` | Added server-safe recursive helpers for visible category node and post counts. |
| `src/features/category-tree/ui/category-tree.tsx` | Reused the shared count helper inside the client tree component. |
| `src/features/category-tree/index.ts` | Re-exported the shared counting helpers separately from the client component. |
| `src/app/(public)/categories/page.tsx` | Switched the server page to the shared helpers instead of calling a function from a client module. |
| `src/app/(public)/layout-shell.tsx` | Applied the desktop sidebar border to the inner wrapper div instead of the outer `aside`. |

## Screenshots

Not included. UI change is limited to divider placement.
