### PR TITLE
refactor: disable admin link prefetch (#373)

### DIFF
--- a/src/app/manage/posts/page.tsx
+++ b/src/app/manage/posts/page.tsx
@@ -540,6 +540,7 @@ export default function ManagePostsPage() {
           action={
             <Link
               href="/manage/posts/new"
+              prefetch={false}
               className="inline-flex items-center justify-center rounded-lg bg-primary-1 px-4 py-2.5 text-body-sm font-semibold text-white transition-opacity hover:opacity-90"
             >
               새 글 작성

--- a/src/shared/ui/libs/error-content.tsx
+++ b/src/shared/ui/libs/error-content.tsx
@@ -103,6 +103,7 @@ export function ErrorContent({
             {action.type === "link" ? (
               <Link
                 href={action.href}
+                prefetch={context === "admin" ? false : undefined}
                 className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl bg-primary-1 px-5 py-2.5 text-ui-sm font-semibold text-white transition-all duration-300 hover:-translate-y-0.5 hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-1/35"
               >
                 <Icon

--- a/src/widgets/admin-comments/ui/comment-detail-modal.tsx
+++ b/src/widgets/admin-comments/ui/comment-detail-modal.tsx
@@ -316,6 +316,7 @@ function DetailView({
             {comment.post ? (
               <Link
                 href={`/manage/posts/${comment.postId}/preview`}
+                prefetch={false}
                 className="inline-flex min-h-6 items-end gap-1 cursor-pointer text-primary-1 transition-colors hover:text-primary-2 hover:underline"
                 target="_blank"
               >
@@ -572,6 +573,7 @@ function ThreadView({
               <span className="text-sm text-text-3">글:</span>
               <Link
                 href={`/manage/posts/${postId}/preview`}
+                prefetch={false}
                 className="inline-flex min-h-6 items-end gap-1 cursor-pointer text-sm text-primary-1 transition-colors hover:text-primary-2 hover:underline"
                 target="_blank"
               >

--- a/src/widgets/admin-comments/ui/comment-table.tsx
+++ b/src/widgets/admin-comments/ui/comment-table.tsx
@@ -170,6 +170,7 @@ export function CommentTable({
                     {item.post ? (
                       <Link
                         href={`/manage/posts/${item.postId}/preview`}
+                        prefetch={false}
                         onClick={(event) => event.stopPropagation()}
                         className="block max-w-[12rem] truncate text-sm leading-none text-primary-1 transition-colors hover:underline"
                       >

--- a/src/widgets/admin-post-list/ui/post-table.tsx
+++ b/src/widgets/admin-post-list/ui/post-table.tsx
@@ -211,6 +211,7 @@ function TableActionButton({
     return (
       <Link
         href={href}
+        prefetch={false}
         aria-label={ariaLabel}
         className={className}
         onClick={(event) => event.stopPropagation()}

--- a/src/widgets/admin-post-preview/ui/post-preview.tsx
+++ b/src/widgets/admin-post-preview/ui/post-preview.tsx
@@ -98,6 +98,7 @@ export function PostPreview({ post, renderedContent }: PostPreviewProps) {
       <div className="flex flex-wrap items-center gap-3 rounded-[1.75rem] border border-border-3 bg-background-2 p-4 shadow-[0px_18px_60px_0px_rgba(0,0,0,0.06)]">
         <Link
           href="/manage/posts"
+          prefetch={false}
           className="inline-flex items-center gap-1.5 rounded-[0.75rem] border border-border-3 px-3 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
         >
           ← 목록
@@ -105,6 +106,7 @@ export function PostPreview({ post, renderedContent }: PostPreviewProps) {
 
         <Link
           href={`/manage/posts/${currentPost.id}/edit`}
+          prefetch={false}
           className="inline-flex items-center rounded-[0.75rem] border border-border-3 px-3 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
         >
           수정

--- a/src/widgets/admin-sidebar/ui/admin-sidebar.tsx
+++ b/src/widgets/admin-sidebar/ui/admin-sidebar.tsx
@@ -141,6 +141,7 @@ function SidebarNav({ collapsed = false, onItemClick }: SidebarNavProps) {
             <li key={item.path}>
               <Link
                 href={item.path}
+                prefetch={false}
                 onClick={onItemClick}
                 className={cn(
                   "flex items-center rounded-lg px-3 py-2 text-sm transition-all",
@@ -296,6 +297,7 @@ export function AdminSidebar({
         >
           <Link
             href="/manage"
+            prefetch={false}
             className={cn(
               "flex min-w-0 items-center text-primary-1 transition-[width] duration-200",
               isCollapsed ? "w-0 overflow-hidden" : "w-auto",
@@ -347,6 +349,7 @@ export function AdminSidebar({
         <div className="mt-auto px-3 pb-4">
           <Link
             href="/"
+            prefetch={false}
             className={cn(
               "flex items-center rounded-lg px-3 py-2 text-sm text-text-3 transition-colors hover:bg-background-3 hover:text-text-1",
               isCollapsed ? "justify-center px-0" : "",
@@ -399,6 +402,7 @@ export function AdminSidebar({
             >
               <Link
                 href="/manage"
+                prefetch={false}
                 onClick={onClose}
                 className="flex items-center gap-2 text-primary-1"
               >
@@ -428,6 +432,7 @@ export function AdminSidebar({
             <div className="mt-auto px-3 pb-4">
               <Link
                 href="/"
+                prefetch={false}
                 onClick={onClose}
                 className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-text-3 transition-colors hover:bg-background-3 hover:text-text-1"
               >

--- a/src/widgets/dashboard/ui/post-status-section.tsx
+++ b/src/widgets/dashboard/ui/post-status-section.tsx
@@ -127,6 +127,7 @@ export function PostStatusSection() {
           <Link
             key={label}
             href={href}
+            prefetch={false}
             className="rounded-xl border border-border-4 bg-background-2 p-5 transition-all duration-200 hover:-translate-y-0.5 hover:border-primary-1/40"
           >
             <div className="flex items-center gap-2">

--- a/src/widgets/dashboard/ui/recent-comments-section.tsx
+++ b/src/widgets/dashboard/ui/recent-comments-section.tsx
@@ -334,6 +334,7 @@ export function RecentCommentsSection() {
         </span>
         <Link
           href="/manage/comments"
+          prefetch={false}
           className="ml-auto text-sm text-primary-1 transition-colors hover:text-primary-2"
         >
           전체보기


### PR DESCRIPTION
## Summary

Closes #373

Admin routes render authenticated, dynamic data, so this disables automatic Next.js route prefetch on admin-rendered internal links that do not need speculative RSC requests.

## Changes

| File | Change |
|------|--------|
| `src/widgets/admin-sidebar/ui/admin-sidebar.tsx` | Disabled automatic prefetch for admin navigation and the admin shell blog-return links. |
| `src/widgets/admin-post-list/ui/post-table.tsx` | Disabled automatic prefetch for post preview action links. |
| `src/widgets/admin-comments/ui/comment-table.tsx` | Disabled automatic prefetch for comment post preview links. |
| `src/widgets/admin-comments/ui/comment-detail-modal.tsx` | Disabled automatic prefetch for preview links in comment detail and thread views. |
| `src/widgets/admin-post-preview/ui/post-preview.tsx` | Disabled automatic prefetch for preview page list/edit links. |
| `src/widgets/dashboard/ui/recent-comments-section.tsx` | Disabled automatic prefetch for the recent comments full-list link. |
| `src/widgets/dashboard/ui/post-status-section.tsx` | Disabled automatic prefetch for dashboard post status cards. |
| `src/app/manage/posts/page.tsx` | Disabled automatic prefetch for the new-post link. |

## Verification

- `pnpm compile:types`
- `pnpm lint` (passes with existing warnings in `image-gallery-modal.tsx` and `error-boundary.tsx`)
- `pnpm build`
