### PR TITLE
refactor: redesign categories compact tree layout (#348)

### DIFF
--- a/src/app/(public)/categories/page.tsx
+++ b/src/app/(public)/categories/page.tsx
@@ -5,6 +5,7 @@ import {
   countVisibleCategories,
   countVisibleCategoryNodes,
 } from "@features/category-tree";
+import { formatNumber } from "@shared/lib/format-number";
 import { buildCanonicalMetadata } from "@shared/lib/seo";
 import { ArchiveHeader, EmptyState, ScrollToTop } from "@shared/ui/libs";
 
@@ -20,23 +21,39 @@ export default async function CategoriesPage() {
   const categories = await fetchCategories();
   const visibleCategoryCount = countVisibleCategoryNodes(categories);
   const visiblePostCount = countVisibleCategories(categories);
+  const headerSummary = `총 ${formatNumber(visibleCategoryCount)}개 분류`;
 
   return (
     <main className="flex min-h-screen flex-col pt-8 pb-16">
       <ArchiveHeader
         variant="category"
         eyebrow="Category Directory"
-        title="Categories"
-        summary={
-          <>
-            총 {visibleCategoryCount.toLocaleString("ko-KR")}개 분류 · 공개 글{" "}
-            {visiblePostCount.toLocaleString("ko-KR")}개
-          </>
-        }
+        title="카테고리"
+        summary={headerSummary}
       />
 
       {visibleCategoryCount > 0 ? (
-        <section aria-label="카테고리 목록">
+        <section aria-label="카테고리 목록" className="motion-reveal">
+          <div className="mb-7 overflow-hidden rounded-[0.875rem] border border-border-4 bg-background-2">
+            <dl className="grid grid-cols-2">
+              <div className="flex min-w-0 flex-col gap-1 px-5 py-4 sm:px-[1.125rem]">
+                <dt className="text-[0.6875rem] font-semibold uppercase tracking-[0.04em] text-text-4">
+                  분류
+                </dt>
+                <dd className="font-['Outfit'] text-[1.625rem] leading-none font-bold tracking-[-0.02em] text-text-1 tabular-nums">
+                  {formatNumber(visibleCategoryCount)}
+                </dd>
+              </div>
+              <div className="flex min-w-0 flex-col gap-1 border-l border-border-4 px-5 py-4 sm:px-[1.125rem]">
+                <dt className="text-[0.6875rem] font-semibold uppercase tracking-[0.04em] text-text-4">
+                  공개 글
+                </dt>
+                <dd className="font-['Outfit'] text-[1.625rem] leading-none font-bold tracking-[-0.02em] text-text-1 tabular-nums">
+                  {formatNumber(visiblePostCount)}
+                </dd>
+              </div>
+            </dl>
+          </div>
           <CategoryTree
             categories={categories}
             showOverviewLink={false}

--- a/src/features/category-tree/ui/category-tree.tsx
+++ b/src/features/category-tree/ui/category-tree.tsx
@@ -2,10 +2,14 @@
 
 import { useEffect, useState } from "react";
 import { Icon } from "@iconify/react";
+import altArrowRightLinear from "@iconify-icons/solar/alt-arrow-right-linear";
 import recordLinear from "@iconify-icons/solar/record-linear";
+import squareDoubleAltArrowDownLinear from "@iconify-icons/solar/square-double-alt-arrow-down-linear";
+import squareDoubleAltArrowUpLinear from "@iconify-icons/solar/square-double-alt-arrow-up-linear";
 import Link from "next/link";
 import { countVisibleCategories } from "../lib/category-counts";
 import type { Category } from "@entities/category";
+import { formatNumber } from "@shared/lib/format-number";
 import { cn } from "@shared/lib/style-utils";
 
 const EMPTY_EXPANDED_SLUGS: string[] = [];
@@ -16,6 +20,21 @@ interface CategoryTreeProps {
   showOverviewLink?: boolean;
   initialExpandedSlugs?: string[];
   variant?: "sidebar" | "overview";
+}
+
+function getVisibleChildren(category: Category): Category[] {
+  return (category.children ?? []).filter((child) => child.isVisible);
+}
+
+function getDefaultExpandedSlugs(
+  categories: Category[],
+  variant: "sidebar" | "overview",
+): string[] {
+  if (variant === "overview") {
+    return categories.slice(0, 3).map((category) => category.slug);
+  }
+
+  return EMPTY_EXPANDED_SLUGS;
 }
 
 function CategoryItem({
@@ -33,7 +52,8 @@ function CategoryItem({
   onItemClick?: () => void;
   variant: "sidebar" | "overview";
 }) {
-  const hasChildren = category.children && category.children.length > 0;
+  const children = getVisibleChildren(category);
+  const hasChildren = children.length > 0;
   const postCount = category.publishedPostCount ?? category.totalPostCount;
   const isOpen = expandedSlugs.has(category.slug);
   const isOverview = variant === "overview";
@@ -51,7 +71,7 @@ function CategoryItem({
               "rounded-full border border-border-3 bg-background-1 px-2 py-0.5 font-medium text-text-3",
           )}
         >
-          {postCount}
+          {formatNumber(postCount)}
         </span>
       )}
     </>
@@ -75,11 +95,11 @@ function CategoryItem({
             />
             <span className="truncate">{category.name}</span>
           </span>
-          {postCount !== undefined && (
+          {postCount !== undefined ? (
             <span className="shrink-0 text-body-xs text-text-4">
-              {postCount}
+              {formatNumber(postCount)}
             </span>
-          )}
+          ) : null}
         </Link>
       </li>
     );
@@ -150,7 +170,7 @@ function CategoryItem({
             isOverview && "mt-1 ml-4 border-l border-border-3 pl-2",
           )}
         >
-          {category.children!.map((child) => (
+          {children.map((child) => (
             <CategoryItem
               key={child.id}
               category={child}
@@ -167,6 +187,203 @@ function CategoryItem({
   );
 }
 
+function OverviewLeaf({
+  category,
+  depth,
+  onItemClick,
+}: {
+  category: Category;
+  depth: number;
+  onItemClick?: () => void;
+}) {
+  const children = getVisibleChildren(category);
+  const postCount = category.publishedPostCount ?? category.totalPostCount;
+
+  return (
+    <>
+      <Link
+        href={`/categories/${category.slug}`}
+        onClick={onItemClick}
+        className={cn(
+          "group flex items-center gap-3 rounded-[0.625rem] px-2 py-2 text-[0.875rem] leading-5 text-text-2 transition-colors hover:bg-primary-1/6 hover:text-primary-1",
+          depth > 0 && "pl-5",
+        )}
+      >
+        <span
+          aria-hidden="true"
+          className="h-[0.3125rem] w-[0.3125rem] shrink-0 rounded-full bg-border-3 transition-colors group-hover:bg-primary-1"
+        />
+        <span className="min-w-0 flex-1 truncate font-medium">
+          {category.name}
+        </span>
+        {postCount !== undefined ? (
+          <span className="shrink-0 font-['Outfit'] text-[0.75rem] font-medium tabular-nums text-text-4">
+            {formatNumber(postCount)}
+          </span>
+        ) : null}
+      </Link>
+      {children.map((child) => (
+        <OverviewLeaf
+          key={child.id}
+          category={child}
+          depth={depth + 1}
+          onItemClick={onItemClick}
+        />
+      ))}
+    </>
+  );
+}
+
+function OverviewGroup({
+  category,
+  expandedSlugs,
+  onToggle,
+  onItemClick,
+}: {
+  category: Category;
+  expandedSlugs: Set<string>;
+  onToggle: (categorySlug: string) => void;
+  onItemClick?: () => void;
+}) {
+  const children = getVisibleChildren(category);
+  const isOpen = expandedSlugs.has(category.slug);
+  const postCount = category.publishedPostCount ?? category.totalPostCount ?? 0;
+  const panelId = `category-tree-panel-${category.slug}`;
+
+  return (
+    <article className="border-b border-border-4">
+      <div className="flex min-h-[3.5rem] items-center gap-3 px-2 py-3 transition-colors hover:bg-background-2">
+        <button
+          type="button"
+          onClick={() => onToggle(category.slug)}
+          aria-expanded={children.length > 0 ? isOpen : undefined}
+          aria-controls={children.length > 0 ? panelId : undefined}
+          aria-label={`${category.name} ${isOpen ? "접기" : "펼치기"}`}
+          disabled={children.length === 0}
+          className={cn(
+            "group flex h-5 w-5 shrink-0 items-center justify-center rounded text-text-3 transition-colors hover:text-text-1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-1",
+            children.length === 0 && "cursor-default",
+          )}
+        >
+          {children.length > 0 ? (
+            <Icon
+              icon={altArrowRightLinear}
+              width="14"
+              aria-hidden="true"
+              className={cn(
+                "transition-transform duration-200",
+                isOpen && "rotate-90 text-primary-1",
+              )}
+            />
+          ) : (
+            <span className="h-1.5 w-1.5 rounded-full bg-border-3" />
+          )}
+        </button>
+        <Link
+          href={`/categories/${category.slug}`}
+          onClick={onItemClick}
+          className="min-w-0 flex-1 truncate text-[1.0625rem] font-bold leading-[1.3] tracking-[-0.01em] text-text-1 transition-colors hover:text-primary-1"
+        >
+          {category.name}
+        </Link>
+        <span className="shrink-0 rounded-full bg-background-2 px-2.5 py-1 font-['Outfit'] text-[0.875rem] font-semibold tabular-nums text-text-3 transition-colors hover:bg-background-3 hover:text-text-1">
+          {formatNumber(postCount)}
+        </span>
+      </div>
+
+      {children.length > 0 ? (
+        <div
+          id={panelId}
+          className={cn(
+            "grid overflow-hidden transition-[grid-template-rows] duration-300 ease-[cubic-bezier(.16,1,.3,1)]",
+            isOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+          )}
+          aria-hidden={!isOpen}
+        >
+          <div className="overflow-hidden">
+            {isOpen ? (
+              <div className="px-2 pb-3 pl-10 pt-1">
+                {children.map((child) => (
+                  <OverviewLeaf
+                    key={child.id}
+                    category={child}
+                    depth={0}
+                    onItemClick={onItemClick}
+                  />
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+function OverviewCategoryTree({
+  categories,
+  expandedSlugs,
+  onToggle,
+  onItemClick,
+  onExpandAll,
+  onCollapseAll,
+}: {
+  categories: Category[];
+  expandedSlugs: Set<string>;
+  onToggle: (categorySlug: string) => void;
+  onItemClick?: () => void;
+  onExpandAll: () => void;
+  onCollapseAll: () => void;
+}) {
+  return (
+    <div className="motion-reveal">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-3">
+        <span className="text-ui-xs font-semibold uppercase tracking-[0.04em] text-text-4">
+          전체 분류
+        </span>
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            onClick={onExpandAll}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-transparent px-3 py-1.5 text-[0.8125rem] font-medium text-text-3 transition-colors hover:border-border-4 hover:bg-background-2 hover:text-text-1"
+          >
+            <Icon
+              icon={squareDoubleAltArrowDownLinear}
+              width="14"
+              aria-hidden="true"
+            />
+            모두 펼치기
+          </button>
+          <button
+            type="button"
+            onClick={onCollapseAll}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-transparent px-3 py-1.5 text-[0.8125rem] font-medium text-text-3 transition-colors hover:border-border-4 hover:bg-background-2 hover:text-text-1"
+          >
+            <Icon
+              icon={squareDoubleAltArrowUpLinear}
+              width="14"
+              aria-hidden="true"
+            />
+            모두 접기
+          </button>
+        </div>
+      </div>
+
+      <section aria-label="카테고리 트리" className="border-t border-border-4">
+        {categories.map((category) => (
+          <OverviewGroup
+            key={category.id}
+            category={category}
+            expandedSlugs={expandedSlugs}
+            onToggle={onToggle}
+            onItemClick={onItemClick}
+          />
+        ))}
+      </section>
+    </div>
+  );
+}
+
 export function CategoryTree({
   categories,
   onItemClick,
@@ -174,18 +391,27 @@ export function CategoryTree({
   initialExpandedSlugs = EMPTY_EXPANDED_SLUGS,
   variant = "sidebar",
 }: CategoryTreeProps) {
-  const visible = categories.filter((c) => c.isVisible);
+  const visible = categories.filter((category) => category.isVisible);
+  const resolvedInitialExpandedSlugs =
+    initialExpandedSlugs.length > 0
+      ? initialExpandedSlugs
+      : getDefaultExpandedSlugs(visible, variant);
+  const expandedStateKey = JSON.stringify(resolvedInitialExpandedSlugs);
   const [expandedSlugs, setExpandedSlugs] = useState(
-    () => new Set(initialExpandedSlugs),
+    () => new Set(resolvedInitialExpandedSlugs),
   );
 
   useEffect(() => {
-    setExpandedSlugs(new Set(initialExpandedSlugs));
-  }, [initialExpandedSlugs]);
+    setExpandedSlugs(new Set(JSON.parse(expandedStateKey) as string[]));
+  }, [expandedStateKey]);
 
   if (visible.length === 0) return null;
 
   const totalCount = countVisibleCategories(visible);
+  const expandableSlugs = visible
+    .filter((category) => getVisibleChildren(category).length > 0)
+    .map((category) => category.slug);
+
   const handleToggle = (categorySlug: string) => {
     setExpandedSlugs((current) => {
       const next = new Set(current);
@@ -200,20 +426,31 @@ export function CategoryTree({
     });
   };
 
+  if (variant === "overview") {
+    return (
+      <OverviewCategoryTree
+        categories={visible}
+        expandedSlugs={expandedSlugs}
+        onToggle={handleToggle}
+        onItemClick={onItemClick}
+        onExpandAll={() => setExpandedSlugs(new Set(expandableSlugs))}
+        onCollapseAll={() => setExpandedSlugs(new Set())}
+      />
+    );
+  }
+
   return (
     <div>
       {showOverviewLink && (
         <Link
           href="/categories"
           onClick={onItemClick}
-          className={cn(
-            "mb-2 flex items-center justify-between rounded px-1 py-1 text-body-sm font-medium text-text-2 transition-colors hover:text-primary-1",
-            variant === "overview" &&
-              "mb-4 rounded-[1.2rem] border border-dashed border-border-3 bg-background-2 px-4 py-3",
-          )}
+          className="mb-2 flex items-center justify-between rounded px-1 py-1 text-body-sm font-medium text-text-2 transition-colors hover:text-primary-1"
         >
           <span>분류 전체보기</span>
-          <span className="text-body-xs text-text-4">({totalCount})</span>
+          <span className="text-body-xs text-text-4">
+            ({formatNumber(totalCount)})
+          </span>
         </Link>
       )}
       <ul>

--- a/src/features/category-tree/ui/category-tree.tsx
+++ b/src/features/category-tree/ui/category-tree.tsx
@@ -1,9 +1,14 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { Icon } from "@iconify/react";
+import altArrowRightLinear from "@iconify-icons/solar/alt-arrow-right-linear";
+import squareDoubleAltArrowDownLinear from "@iconify-icons/solar/square-double-alt-arrow-down-linear";
+import squareDoubleAltArrowUpLinear from "@iconify-icons/solar/square-double-alt-arrow-up-linear";
 import Link from "next/link";
 import { countVisibleCategories } from "../lib/category-counts";
 import type { Category } from "@entities/category";
+import { formatNumber } from "@shared/lib/format-number";
 import { cn } from "@shared/lib/style-utils";
 
 const EMPTY_EXPANDED_SLUGS: string[] = [];
@@ -14,6 +19,21 @@ interface CategoryTreeProps {
   showOverviewLink?: boolean;
   initialExpandedSlugs?: string[];
   variant?: "sidebar" | "overview";
+}
+
+function getVisibleChildren(category: Category): Category[] {
+  return (category.children ?? []).filter((child) => child.isVisible);
+}
+
+function getDefaultExpandedSlugs(
+  categories: Category[],
+  variant: "sidebar" | "overview",
+): string[] {
+  if (variant === "overview") {
+    return categories.slice(0, 3).map((category) => category.slug);
+  }
+
+  return EMPTY_EXPANDED_SLUGS;
 }
 
 function CategoryItem({
@@ -31,7 +51,8 @@ function CategoryItem({
   onItemClick?: () => void;
   variant: "sidebar" | "overview";
 }) {
-  const hasChildren = category.children && category.children.length > 0;
+  const children = getVisibleChildren(category);
+  const hasChildren = children.length > 0;
   const postCount = category.publishedPostCount ?? category.totalPostCount;
   const isOpen = expandedSlugs.has(category.slug);
   const isOverview = variant === "overview";
@@ -102,7 +123,7 @@ function CategoryItem({
                   "rounded-full border border-border-3 bg-background-1 px-2 py-0.5 font-medium text-text-3",
               )}
             >
-              {postCount}
+              {formatNumber(postCount)}
             </span>
           )}
         </Link>
@@ -114,7 +135,7 @@ function CategoryItem({
             isOverview && "mt-1 ml-4 border-l border-border-3 pl-2",
           )}
         >
-          {category.children!.map((child) => (
+          {children.map((child) => (
             <CategoryItem
               key={child.id}
               category={child}
@@ -131,6 +152,200 @@ function CategoryItem({
   );
 }
 
+function OverviewLeaf({
+  category,
+  depth,
+  onItemClick,
+}: {
+  category: Category;
+  depth: number;
+  onItemClick?: () => void;
+}) {
+  const children = getVisibleChildren(category);
+  const postCount = category.publishedPostCount ?? category.totalPostCount;
+
+  return (
+    <>
+      <Link
+        href={`/categories/${category.slug}`}
+        onClick={onItemClick}
+        className={cn(
+          "group flex items-center gap-3 rounded-[0.625rem] px-2 py-2 text-[0.875rem] leading-5 text-text-2 transition-colors hover:bg-primary-1/6 hover:text-primary-1",
+          depth > 0 && "pl-5",
+        )}
+      >
+        <span
+          aria-hidden="true"
+          className="h-[0.3125rem] w-[0.3125rem] shrink-0 rounded-full bg-border-3 transition-colors group-hover:bg-primary-1"
+        />
+        <span className="min-w-0 flex-1 truncate font-medium">
+          {category.name}
+        </span>
+        {postCount !== undefined ? (
+          <span className="shrink-0 font-['Outfit'] text-[0.75rem] font-medium tabular-nums text-text-4">
+            {formatNumber(postCount)}
+          </span>
+        ) : null}
+      </Link>
+      {children.map((child) => (
+        <OverviewLeaf
+          key={child.id}
+          category={child}
+          depth={depth + 1}
+          onItemClick={onItemClick}
+        />
+      ))}
+    </>
+  );
+}
+
+function OverviewGroup({
+  category,
+  expandedSlugs,
+  onToggle,
+  onItemClick,
+}: {
+  category: Category;
+  expandedSlugs: Set<string>;
+  onToggle: (categorySlug: string) => void;
+  onItemClick?: () => void;
+}) {
+  const children = getVisibleChildren(category);
+  const isOpen = expandedSlugs.has(category.slug);
+  const postCount = category.publishedPostCount ?? category.totalPostCount ?? 0;
+  const panelId = `category-tree-panel-${category.slug}`;
+
+  return (
+    <article className="border-b border-border-4">
+      <div className="flex min-h-[3.5rem] items-center gap-3 px-2 py-3 transition-colors hover:bg-background-2">
+        <button
+          type="button"
+          onClick={() => onToggle(category.slug)}
+          aria-expanded={children.length > 0 ? isOpen : undefined}
+          aria-controls={children.length > 0 ? panelId : undefined}
+          aria-label={`${category.name} ${isOpen ? "접기" : "펼치기"}`}
+          disabled={children.length === 0}
+          className={cn(
+            "group flex h-5 w-5 shrink-0 items-center justify-center rounded text-text-3 transition-colors hover:text-text-1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-1",
+            children.length === 0 && "cursor-default",
+          )}
+        >
+          {children.length > 0 ? (
+            <Icon
+              icon={altArrowRightLinear}
+              width="14"
+              aria-hidden="true"
+              className={cn(
+                "transition-transform duration-200",
+                isOpen && "rotate-90 text-primary-1",
+              )}
+            />
+          ) : (
+            <span className="h-1.5 w-1.5 rounded-full bg-border-3" />
+          )}
+        </button>
+        <Link
+          href={`/categories/${category.slug}`}
+          onClick={onItemClick}
+          className="min-w-0 flex-1 truncate text-[1.0625rem] font-bold leading-[1.3] tracking-[-0.01em] text-text-1 transition-colors hover:text-primary-1"
+        >
+          {category.name}
+        </Link>
+        <span className="shrink-0 rounded-full bg-background-2 px-2.5 py-1 font-['Outfit'] text-[0.875rem] font-semibold tabular-nums text-text-3 transition-colors hover:bg-background-3 hover:text-text-1">
+          {formatNumber(postCount)}
+        </span>
+      </div>
+
+      {children.length > 0 ? (
+        <div
+          id={panelId}
+          className={cn(
+            "grid overflow-hidden transition-[grid-template-rows] duration-300 ease-[cubic-bezier(.16,1,.3,1)]",
+            isOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+          )}
+        >
+          <div className="overflow-hidden">
+            <div className="px-2 pb-3 pl-10 pt-1">
+              {children.map((child) => (
+                <OverviewLeaf
+                  key={child.id}
+                  category={child}
+                  depth={0}
+                  onItemClick={onItemClick}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+function OverviewCategoryTree({
+  categories,
+  expandedSlugs,
+  onToggle,
+  onItemClick,
+  onExpandAll,
+  onCollapseAll,
+}: {
+  categories: Category[];
+  expandedSlugs: Set<string>;
+  onToggle: (categorySlug: string) => void;
+  onItemClick?: () => void;
+  onExpandAll: () => void;
+  onCollapseAll: () => void;
+}) {
+  return (
+    <div className="motion-reveal">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-3">
+        <span className="text-ui-xs font-semibold uppercase tracking-[0.04em] text-text-4">
+          전체 분류
+        </span>
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            onClick={onExpandAll}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-transparent px-3 py-1.5 text-[0.8125rem] font-medium text-text-3 transition-colors hover:border-border-4 hover:bg-background-2 hover:text-text-1"
+          >
+            <Icon
+              icon={squareDoubleAltArrowDownLinear}
+              width="14"
+              aria-hidden="true"
+            />
+            모두 펼치기
+          </button>
+          <button
+            type="button"
+            onClick={onCollapseAll}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-transparent px-3 py-1.5 text-[0.8125rem] font-medium text-text-3 transition-colors hover:border-border-4 hover:bg-background-2 hover:text-text-1"
+          >
+            <Icon
+              icon={squareDoubleAltArrowUpLinear}
+              width="14"
+              aria-hidden="true"
+            />
+            모두 접기
+          </button>
+        </div>
+      </div>
+
+      <section aria-label="카테고리 트리" className="border-t border-border-4">
+        {categories.map((category) => (
+          <OverviewGroup
+            key={category.id}
+            category={category}
+            expandedSlugs={expandedSlugs}
+            onToggle={onToggle}
+            onItemClick={onItemClick}
+          />
+        ))}
+      </section>
+    </div>
+  );
+}
+
 export function CategoryTree({
   categories,
   onItemClick,
@@ -138,18 +353,27 @@ export function CategoryTree({
   initialExpandedSlugs = EMPTY_EXPANDED_SLUGS,
   variant = "sidebar",
 }: CategoryTreeProps) {
-  const visible = categories.filter((c) => c.isVisible);
+  const visible = categories.filter((category) => category.isVisible);
+  const resolvedInitialExpandedSlugs =
+    initialExpandedSlugs.length > 0
+      ? initialExpandedSlugs
+      : getDefaultExpandedSlugs(visible, variant);
+  const expandedStateKey = JSON.stringify(resolvedInitialExpandedSlugs);
   const [expandedSlugs, setExpandedSlugs] = useState(
-    () => new Set(initialExpandedSlugs),
+    () => new Set(resolvedInitialExpandedSlugs),
   );
 
   useEffect(() => {
-    setExpandedSlugs(new Set(initialExpandedSlugs));
-  }, [initialExpandedSlugs]);
+    setExpandedSlugs(new Set(JSON.parse(expandedStateKey) as string[]));
+  }, [expandedStateKey]);
 
   if (visible.length === 0) return null;
 
   const totalCount = countVisibleCategories(visible);
+  const expandableSlugs = visible
+    .filter((category) => getVisibleChildren(category).length > 0)
+    .map((category) => category.slug);
+
   const handleToggle = (categorySlug: string) => {
     setExpandedSlugs((current) => {
       const next = new Set(current);
@@ -164,20 +388,31 @@ export function CategoryTree({
     });
   };
 
+  if (variant === "overview") {
+    return (
+      <OverviewCategoryTree
+        categories={visible}
+        expandedSlugs={expandedSlugs}
+        onToggle={handleToggle}
+        onItemClick={onItemClick}
+        onExpandAll={() => setExpandedSlugs(new Set(expandableSlugs))}
+        onCollapseAll={() => setExpandedSlugs(new Set())}
+      />
+    );
+  }
+
   return (
     <div>
       {showOverviewLink && (
         <Link
           href="/categories"
           onClick={onItemClick}
-          className={cn(
-            "mb-2 flex items-center justify-between rounded px-1 py-1 text-body-sm font-medium text-text-2 transition-colors hover:text-primary-1",
-            variant === "overview" &&
-              "mb-4 rounded-[1.2rem] border border-dashed border-border-3 bg-background-2 px-4 py-3",
-          )}
+          className="mb-2 flex items-center justify-between rounded px-1 py-1 text-body-sm font-medium text-text-2 transition-colors hover:text-primary-1"
         >
           <span>분류 전체보기</span>
-          <span className="text-body-xs text-text-4">({totalCount})</span>
+          <span className="text-body-xs text-text-4">
+            ({formatNumber(totalCount)})
+          </span>
         </Link>
       )}
       <ul>

--- a/src/features/category-tree/ui/category-tree.tsx
+++ b/src/features/category-tree/ui/category-tree.tsx
@@ -263,18 +263,21 @@ function OverviewGroup({
             "grid overflow-hidden transition-[grid-template-rows] duration-300 ease-[cubic-bezier(.16,1,.3,1)]",
             isOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
           )}
+          aria-hidden={!isOpen}
         >
           <div className="overflow-hidden">
-            <div className="px-2 pb-3 pl-10 pt-1">
-              {children.map((child) => (
-                <OverviewLeaf
-                  key={child.id}
-                  category={child}
-                  depth={0}
-                  onItemClick={onItemClick}
-                />
-              ))}
-            </div>
+            {isOpen ? (
+              <div className="px-2 pb-3 pl-10 pt-1">
+                {children.map((child) => (
+                  <OverviewLeaf
+                    key={child.id}
+                    category={child}
+                    depth={0}
+                    onItemClick={onItemClick}
+                  />
+                ))}
+              </div>
+            ) : null}
           </div>
         </div>
       ) : null}


### PR DESCRIPTION
## Summary

Closes #348

/categories 페이지를 와이어프레임 기준의 컴팩트 트리 레이아웃으로 재구성했습니다. 기존 기능은 유지하면서 헤더, 요약 통계, 그룹/리프 구조, 전체 펼치기/접기 동작을 정리했습니다.

## Changes

| File | Change |
|------|--------|
| `src/app/(public)/categories/page.tsx` | 헤더 타이틀/요약을 와이어프레임에 맞게 조정하고 2칸 통계 스트립을 추가 |
| `src/features/category-tree/ui/category-tree.tsx` | overview 전용 컴팩트 트리 UI, 그룹 토글, 전체 펼치기/접기, 숫자 포맷팅을 구현 |

## Screenshots

- CLI 파이프라인 실행으로 별도 첨부 없음
