### PR TITLE
fix: preserve category tree ancestors (#359)

### DIFF
--- a/src/features/category-manager/lib/tree-utils.ts
+++ b/src/features/category-manager/lib/tree-utils.ts
@@ -325,9 +325,7 @@ function removeCategory(
   targetId: number,
   parentId: number | null = null,
 ): {
-  tree: Category[];
   removedCategory: Category;
-  parentId: number | null;
 } | null {
   const index = categories.findIndex((category) => category.id === targetId);
 
@@ -336,9 +334,7 @@ function removeCategory(
     normalizeSiblingOrder(categories, parentId);
 
     return {
-      tree: categories,
       removedCategory,
-      parentId,
     };
   }
 
@@ -350,8 +346,6 @@ function removeCategory(
     );
 
     if (result) {
-      category.children = result.tree;
-
       return result;
     }
   }


### PR DESCRIPTION
## Summary

Closes #359

Fixes category batch-edit tree rebuilding so moving a deep child does not drop its intermediate ancestor from the working tree.

## Changes

| File | Change |
|------|--------|
| `src/features/category-manager/lib/tree-utils.ts` | Stops recursive category removal from assigning the direct parent's child list onto each ancestor while unwinding. |
