### PR TITLE
fix: apply admin trash deleted filter (#372)

### DIFF
--- a/src/app/manage/posts/page.tsx
+++ b/src/app/manage/posts/page.tsx
@@ -132,7 +132,7 @@ export default function ManagePostsPage() {
         q: searchQuery || undefined,
         sort,
         order,
-        includeDeleted: tab === "trash",
+        deletedState: tab === "trash" ? "deleted" : undefined,
       }),
   });
 

--- a/src/entities/post/api.ts
+++ b/src/entities/post/api.ts
@@ -79,6 +79,10 @@ function buildSearchParams(
     searchParams.set("includeDeleted", String(params.includeDeleted));
   }
 
+  if ("deletedState" in params && params.deletedState !== undefined) {
+    searchParams.set("deletedState", params.deletedState);
+  }
+
   return searchParams.toString();
 }
 

--- a/src/entities/post/model.ts
+++ b/src/entities/post/model.ts
@@ -118,6 +118,7 @@ export interface FetchAdminPostsParams {
   sort?: "published_at" | "created_at" | "totalPageviews" | "commentCount";
   order?: "asc" | "desc";
   includeDeleted?: boolean;
+  deletedState?: "active" | "deleted" | "all";
 }
 
 export interface BulkPostAction {

--- a/stories/mocks/post-list-handlers.ts
+++ b/stories/mocks/post-list-handlers.ts
@@ -1,9 +1,29 @@
 import { http, HttpResponse } from "msw";
-import type { BulkPostAction, Post, UpdatePostBody } from "@entities/post";
+import type {
+  BulkPostAction,
+  FetchAdminPostsParams,
+  Post,
+  UpdatePostBody,
+} from "@entities/post";
 import { mockCategories } from "./data/categories";
 import { mockMeta, mockPosts } from "./data/posts";
 
 const API_BASE_URL = "http://localhost:5500";
+type DeletedState = NonNullable<FetchAdminPostsParams["deletedState"]>;
+
+function getDeletedState(searchParams: URLSearchParams): DeletedState {
+  const deletedState = searchParams.get("deletedState");
+
+  if (
+    deletedState === "active" ||
+    deletedState === "deleted" ||
+    deletedState === "all"
+  ) {
+    return deletedState;
+  }
+
+  return searchParams.get("includeDeleted") === "true" ? "all" : "active";
+}
 
 function createSeedPosts() {
   return mockPosts.map((post, index): Post => ({
@@ -16,7 +36,7 @@ function createSeedPosts() {
 function filterPosts(
   posts: Post[],
   searchParams: URLSearchParams,
-  includeDeleted: boolean,
+  deletedState: DeletedState,
 ) {
   const status = searchParams.get("status");
   const visibility = searchParams.get("visibility");
@@ -24,7 +44,11 @@ function filterPosts(
   const query = searchParams.get("q")?.trim().toLowerCase();
 
   return posts.filter((post) => {
-    if (Boolean(post.deletedAt) !== includeDeleted) {
+    if (deletedState === "active" && post.deletedAt) {
+      return false;
+    }
+
+    if (deletedState === "deleted" && !post.deletedAt) {
       return false;
     }
 
@@ -157,9 +181,12 @@ export function createPostListHandlers(options?: {
       }
 
       const url = new URL(request.url);
-      const includeDeleted = url.searchParams.get("includeDeleted") === "true";
-      const source = includeDeleted ? trashPosts : activePosts;
-      const filtered = filterPosts(source, url.searchParams, includeDeleted);
+      const deletedState = getDeletedState(url.searchParams);
+      const filtered = filterPosts(
+        [...activePosts, ...trashPosts],
+        url.searchParams,
+        deletedState,
+      );
       const sorted = sortPosts(filtered, url.searchParams);
 
       return HttpResponse.json(paginatePosts(sorted, url.searchParams));


### PR DESCRIPTION
## Summary

Closes #372

Admin post trash tab now requests the backend's explicit deleted-only filter instead of legacy `includeDeleted=true`, which means "include deleted posts in the full result set."

## Changes

| File | Change |
|------|--------|
| `src/entities/post/model.ts` | Added the `deletedState` admin post list query parameter type. |
| `src/entities/post/api.ts` | Serializes `deletedState` into `/admin/posts` query strings. |
| `src/app/manage/posts/page.tsx` | Uses `deletedState=deleted` for the trash tab while keeping the active tab on the default active-only query. |
| `stories/mocks/post-list-handlers.ts` | Updated MSW behavior so `includeDeleted=true` means all posts and `deletedState=deleted` means deleted-only. |
