### PR TITLE
fix: stabilize sidebar icon and font loading (#368)

### DIFF
--- a/src/app/(public)/categories/[slug]/page.tsx
+++ b/src/app/(public)/categories/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { cache } from "react";
 import type { Metadata } from "next";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import documentTextLinear from "@iconify-icons/solar/document-text-linear";
 import { notFound } from "next/navigation";
 import {

--- a/src/app/(public)/posts/[slug]/page.tsx
+++ b/src/app/(public)/posts/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { cache } from "react";
 import type { Metadata } from "next";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import eyeLinear from "@iconify-icons/solar/eye-linear";
 import { cookies } from "next/headers";
 import Image from "next/image";

--- a/src/app/(public)/tags/[slug]/page.tsx
+++ b/src/app/(public)/tags/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { cache } from "react";
 import type { Metadata } from "next";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import tagLinear from "@iconify-icons/solar/tag-linear";
 import { notFound } from "next/navigation";
 import { fetchPosts } from "@entities/post";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,11 @@ import {
 } from "@shared/lib/seo";
 import { ErrorBoundaryWithReset } from "@shared/ui/error-boundary";
 
+const CRITICAL_FONT_PRELOADS = [
+  "/fonts/nanum-square-neo/NanumSquareNeoTTF-bRg.woff2",
+  "/fonts/nanum-square-neo/NanumSquareNeoTTF-cBd.woff2",
+] as const;
+
 export const metadata: Metadata = {
   metadataBase: getMetadataBase(),
   title: {
@@ -77,6 +82,18 @@ export default async function RootLayout({
 
   return (
     <html lang="ko" data-theme={themeType || undefined}>
+      <head>
+        {CRITICAL_FONT_PRELOADS.map((href) => (
+          <link
+            key={href}
+            rel="preload"
+            href={href}
+            as="font"
+            type="font/woff2"
+            crossOrigin="anonymous"
+          />
+        ))}
+      </head>
       <body>
         <div className="w-full h-full">
           <ErrorBoundaryWithReset>

--- a/src/app/manage/layout-shell.tsx
+++ b/src/app/manage/layout-shell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import hamburgerMenuLinear from "@iconify-icons/solar/hamburger-menu-linear";
 import { usePathname } from "next/navigation";
 import {
@@ -107,7 +107,12 @@ export function ManageLayoutShell({ children }: { children: React.ReactNode }) {
             aria-controls={sidebarOpen ? "admin-nav-overlay" : undefined}
             className="inline-flex h-9 w-9 items-center justify-center rounded-lg text-text-2 transition-colors hover:bg-background-3 hover:text-text-1 md:hidden"
           >
-            <Icon icon={hamburgerMenuLinear} width="22" aria-hidden="true" />
+            <Icon
+              icon={hamburgerMenuLinear}
+              width="22"
+              height="22"
+              aria-hidden="true"
+            />
           </button>
 
           <p className="text-lg font-bold text-text-1">

--- a/src/features/asset-uploader/ui/asset-detail-modal.tsx
+++ b/src/features/asset-uploader/ui/asset-detail-modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { type ReactNode, useEffect, useMemo, useState } from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import closeCircleLinear from "@iconify-icons/solar/close-circle-linear";
 import codeSquareLinear from "@iconify-icons/solar/code-square-linear";
 import linkMinimalistic2Linear from "@iconify-icons/solar/link-minimalistic-2-linear";

--- a/src/features/asset-uploader/ui/asset-grid.tsx
+++ b/src/features/asset-uploader/ui/asset-grid.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import checkCircleLinear from "@iconify-icons/solar/check-circle-linear";
 import checkSquareLinear from "@iconify-icons/solar/check-square-linear";
 import linkMinimalistic2Linear from "@iconify-icons/solar/link-minimalistic-2-linear";

--- a/src/features/asset-uploader/ui/upload-zone.tsx
+++ b/src/features/asset-uploader/ui/upload-zone.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import cloudUploadLinear from "@iconify-icons/solar/cloud-upload-linear";
 import galleryWideLinear from "@iconify-icons/solar/gallery-wide-linear";
 import linkMinimalistic2Linear from "@iconify-icons/solar/link-minimalistic-2-linear";

--- a/src/features/category-manager/ui/category-tree-row.tsx
+++ b/src/features/category-manager/ui/category-tree-row.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useDraggable, useDroppable } from "@dnd-kit/core";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import altArrowRightLinear from "@iconify-icons/solar/alt-arrow-right-linear";
 import menuDotsLinear from "@iconify-icons/solar/menu-dots-linear";
 import penNewRoundLinear from "@iconify-icons/solar/pen-new-round-linear";

--- a/src/features/category-manager/ui/category-tree-toolbar.tsx
+++ b/src/features/category-manager/ui/category-tree-toolbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import addFolderLinear from "@iconify-icons/solar/add-folder-linear";
 import altArrowDownLinear from "@iconify-icons/solar/alt-arrow-down-linear";
 import altArrowUpLinear from "@iconify-icons/solar/alt-arrow-up-linear";

--- a/src/features/category-tree/ui/overview-category-tree.tsx
+++ b/src/features/category-tree/ui/overview-category-tree.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import squareDoubleAltArrowDownLinear from "@iconify-icons/solar/square-double-alt-arrow-down-linear";
 import squareDoubleAltArrowUpLinear from "@iconify-icons/solar/square-double-alt-arrow-up-linear";
 import Link from "next/link";

--- a/src/features/guestbook-manager/ui/guestbook-table.tsx
+++ b/src/features/guestbook-manager/ui/guestbook-table.tsx
@@ -7,7 +7,7 @@ import {
   type FormEvent,
   type KeyboardEvent,
 } from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import chatRoundDotsLinear from "@iconify-icons/solar/chat-round-dots-linear";
 import closeCircleLinear from "@iconify-icons/solar/close-circle-linear";
 import lockKeyholeLinear from "@iconify-icons/solar/lock-keyhole-linear";

--- a/src/features/post-detail/ui/related-posts.tsx
+++ b/src/features/post-detail/ui/related-posts.tsx
@@ -1,4 +1,4 @@
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import documentTextLinear from "@iconify-icons/solar/document-text-linear";
 import Image from "next/image";
 import Link from "next/link";

--- a/src/features/post-editor/ui/post-form.tsx
+++ b/src/features/post-editor/ui/post-form.tsx
@@ -6,7 +6,7 @@ import type {
   ReactNode,
 } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import archiveLinear from "@iconify-icons/solar/archive-linear";
 import checkCircleLinear from "@iconify-icons/solar/check-circle-linear";
 import disketteLinear from "@iconify-icons/solar/diskette-linear";

--- a/src/features/post-editor/ui/thumbnail-uploader.tsx
+++ b/src/features/post-editor/ui/thumbnail-uploader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import clipboardLinear from "@iconify-icons/solar/clipboard-linear";
 import galleryWideLinear from "@iconify-icons/solar/gallery-wide-linear";
 import linkMinimalistic2Linear from "@iconify-icons/solar/link-minimalistic-2-linear";

--- a/src/features/post-list/ui/post-list-item.tsx
+++ b/src/features/post-list/ui/post-list-item.tsx
@@ -1,4 +1,4 @@
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import chatRoundDotsLinear from "@iconify-icons/solar/chat-round-dots-linear";
 import eyeLinear from "@iconify-icons/solar/eye-linear";
 import pinBold from "@iconify-icons/solar/pin-bold";

--- a/src/features/post-list/ui/post-list.tsx
+++ b/src/features/post-list/ui/post-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Suspense } from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import documentTextLinear from "@iconify-icons/solar/document-text-linear";
 import { useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";

--- a/src/features/search/ui/search-empty-state.tsx
+++ b/src/features/search/ui/search-empty-state.tsx
@@ -1,4 +1,4 @@
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import magniferLinear from "@iconify-icons/solar/magnifer-linear";
 import magniferZoomInLinear from "@iconify-icons/solar/magnifer-zoom-in-linear";
 

--- a/src/features/search/ui/search-form.tsx
+++ b/src/features/search/ui/search-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import magniferLinear from "@iconify-icons/solar/magnifer-linear";
 import { useRouter } from "next/navigation";
 import type { SearchFilter } from "@entities/post";

--- a/src/features/search/ui/search-result-item.tsx
+++ b/src/features/search/ui/search-result-item.tsx
@@ -1,4 +1,4 @@
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import chatRoundDotsLinear from "@iconify-icons/solar/chat-round-dots-linear";
 import eyeLinear from "@iconify-icons/solar/eye-linear";
 import Link from "next/link";

--- a/src/features/toc/ui/toc-section.tsx
+++ b/src/features/toc/ui/toc-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { type MouseEvent, useEffect, useState } from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import listLinear from "@iconify-icons/solar/list-linear";
 import type { TocItem } from "@shared/lib/markdown";
 import { cn } from "@shared/lib/style-utils";

--- a/src/shared/ui/libs/archive-header.tsx
+++ b/src/shared/ui/libs/archive-header.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import altArrowRightLinear from "@iconify-icons/solar/alt-arrow-right-linear";
 import Link from "next/link";
 import { formatNumber } from "@shared/lib/format-number";

--- a/src/shared/ui/libs/error-content.tsx
+++ b/src/shared/ui/libs/error-content.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import dangerTriangleLinear from "@iconify-icons/solar/danger-triangle-linear";
 import linkMinimalistic2Linear from "@iconify-icons/solar/link-minimalistic-2-linear";
 import refreshLinear from "@iconify-icons/solar/refresh-linear";

--- a/src/widgets/admin-comments/ui/comment-detail-modal.tsx
+++ b/src/widgets/admin-comments/ui/comment-detail-modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import closeCircleLinear from "@iconify-icons/solar/close-circle-linear";
 import lockKeyholeLinear from "@iconify-icons/solar/lock-keyhole-linear";
 import trashBinMinimalisticLinear from "@iconify-icons/solar/trash-bin-minimalistic-linear";

--- a/src/widgets/admin-comments/ui/comment-filters.tsx
+++ b/src/widgets/admin-comments/ui/comment-filters.tsx
@@ -7,7 +7,7 @@ import {
   type DateRange,
   type MonthCaptionProps,
 } from "react-day-picker";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import calendarLinear from "@iconify-icons/solar/calendar-linear";
 import closeCircleLinear from "@iconify-icons/solar/close-circle-linear";
 import magniferLinear from "@iconify-icons/solar/magnifer-linear";

--- a/src/widgets/admin-comments/ui/comment-table.tsx
+++ b/src/widgets/admin-comments/ui/comment-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import lockKeyholeLinear from "@iconify-icons/solar/lock-keyhole-linear";
 import restartLinear from "@iconify-icons/solar/restart-linear";
 import trashBinMinimalisticLinear from "@iconify-icons/solar/trash-bin-minimalistic-linear";

--- a/src/widgets/admin-post-list/ui/bulk-actions.tsx
+++ b/src/widgets/admin-post-list/ui/bulk-actions.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useId, useMemo, useRef, useState } from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import altArrowDownLinear from "@iconify-icons/solar/alt-arrow-down-linear";
 import restartLinear from "@iconify-icons/solar/restart-linear";
 import type { AdminPostTab } from "./post-filters";

--- a/src/widgets/admin-post-list/ui/post-filters.tsx
+++ b/src/widgets/admin-post-list/ui/post-filters.tsx
@@ -9,7 +9,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import altArrowDownLinear from "@iconify-icons/solar/alt-arrow-down-linear";
 import magniferLinear from "@iconify-icons/solar/magnifer-linear";
 import type { Category } from "@entities/category";

--- a/src/widgets/admin-post-list/ui/post-table.tsx
+++ b/src/widgets/admin-post-list/ui/post-table.tsx
@@ -2,7 +2,7 @@
 
 import type { ComponentProps, ReactNode } from "react";
 import { useState } from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import altArrowDownLinear from "@iconify-icons/solar/alt-arrow-down-linear";
 import altArrowUpLinear from "@iconify-icons/solar/alt-arrow-up-linear";
 import chatRoundDotsLinear from "@iconify-icons/solar/chat-round-dots-linear";

--- a/src/widgets/admin-sidebar/ui/admin-sidebar.tsx
+++ b/src/widgets/admin-sidebar/ui/admin-sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useTransition } from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import arrowLeftLinear from "@iconify-icons/solar/arrow-left-linear";
 import chart2Linear from "@iconify-icons/solar/chart-2-linear";
 import chatRoundDotsLinear from "@iconify-icons/solar/chat-round-dots-linear";
@@ -122,7 +122,7 @@ function AdminLogoutButton({
         className,
       )}
     >
-      <Icon icon={logout2Linear} width="18" aria-hidden="true" />
+      <Icon icon={logout2Linear} width="18" height="18" aria-hidden="true" />
       {iconOnly ? null : <span>로그아웃</span>}
     </button>
   );
@@ -155,6 +155,7 @@ function SidebarNav({ collapsed = false, onItemClick }: SidebarNavProps) {
                 <Icon
                   icon={item.icon}
                   width="20"
+                  height="20"
                   aria-hidden="true"
                   className="shrink-0"
                 />
@@ -335,6 +336,7 @@ export function AdminSidebar({
             <Icon
               icon={sidebarMinimalisticLinear}
               width="18"
+              height="18"
               aria-hidden="true"
             />
           </button>
@@ -351,7 +353,13 @@ export function AdminSidebar({
             )}
             title="블로그로 돌아가기"
           >
-            <Icon icon={arrowLeftLinear} width="16" aria-hidden="true" />
+            <Icon
+              icon={arrowLeftLinear}
+              width="16"
+              height="16"
+              aria-hidden="true"
+              className="shrink-0"
+            />
             <span
               className={cn(
                 "truncate transition-[margin,width,opacity] duration-200",
@@ -409,6 +417,7 @@ export function AdminSidebar({
                 <Icon
                   icon={hamburgerMenuLinear}
                   width="18"
+                  height="18"
                   aria-hidden="true"
                 />
               </button>
@@ -422,7 +431,13 @@ export function AdminSidebar({
                 onClick={onClose}
                 className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-text-3 transition-colors hover:bg-background-3 hover:text-text-1"
               >
-                <Icon icon={arrowLeftLinear} width="16" aria-hidden="true" />
+                <Icon
+                  icon={arrowLeftLinear}
+                  width="16"
+                  height="16"
+                  aria-hidden="true"
+                  className="shrink-0"
+                />
                 <span>블로그로 돌아가기</span>
               </Link>
             </div>

--- a/src/widgets/dashboard/ui/post-status-section.tsx
+++ b/src/widgets/dashboard/ui/post-status-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import archiveLinear from "@iconify-icons/solar/archive-linear";
 import checkCircleLinear from "@iconify-icons/solar/check-circle-linear";
 import documentTextLinear from "@iconify-icons/solar/document-text-linear";

--- a/src/widgets/dashboard/ui/recent-comments-section.tsx
+++ b/src/widgets/dashboard/ui/recent-comments-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import lockLinear from "@iconify-icons/solar/lock-linear";
 import trashBinMinimalisticLinear from "@iconify-icons/solar/trash-bin-minimalistic-linear";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";

--- a/src/widgets/dashboard/ui/stats-section.tsx
+++ b/src/widgets/dashboard/ui/stats-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import chart2Linear from "@iconify-icons/solar/chart-2-linear";
 import eyeLinear from "@iconify-icons/solar/eye-linear";
 import graphUpLinear from "@iconify-icons/solar/graph-up-linear";

--- a/src/widgets/footer/index.tsx
+++ b/src/widgets/footer/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import letterLinear from "@iconify-icons/solar/letter-linear";
 import linkMinimalistic2Linear from "@iconify-icons/solar/link-minimalistic-2-linear";
 import Link from "next/link";

--- a/src/widgets/header/index.tsx
+++ b/src/widgets/header/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import hamburgerMenuLinear from "@iconify-icons/solar/hamburger-menu-linear";
 import Link from "next/link";
 import { cn } from "@shared/lib/style-utils";

--- a/src/widgets/header/search-bar.tsx
+++ b/src/widgets/header/search-bar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import magniferLinear from "@iconify-icons/solar/magnifer-linear";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { cn } from "@shared/lib/style-utils";

--- a/src/widgets/header/theme-button.tsx
+++ b/src/widgets/header/theme-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import moonLinear from "@iconify-icons/solar/moon-linear";
 import sun2Linear from "@iconify-icons/solar/sun-2-linear";
 import { useTheme } from "@app-layer/theme";

--- a/src/widgets/public-sidebar/ui/public-sidebar.tsx
+++ b/src/widgets/public-sidebar/ui/public-sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState, type ReactNode } from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify/react/offline";
 import altArrowRightLinear from "@iconify-icons/solar/alt-arrow-right-linear";
 import closeCircleLinear from "@iconify-icons/solar/close-circle-linear";
 import eyeLinear from "@iconify-icons/solar/eye-linear";
@@ -143,7 +143,15 @@ export function PublicSidebarContent({
       {categories.some((c) => c.isVisible) && (
         <SidebarSection
           title={`카테고리 (${visibleCategoryCount})`}
-          icon={<Icon icon={folder2Linear} width="13" aria-hidden="true" />}
+          icon={
+            <Icon
+              icon={folder2Linear}
+              width="13"
+              height="13"
+              aria-hidden="true"
+              className="shrink-0"
+            />
+          }
           action={
             <Link
               href="/categories"
@@ -151,7 +159,13 @@ export function PublicSidebarContent({
               className="inline-flex items-center gap-0.5 text-ui-xs font-medium text-primary-1 underline-offset-4 hover:underline"
             >
               전체보기
-              <Icon icon={altArrowRightLinear} width="10" aria-hidden="true" />
+              <Icon
+                icon={altArrowRightLinear}
+                width="10"
+                height="10"
+                aria-hidden="true"
+                className="shrink-0"
+              />
             </Link>
           }
         >
@@ -167,14 +181,28 @@ export function PublicSidebarContent({
       {tags.length > 0 && (
         <SidebarSection
           title="태그"
-          icon={<Icon icon={tagLinear} width="13" aria-hidden="true" />}
+          icon={
+            <Icon
+              icon={tagLinear}
+              width="13"
+              height="13"
+              aria-hidden="true"
+              className="shrink-0"
+            />
+          }
           action={
             <Link
               href="/tags"
               className="inline-flex items-center gap-0.5 text-ui-xs font-medium text-primary-1 underline-offset-4 hover:underline"
             >
               전체보기
-              <Icon icon={altArrowRightLinear} width="10" aria-hidden="true" />
+              <Icon
+                icon={altArrowRightLinear}
+                width="10"
+                height="10"
+                aria-hidden="true"
+                className="shrink-0"
+              />
             </Link>
           }
         >
@@ -185,7 +213,15 @@ export function PublicSidebarContent({
       {totalViews !== null && (
         <SidebarSection
           title="블로그 조회수"
-          icon={<Icon icon={eyeLinear} width="13" aria-hidden="true" />}
+          icon={
+            <Icon
+              icon={eyeLinear}
+              width="13"
+              height="13"
+              aria-hidden="true"
+              className="shrink-0"
+            />
+          }
         >
           <TotalViewCount totalPageviews={totalViews.totalPageviews} />
         </SidebarSection>
@@ -215,7 +251,12 @@ export function PublicSidebarPanel({
           aria-label="메뉴 닫기"
           className="flex h-9 w-9 items-center justify-center rounded-lg text-text-3 transition-colors hover:bg-background-3"
         >
-          <Icon icon={closeCircleLinear} width="20" aria-hidden="true" />
+          <Icon
+            icon={closeCircleLinear}
+            width="20"
+            height="20"
+            aria-hidden="true"
+          />
         </button>
       </div>
 


### PR DESCRIPTION
## Summary

Closes #368

강력 새로고침/cold cache에서 Iconify 아이콘이 초기 빈 span으로 렌더되는 문제를 줄이고, 핵심 UI 폰트를 먼저 요청하도록 preload를 추가합니다.

## Changes

| File | Change |
|------|--------|
| `src/**/*.tsx` | 정적 Solar 아이콘 사용처를 `@iconify/react/offline`으로 전환해 첫 렌더부터 SVG가 출력되도록 변경 |
| `src/widgets/public-sidebar/ui/public-sidebar.tsx` | public sidebar 섹션/액션/닫기 아이콘에 명시적 width/height와 shrink 처리를 추가 |
| `src/widgets/admin-sidebar/ui/admin-sidebar.tsx` | admin sidebar 내비게이션/액션 아이콘에 명시적 height와 고정 크기 처리를 추가 |
| `src/app/layout.tsx` | NanumSquareNeo regular/bold woff2 preload를 추가해 주요 UI 폰트 지연 적용을 완화 |

## Screenshots

N/A
