### PR TITLE
feat: unify taxonomy archive ui (#344)

### DIFF
--- a/src/app/(public)/categories/page.tsx
+++ b/src/app/(public)/categories/page.tsx
@@ -6,13 +6,13 @@ import {
   countVisibleCategoryNodes,
 } from "@features/category-tree";
 import { buildCanonicalMetadata } from "@shared/lib/seo";
-import { EmptyState, ScrollToTop } from "@shared/ui/libs";
+import { ArchiveHeader, EmptyState, ScrollToTop } from "@shared/ui/libs";
 
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-  title: "카테고리 목록",
-  description: "모든 카테고리 목록",
+  title: "Categories",
+  description: "블로그 전체 카테고리 목록",
   ...buildCanonicalMetadata("/categories"),
 };
 
@@ -23,22 +23,25 @@ export default async function CategoriesPage() {
 
   return (
     <main className="flex min-h-screen flex-col pt-8 pb-16">
-      <header className="mb-8 motion-reveal">
-        <div className="flex flex-wrap items-baseline justify-between gap-4">
-          <h1 className="break-keep text-body-lg font-bold tracking-tight text-text-1 sm:text-h1">
-            카테고리
-          </h1>
-          <span className="text-body-sm text-text-4">
+      <ArchiveHeader
+        variant="category"
+        eyebrow="Category Directory"
+        title="Categories"
+        summary={
+          <>
             총 {visibleCategoryCount.toLocaleString("ko-KR")}개 분류 · 공개 글{" "}
             {visiblePostCount.toLocaleString("ko-KR")}개
-          </span>
-        </div>
-        <div className="mt-4 h-px bg-border-4" />
-      </header>
+          </>
+        }
+      />
 
       {visibleCategoryCount > 0 ? (
         <section aria-label="카테고리 목록">
-          <CategoryTree categories={categories} showOverviewLink={false} />
+          <CategoryTree
+            categories={categories}
+            showOverviewLink={false}
+            variant="overview"
+          />
         </section>
       ) : (
         <EmptyState

--- a/src/app/(public)/layout-shell.tsx
+++ b/src/app/(public)/layout-shell.tsx
@@ -72,7 +72,7 @@ export function PublicLayoutShell({
         {/* Desktop sidebar */}
         <aside
           aria-label="사이드바"
-          className="hidden w-[234px] shrink-0 lg:block"
+          className="hidden w-[240px] shrink-0 lg:block"
         >
           <StickySidebarWrapper>
             <div className="border-r border-border-3 pt-8 pb-16 pr-8">

--- a/src/app/(public)/tags/page.tsx
+++ b/src/app/(public)/tags/page.tsx
@@ -1,13 +1,18 @@
 import type { Metadata } from "next";
 import { fetchTags } from "@entities/tag";
 import { buildCanonicalMetadata } from "@shared/lib/seo";
-import { ArchiveTagBadge, EmptyState, ScrollToTop } from "@shared/ui/libs";
+import {
+  ArchiveHeader,
+  ArchiveTagBadge,
+  EmptyState,
+  ScrollToTop,
+} from "@shared/ui/libs";
 
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-  title: "태그 목록",
-  description: "모든 태그 목록",
+  title: "Tags",
+  description: "블로그 전체 태그 목록",
   ...buildCanonicalMetadata("/tags"),
 };
 
@@ -19,17 +24,12 @@ export default async function TagsPage() {
 
   return (
     <main className="flex min-h-screen flex-col pt-8 pb-16">
-      <header className="mb-8 motion-reveal">
-        <div className="flex flex-wrap items-baseline justify-between gap-4">
-          <h1 className="break-keep text-body-lg font-bold tracking-tight text-text-1 sm:text-h1">
-            태그
-          </h1>
-          <span className="text-body-sm text-text-4">
-            총 {sortedTags.length.toLocaleString("ko-KR")}개 태그
-          </span>
-        </div>
-        <div className="mt-4 h-px bg-border-4" />
-      </header>
+      <ArchiveHeader
+        variant="tag"
+        eyebrow="Tag Directory"
+        title="Tags"
+        summary={<>총 {sortedTags.length.toLocaleString("ko-KR")}개 태그</>}
+      />
 
       {sortedTags.length > 0 ? (
         <section aria-label="태그 목록">

--- a/src/features/category-tree/ui/category-tree.tsx
+++ b/src/features/category-tree/ui/category-tree.tsx
@@ -13,6 +13,7 @@ interface CategoryTreeProps {
   onItemClick?: () => void;
   showOverviewLink?: boolean;
   initialExpandedSlugs?: string[];
+  variant?: "sidebar" | "overview";
 }
 
 function CategoryItem({
@@ -21,21 +22,28 @@ function CategoryItem({
   expandedSlugs,
   onToggle,
   onItemClick,
+  variant,
 }: {
   category: Category;
   depth: number;
   expandedSlugs: Set<string>;
   onToggle: (categorySlug: string) => void;
   onItemClick?: () => void;
+  variant: "sidebar" | "overview";
 }) {
   const hasChildren = category.children && category.children.length > 0;
   const postCount = category.publishedPostCount ?? category.totalPostCount;
   const isOpen = expandedSlugs.has(category.slug);
+  const isOverview = variant === "overview";
 
   return (
-    <li>
+    <li className={cn(isOverview && "mt-3 first:mt-0")}>
       <div
-        className="flex items-center gap-1"
+        className={cn(
+          "flex items-center gap-1",
+          isOverview &&
+            "rounded-[1.4rem] border border-border-3 bg-background-2 px-3 py-2.5 shadow-[0_14px_34px_rgba(15,23,42,0.04)] transition-colors hover:border-border-2",
+        )}
         style={{ paddingLeft: `${depth * 0.75}rem` }}
       >
         {hasChildren ? (
@@ -44,26 +52,41 @@ function CategoryItem({
             onClick={() => onToggle(category.slug)}
             aria-expanded={isOpen}
             aria-label={`${category.name} ${isOpen ? "접기" : "펼치기"}`}
-            className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-text-4 transition-colors hover:text-text-1"
+            className={cn(
+              "flex shrink-0 items-center justify-center rounded text-text-4 transition-colors hover:text-text-1",
+              isOverview ? "h-8 w-8 bg-background-1" : "h-5 w-5",
+            )}
           >
             <ChevronIcon
               className={cn(
-                "h-3.5 w-3.5 transition-transform duration-200",
+                "transition-transform duration-200",
+                isOverview ? "h-4 w-4" : "h-3.5 w-3.5",
                 isOpen && "rotate-90",
               )}
             />
           </button>
         ) : (
-          <span className="w-5 shrink-0" />
+          <span className={cn("shrink-0", isOverview ? "w-8" : "w-5")} />
         )}
         <Link
           href={`/categories/${category.slug}`}
           onClick={onItemClick}
-          className="flex flex-1 items-center justify-between gap-2 rounded px-1 py-1.5 text-body-sm text-text-2 transition-colors hover:text-primary-1"
+          className={cn(
+            "flex flex-1 items-center justify-between gap-2 rounded transition-colors hover:text-primary-1",
+            isOverview
+              ? "px-1 py-0.5 text-[0.95rem] text-text-1"
+              : "px-1 py-1.5 text-body-sm text-text-2",
+          )}
         >
-          <span className="truncate">{category.name}</span>
+          <span className="truncate font-medium">{category.name}</span>
           {postCount !== undefined && (
-            <span className="shrink-0 text-body-xs text-text-4">
+            <span
+              className={cn(
+                "shrink-0 text-body-xs text-text-4",
+                isOverview &&
+                  "rounded-full border border-border-3 bg-background-1 px-2.5 py-1 font-medium text-text-3",
+              )}
+            >
               {postCount}
             </span>
           )}
@@ -71,7 +94,11 @@ function CategoryItem({
       </div>
 
       {hasChildren && isOpen && (
-        <ul>
+        <ul
+          className={cn(
+            isOverview && "ml-4 border-l border-dashed border-border-3 pl-2",
+          )}
+        >
           {category.children!.map((child) => (
             <CategoryItem
               key={child.id}
@@ -80,6 +107,7 @@ function CategoryItem({
               expandedSlugs={expandedSlugs}
               onToggle={onToggle}
               onItemClick={onItemClick}
+              variant={variant}
             />
           ))}
         </ul>
@@ -93,6 +121,7 @@ export function CategoryTree({
   onItemClick,
   showOverviewLink = true,
   initialExpandedSlugs = EMPTY_EXPANDED_SLUGS,
+  variant = "sidebar",
 }: CategoryTreeProps) {
   const visible = categories.filter((c) => c.isVisible);
   const [expandedSlugs, setExpandedSlugs] = useState(
@@ -126,7 +155,11 @@ export function CategoryTree({
         <Link
           href="/categories"
           onClick={onItemClick}
-          className="mb-2 flex items-center justify-between rounded px-1 py-1 text-body-sm font-medium text-text-2 transition-colors hover:text-primary-1"
+          className={cn(
+            "mb-2 flex items-center justify-between rounded px-1 py-1 text-body-sm font-medium text-text-2 transition-colors hover:text-primary-1",
+            variant === "overview" &&
+              "mb-4 rounded-[1.2rem] border border-dashed border-border-3 bg-background-2 px-4 py-3",
+          )}
         >
           <span>분류 전체보기</span>
           <span className="text-body-xs text-text-4">({totalCount})</span>
@@ -141,6 +174,7 @@ export function CategoryTree({
             expandedSlugs={expandedSlugs}
             onToggle={handleToggle}
             onItemClick={onItemClick}
+            variant={variant}
           />
         ))}
       </ul>

--- a/src/shared/ui/libs/archive-header.tsx
+++ b/src/shared/ui/libs/archive-header.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { Icon } from "@iconify/react";
 import altArrowRightLinear from "@iconify-icons/solar/alt-arrow-right-linear";
 import Link from "next/link";
@@ -12,26 +13,35 @@ interface ArchiveBreadcrumbItem {
 interface ArchiveHeaderProps {
   variant: "category" | "tag";
   title: string;
-  count: number;
+  count?: number;
+  summary?: ReactNode;
   breadcrumbs?: ArchiveBreadcrumbItem[];
   className?: string;
+  eyebrow?: string;
 }
 
 export function ArchiveHeader({
   variant,
   title,
   count,
+  summary,
   breadcrumbs,
   className,
+  eyebrow,
 }: ArchiveHeaderProps) {
   const hasBreadcrumbs = Boolean(breadcrumbs && breadcrumbs.length > 0);
+  const resolvedEyebrow =
+    eyebrow ?? (variant === "category" ? "Category Archive" : "Tag Archive");
+  const resolvedSummary =
+    summary ??
+    (count === undefined ? null : `총 ${formatNumber(count)}개의 글`);
 
   return (
     <header className={cn("mb-8 w-full min-w-0 motion-reveal", className)}>
       {variant === "category" ? (
         <div className="mb-5 flex flex-wrap items-center gap-2">
           <span className="text-body-xs font-bold uppercase tracking-[0.18em] text-text-4">
-            Category Archive
+            {resolvedEyebrow}
           </span>
           {hasBreadcrumbs ? (
             <>
@@ -75,7 +85,7 @@ export function ArchiveHeader({
       ) : (
         <div className="mb-5">
           <span className="text-body-xs font-bold uppercase tracking-[0.18em] text-text-4">
-            Tag Archive
+            {resolvedEyebrow}
           </span>
         </div>
       )}
@@ -85,9 +95,11 @@ export function ArchiveHeader({
           {variant === "tag" ? <span className="text-primary-1">#</span> : null}
           {title}
         </h1>
-        <span className="shrink-0 whitespace-nowrap text-body-sm text-text-4">
-          총 {formatNumber(count)}개의 글
-        </span>
+        {resolvedSummary ? (
+          <span className="shrink-0 whitespace-nowrap text-body-sm text-text-4">
+            {resolvedSummary}
+          </span>
+        ) : null}
       </div>
 
       <div className="mt-6 h-px bg-border-4" />


### PR DESCRIPTION
## Summary

Closes #344

Unifies the public categories and tags archive header system, gives the categories overview a clearer item hierarchy, and widens the desktop public sidebar to restore breathing room after the border change.

## Changes

| File | Change |
|------|--------|
| `src/shared/ui/libs/archive-header.tsx` | Generalize archive header summary/eyebrow rendering so category and tag archive pages can share one title system with page-specific metadata text. |
| `src/app/(public)/categories/page.tsx` | Switch the categories index to the shared archive header, rename the title to `Categories`, and use the overview variant of the category tree. |
| `src/app/(public)/tags/page.tsx` | Switch the tags index to the shared archive header so it matches the archive title design language. |
| `src/features/category-tree/ui/category-tree.tsx` | Add an overview presentation with bordered category rows and clearer nested grouping while preserving the compact sidebar tree behavior. |
| `src/app/(public)/layout-shell.tsx` | Increase the desktop public sidebar width from `234px` to `240px`. |

## Screenshots

UI change; screenshots not attached in this automated pipeline run.
