### PR TITLE
feat: add category bulk delete action (#360)

### DIFF
--- a/src/entities/category/api.ts
+++ b/src/entities/category/api.ts
@@ -2,6 +2,7 @@ import type {
   Category,
   CategoryTreeChange,
   CreateCategoryBody,
+  DeleteCategoriesBody,
   DeleteCategoryOptions,
   UpdateCategoryBody,
   UpdateCategoryOrderBody,
@@ -109,5 +110,20 @@ export async function deleteCategory(
 
   await clientMutate<void>(`/categories/${id}${query ? `?${query}` : ""}`, {
     method: "DELETE",
+  });
+}
+
+export async function deleteCategories(
+  ids: number[],
+  options: DeleteCategoryOptions,
+): Promise<void> {
+  const body: DeleteCategoriesBody = {
+    ids,
+    ...options,
+  };
+
+  await clientMutate<void>("/categories/bulk", {
+    method: "DELETE",
+    body: JSON.stringify(body),
   });
 }

--- a/src/entities/category/index.ts
+++ b/src/entities/category/index.ts
@@ -2,6 +2,7 @@ export type {
   Category,
   CategoryTreeChange,
   CreateCategoryBody,
+  DeleteCategoriesBody,
   DeleteCategoryAction,
   DeleteCategoryOptions,
   UpdateCategoryBody,
@@ -10,6 +11,7 @@ export type {
 } from "./model";
 export { findCategoryBySlug, getCategoryAncestors } from "./lib";
 export {
+  deleteCategories,
   createCategory,
   deleteCategory,
   fetchCategories,

--- a/src/entities/category/model.ts
+++ b/src/entities/category/model.ts
@@ -47,3 +47,7 @@ export interface DeleteCategoryOptions {
   action: DeleteCategoryAction;
   moveTo?: number;
 }
+
+export interface DeleteCategoriesBody extends DeleteCategoryOptions {
+  ids: number[];
+}

--- a/src/features/category-manager/ui/category-bulk-delete-modal.tsx
+++ b/src/features/category-manager/ui/category-bulk-delete-modal.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { Category, DeleteCategoryOptions } from "@entities/category";
+import { cn } from "@shared/lib/style-utils";
+import { Modal, Spinner } from "@shared/ui/libs";
+
+interface CategoryBulkDeleteModalProps {
+  isOpen: boolean;
+  selectedCategories: Category[];
+  categories: Category[];
+  isDeleting: boolean;
+  onCancel: () => void;
+  onConfirm: (options: DeleteCategoryOptions) => void;
+}
+
+type DeleteMode = DeleteCategoryOptions["action"] | null;
+
+export function CategoryBulkDeleteModal({
+  isOpen,
+  selectedCategories,
+  categories,
+  isDeleting,
+  onCancel,
+  onConfirm,
+}: CategoryBulkDeleteModalProps) {
+  const [mode, setMode] = useState<DeleteMode>(null);
+  const [moveTo, setMoveTo] = useState<number | null>(null);
+
+  const selectedIds = useMemo(
+    () => new Set(selectedCategories.map((category) => category.id)),
+    [selectedCategories],
+  );
+  const selectedCount = selectedCategories.length;
+  const categoriesWithChildren = selectedCategories.filter(
+    (category) => (category.children?.length ?? 0) > 0,
+  );
+  const categoriesWithPosts = selectedCategories.filter(
+    (category) => (category.totalPostCount ?? 0) > 0,
+  );
+  const postCount = categoriesWithPosts.reduce(
+    (total, category) => total + (category.totalPostCount ?? 0),
+    0,
+  );
+  const hasChildren = categoriesWithChildren.length > 0;
+
+  useEffect(() => {
+    if (!isOpen) {
+      setMode(null);
+      setMoveTo(null);
+
+      return;
+    }
+
+    if (postCount > 0) {
+      setMode(null);
+      setMoveTo(null);
+
+      return;
+    }
+
+    setMode("trash");
+    setMoveTo(null);
+  }, [isOpen, postCount]);
+
+  const moveOptions = useMemo(
+    () =>
+      flattenCategories(categories)
+        .filter((option) => !selectedIds.has(option.id))
+        .map(({ id, name, depth }) => ({
+          id,
+          label: `${"— ".repeat(depth)}${name}`,
+        })),
+    [categories, selectedIds],
+  );
+
+  const requiresMoveTarget =
+    postCount > 0 && mode === "move" && moveTo === null;
+  const isConfirmDisabled =
+    isDeleting ||
+    selectedCount === 0 ||
+    hasChildren ||
+    (postCount > 0 && (mode === null || requiresMoveTarget));
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={() => {
+        if (!isDeleting) {
+          onCancel();
+        }
+      }}
+      withBackground
+      aria-label="카테고리 일괄 삭제"
+      className="w-[min(100%,36rem)] p-0 text-left"
+    >
+      <div className="border-b border-border-3 px-6 py-5">
+        <p className="text-body-xs uppercase tracking-[0.2em] text-text-4">
+          Delete categories
+        </p>
+        <h2 className="mt-2 text-xl font-semibold text-text-1">
+          {hasChildren ? "삭제 불가" : "카테고리 일괄 삭제"}
+        </h2>
+      </div>
+
+      {hasChildren ? (
+        <div className="space-y-4 px-6 py-5">
+          <p className="text-sm leading-6 text-text-2">
+            선택한 {selectedCount}개 카테고리 중 하위 카테고리가 있는 항목{" "}
+            {categoriesWithChildren.length}개는 삭제할 수 없습니다.
+          </p>
+          <div className="rounded-[0.9rem] border border-negative-1/20 bg-negative-1/10 px-4 py-3">
+            <p className="text-sm font-medium text-negative-1">
+              하위 카테고리 포함 항목
+            </p>
+            <p className="mt-2 text-sm leading-6 text-text-2">
+              {formatCategoryNames(categoriesWithChildren)}
+            </p>
+          </div>
+          <p className="text-sm leading-6 text-text-3">
+            하위 카테고리를 먼저 삭제하거나 다른 위치로 이동한 뒤 다시 시도해
+            주세요.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-5 px-6 py-5">
+          <div className="space-y-2">
+            <p className="text-sm leading-6 text-text-2">
+              선택한{" "}
+              <strong className="font-semibold text-text-1">
+                {selectedCount}개
+              </strong>{" "}
+              카테고리를 삭제합니다.
+            </p>
+            {postCount > 0 ? (
+              <>
+                <p className="text-sm leading-6 text-text-2">
+                  포함된 글은 총{" "}
+                  <strong className="font-semibold text-text-1">
+                    {postCount}개
+                  </strong>
+                  입니다.
+                </p>
+                <p className="text-sm leading-6 text-text-3">
+                  삭제 전에 선택한 카테고리의 글 처리 방식을 선택해야 합니다.
+                </p>
+              </>
+            ) : (
+              <p className="text-sm leading-6 text-text-3">
+                연결된 글이 없는 카테고리입니다. 이 작업은 되돌릴 수 없습니다.
+              </p>
+            )}
+          </div>
+
+          {postCount > 0 ? (
+            <fieldset className="space-y-3">
+              <legend className="sr-only">삭제 전 글 처리 방식 선택</legend>
+
+              <label
+                className={cn(
+                  "flex cursor-pointer gap-4 rounded-[1rem] border px-4 py-4 transition-colors",
+                  mode === "move"
+                    ? "border-primary-1 bg-primary-1/5"
+                    : "border-border-3 bg-background-1 hover:border-border-2",
+                )}
+              >
+                <input
+                  type="radio"
+                  name="category-bulk-delete-action"
+                  checked={mode === "move"}
+                  onChange={() => setMode("move")}
+                  disabled={isDeleting || moveOptions.length === 0}
+                  aria-label="다른 카테고리로 이동"
+                  className="mt-1 h-4 w-4 border-border-3 accent-primary-1"
+                />
+                <span className="flex-1 space-y-3">
+                  <span className="block">
+                    <span className="block text-sm font-semibold text-text-1">
+                      다른 카테고리로 이동
+                    </span>
+                    <span className="mt-1 block text-sm leading-6 text-text-3">
+                      선택한 카테고리의 글을 삭제 대상이 아닌 카테고리로
+                      옮깁니다.
+                    </span>
+                  </span>
+
+                  <select
+                    value={moveTo ?? ""}
+                    onChange={(event) =>
+                      setMoveTo(
+                        event.target.value ? Number(event.target.value) : null,
+                      )
+                    }
+                    disabled={
+                      isDeleting || mode !== "move" || moveOptions.length === 0
+                    }
+                    aria-label="이동 대상 카테고리"
+                    className="w-full rounded-[0.9rem] border border-border-3 bg-background-1 px-4 py-3 text-sm text-text-1 outline-none transition-colors focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    <option value="">
+                      {moveOptions.length > 0
+                        ? "이동할 카테고리를 선택하세요"
+                        : "이동 가능한 카테고리가 없습니다"}
+                    </option>
+                    {moveOptions.map((option) => (
+                      <option key={option.id} value={option.id}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </span>
+              </label>
+
+              <label
+                className={cn(
+                  "flex cursor-pointer gap-4 rounded-[1rem] border px-4 py-4 transition-colors",
+                  mode === "trash"
+                    ? "border-negative-1/40 bg-negative-1/5"
+                    : "border-border-3 bg-background-1 hover:border-border-2",
+                )}
+              >
+                <input
+                  type="radio"
+                  name="category-bulk-delete-action"
+                  checked={mode === "trash"}
+                  onChange={() => setMode("trash")}
+                  disabled={isDeleting}
+                  aria-label="글을 휴지통으로 이동"
+                  className="mt-1 h-4 w-4 border-border-3 accent-negative-1"
+                />
+                <span className="block">
+                  <span className="block text-sm font-semibold text-text-1">
+                    글을 휴지통으로 이동
+                  </span>
+                  <span className="mt-1 block text-sm leading-6 text-text-3">
+                    선택한 카테고리의 글을 휴지통으로 보낸 뒤 카테고리를
+                    삭제합니다. 복원할 때는 카테고리를 다시 지정해야 합니다.
+                  </span>
+                </span>
+              </label>
+            </fieldset>
+          ) : null}
+        </div>
+      )}
+
+      <div className="flex justify-end gap-3 border-t border-border-3 px-6 py-5">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isDeleting}
+          className="inline-flex items-center justify-center rounded-[0.75rem] border border-border-3 px-4 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {hasChildren ? "확인" : "취소"}
+        </button>
+        {!hasChildren ? (
+          <button
+            type="button"
+            onClick={() => {
+              if (postCount > 0) {
+                if (mode === "move" && moveTo !== null) {
+                  onConfirm({ action: "move", moveTo });
+                }
+
+                if (mode === "trash") {
+                  onConfirm({ action: "trash" });
+                }
+
+                return;
+              }
+
+              onConfirm({ action: "trash" });
+            }}
+            disabled={isConfirmDisabled}
+            className="inline-flex items-center justify-center gap-2 rounded-[0.75rem] bg-negative-1 px-4 py-2 text-sm font-medium text-text-1 transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isDeleting ? (
+              <>
+                <Spinner size="sm" /> 삭제 중
+              </>
+            ) : (
+              "삭제"
+            )}
+          </button>
+        ) : null}
+      </div>
+    </Modal>
+  );
+}
+
+function flattenCategories(
+  categories: Category[],
+  depth = 0,
+): Array<{ id: number; name: string; depth: number }> {
+  return categories.flatMap((category) => [
+    { id: category.id, name: category.name, depth },
+    ...flattenCategories(category.children ?? [], depth + 1),
+  ]);
+}
+
+function formatCategoryNames(categories: Category[]) {
+  const visibleNames = categories.slice(0, 3).map((category) => category.name);
+  const remainingCount = categories.length - visibleNames.length;
+
+  if (remainingCount <= 0) {
+    return visibleNames.join(", ");
+  }
+
+  return `${visibleNames.join(", ")} 외 ${remainingCount}개`;
+}

--- a/src/features/category-manager/ui/category-manager.tsx
+++ b/src/features/category-manager/ui/category-manager.tsx
@@ -13,6 +13,7 @@ import {
 import { CategoryTree } from "./category-tree";
 import {
   createCategory,
+  deleteCategories,
   deleteCategory,
   fetchCategoriesAdmin,
   updateCategoryTree,
@@ -92,6 +93,25 @@ export function CategoryManager() {
     },
     onError: (error) => {
       toast.error(getErrorMessage(error, "카테고리 삭제에 실패했습니다."));
+    },
+  });
+
+  const bulkDeleteMutation = useMutation({
+    mutationFn: ({
+      ids,
+      options,
+    }: {
+      ids: number[];
+      options: DeleteCategoryOptions;
+    }) => deleteCategories(ids, options),
+    onSuccess: async (_data, variables) => {
+      await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      toast.success(
+        `선택한 카테고리 ${variables.ids.length}개를 삭제했습니다.`,
+      );
+    },
+    onError: (error) => {
+      toast.error(getErrorMessage(error, "카테고리 일괄 삭제에 실패했습니다."));
     },
   });
 
@@ -226,10 +246,14 @@ export function CategoryManager() {
               onBulkVisibilityChange={async (ids, isVisible) => {
                 await bulkVisibilityMutation.mutateAsync({ ids, isVisible });
               }}
+              onBulkDelete={async (ids, options) => {
+                await bulkDeleteMutation.mutateAsync({ ids, options });
+              }}
               onSaveTree={async (changes) => {
                 await treeUpdateMutation.mutateAsync(changes);
               }}
               isBulkUpdating={bulkVisibilityMutation.isPending}
+              isBulkDeleting={bulkDeleteMutation.isPending}
               isSavingTree={treeUpdateMutation.isPending}
             />
           ) : null}

--- a/src/features/category-manager/ui/category-tree.tsx
+++ b/src/features/category-manager/ui/category-tree.tsx
@@ -14,6 +14,7 @@ import {
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
+import { CategoryBulkDeleteModal } from "./category-bulk-delete-modal";
 import { CategoryTreeRow, CategoryTreeRowPreview } from "./category-tree-row";
 import { CategoryTreeToolbar } from "./category-tree-toolbar";
 import {
@@ -29,7 +30,11 @@ import {
   type CategoryTreeMode,
   type DropTarget,
 } from "../lib/tree-utils";
-import type { Category, CategoryTreeChange } from "@entities/category";
+import type {
+  Category,
+  CategoryTreeChange,
+  DeleteCategoryOptions,
+} from "@entities/category";
 import { ConfirmDialog } from "@shared/ui/confirm-dialog";
 import { EmptyState } from "@shared/ui/libs";
 
@@ -41,8 +46,13 @@ interface CategoryTreeProps {
   onToggleVisibility: (category: Category) => Promise<void>;
   onCreate: () => void;
   onBulkVisibilityChange: (ids: number[], isVisible: boolean) => Promise<void>;
+  onBulkDelete: (
+    ids: number[],
+    options: DeleteCategoryOptions,
+  ) => Promise<void>;
   onSaveTree: (changes: CategoryTreeChange[]) => Promise<void>;
   isBulkUpdating: boolean;
+  isBulkDeleting: boolean;
   isSavingTree: boolean;
 }
 
@@ -54,8 +64,10 @@ export function CategoryTree({
   onToggleVisibility,
   onCreate,
   onBulkVisibilityChange,
+  onBulkDelete,
   onSaveTree,
   isBulkUpdating,
+  isBulkDeleting,
   isSavingTree,
 }: CategoryTreeProps) {
   const collisionDetection: CollisionDetection = useCallback((args) => {
@@ -91,6 +103,7 @@ export function CategoryTree({
   const [activeDragId, setActiveDragId] = useState<number | null>(null);
   const [dropTarget, setDropTarget] = useState<DropTarget | null>(null);
   const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false);
+  const [isBulkDeleteModalOpen, setIsBulkDeleteModalOpen] = useState(false);
   const hoverExpandTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
@@ -130,6 +143,17 @@ export function CategoryTree({
     ? visibleRows.find(({ category }) => category.id === activeDragId)
     : null;
   const selectedCount = selectedIds.size;
+  const selectedCategories = useMemo(
+    () =>
+      flattenCategoryTree(
+        workingCategories,
+        collectExpandableIds(workingCategories, true),
+        true,
+      )
+        .map(({ category }) => category)
+        .filter((category) => selectedIds.has(category.id)),
+    [selectedIds, workingCategories],
+  );
   const rowMetaMap = useMemo(
     () =>
       new Map(
@@ -288,6 +312,22 @@ export function CategoryTree({
 
     await onBulkVisibilityChange(ids, isVisible);
     setSelectedIds(new Set());
+  };
+
+  const handleBulkDeleteConfirm = async (options: DeleteCategoryOptions) => {
+    const ids = Array.from(selectedIds);
+
+    if (ids.length === 0) {
+      return;
+    }
+
+    try {
+      await onBulkDelete(ids, options);
+      setSelectedIds(new Set());
+      setIsBulkDeleteModalOpen(false);
+    } catch {
+      // The caller owns toast messaging for API failures.
+    }
   };
 
   const handleSaveEditMode = async () => {
@@ -598,6 +638,16 @@ export function CategoryTree({
                 </button>
                 <button
                   type="button"
+                  onClick={() => setIsBulkDeleteModalOpen(true)}
+                  disabled={
+                    selectedCount === 0 || isBulkDeleting || isBulkUpdating
+                  }
+                  className="inline-flex h-9 cursor-pointer items-center rounded-[0.7rem] bg-negative-1 px-3 text-sm text-text-1 transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  삭제
+                </button>
+                <button
+                  type="button"
                   onClick={handleExitSelectMode}
                   className="inline-flex h-9 cursor-pointer items-center rounded-[0.7rem] bg-primary-1 px-3 text-sm text-white transition-opacity hover:opacity-90"
                 >
@@ -647,6 +697,15 @@ export function CategoryTree({
       >
         저장하지 않은 배치 편집 변경사항이 사라집니다.
       </ConfirmDialog>
+
+      <CategoryBulkDeleteModal
+        isOpen={isBulkDeleteModalOpen}
+        selectedCategories={selectedCategories}
+        categories={workingCategories}
+        isDeleting={isBulkDeleting}
+        onCancel={() => setIsBulkDeleteModalOpen(false)}
+        onConfirm={(options) => void handleBulkDeleteConfirm(options)}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary

Closes #360

Adds bulk deletion to the admin category selection flow, including the `/categories/bulk` client API integration and confirmation handling for child categories and posts.

## Changes

| File | Change |
|------|--------|
| `src/entities/category/*` | Add bulk delete request typing and `deleteCategories(ids, options)` API helper. |
| `src/features/category-manager/ui/category-manager.tsx` | Wire bulk delete mutation, success invalidation, and error toast. |
| `src/features/category-manager/ui/category-tree.tsx` | Add select-mode delete action and reset selected IDs after successful deletion. |
| `src/features/category-manager/ui/category-bulk-delete-modal.tsx` | Add bulk delete confirmation modal with child blocking, post handling choices, and move target filtering. |

## Screenshots

Not captured; admin API state is required to exercise the modal data paths.
