### PR TITLE
refactor: add admin session cleanup boundary (#375)

### DIFF
--- a/src/app-layer/provider/query-provider.tsx
+++ b/src/app-layer/provider/query-provider.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { PropsWithChildren, useState } from "react";
+import { PropsWithChildren, useEffect, useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { registerClientSessionCleanup } from "@shared/api";
 
 function makeQueryClient() {
   return new QueryClient({
@@ -29,6 +30,12 @@ function getQueryClient() {
 
 export function QueryProvider({ children }: PropsWithChildren) {
   const [queryClient] = useState(() => getQueryClient());
+
+  useEffect(() => {
+    return registerClientSessionCleanup(() => {
+      queryClient.clear();
+    });
+  }, [queryClient]);
 
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>

--- a/src/entities/asset/api.ts
+++ b/src/entities/asset/api.ts
@@ -6,6 +6,7 @@ import {
   clientFetch,
   clientMutate,
   getCsrfToken,
+  handleManageAuthBoundaryFailure,
 } from "@shared/api";
 import { normalizeAssetUrl } from "@shared/lib/asset-url";
 
@@ -62,6 +63,8 @@ export async function uploadAssets(
         statusCode: xhr.status,
         message: xhr.statusText,
       };
+      handleManageAuthBoundaryFailure(xhr.status);
+
       try {
         const error: ApiError = JSON.parse(xhr.responseText) as ApiError;
         reject(new ApiResponseError(error));

--- a/src/features/admin-login/ui/login-form.tsx
+++ b/src/features/admin-login/ui/login-form.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { login } from "@entities/auth";
+import { runClientSessionCleanup } from "@shared/api";
 import { getErrorMessage } from "@shared/lib/get-error-message";
 import { Spinner } from "@shared/ui/libs";
 
@@ -14,6 +15,10 @@ export function LoginForm() {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const busy = isLoading || isPending;
+
+  useEffect(() => {
+    runClientSessionCleanup();
+  }, []);
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -81,7 +81,7 @@ export async function serverFetch<T>(
 
 /**
  * Client Components 용 fetch. 브라우저 쿠키를 자동으로 포함.
- * /manage 경로에서 403 응답 시 /manage/login?reason=forbidden 으로 리다이렉트.
+ * /manage 경로에서 인증 경계 응답 시 /manage/login 으로 리다이렉트.
  */
 export async function clientFetch<T>(
   path: string,
@@ -95,13 +95,13 @@ export async function clientFetch<T>(
     credentials: "include",
   });
 
-  if (
-    response.status === 403 &&
-    handleManageAuthBoundaryFailure(response.status)
-  ) {
+  if (handleManageAuthBoundaryFailure(response.status)) {
     throw new ApiResponseError({
-      statusCode: 403,
-      message: "접근 권한이 없습니다",
+      statusCode: response.status,
+      message:
+        response.status === 403
+          ? "접근 권한이 없습니다"
+          : "로그인이 필요합니다",
     });
   }
 

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,3 +1,4 @@
+import { handleManageAuthBoundaryFailure } from "./session-cleanup";
 import { ApiResponseError, type ApiError } from "./types";
 
 const PUBLIC_API_URL =
@@ -96,9 +97,8 @@ export async function clientFetch<T>(
 
   if (
     response.status === 403 &&
-    window.location.pathname.startsWith("/manage")
+    handleManageAuthBoundaryFailure(response.status)
   ) {
-    window.location.href = "/manage/login?reason=forbidden";
     throw new ApiResponseError({
       statusCode: 403,
       message: "접근 권한이 없습니다",

--- a/src/shared/api/csrf.ts
+++ b/src/shared/api/csrf.ts
@@ -1,4 +1,5 @@
 import { clientFetch } from "./client";
+import { registerClientSessionCleanup } from "./session-cleanup";
 
 let tokenPromise: Promise<string> | null = null;
 
@@ -18,3 +19,5 @@ export async function getCsrfToken(): Promise<string> {
 export function clearCsrfToken(): void {
   tokenPromise = null;
 }
+
+registerClientSessionCleanup(clearCsrfToken);

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -3,3 +3,8 @@ export { ApiResponseError } from "./types";
 export type { PaginatedResponse, ApiError } from "./types";
 export { getCsrfToken, clearCsrfToken } from "./csrf";
 export { clientMutate } from "./mutation";
+export {
+  handleManageAuthBoundaryFailure,
+  registerClientSessionCleanup,
+  runClientSessionCleanup,
+} from "./session-cleanup";

--- a/src/shared/api/session-cleanup.ts
+++ b/src/shared/api/session-cleanup.ts
@@ -1,0 +1,51 @@
+type ClientSessionCleanupCallback = () => void;
+
+const cleanupCallbacks = new Set<ClientSessionCleanupCallback>();
+
+let isCleanupRunning = false;
+
+export function registerClientSessionCleanup(
+  callback: ClientSessionCleanupCallback,
+): () => void {
+  cleanupCallbacks.add(callback);
+
+  return () => {
+    cleanupCallbacks.delete(callback);
+  };
+}
+
+export function runClientSessionCleanup(): void {
+  if (isCleanupRunning) {
+    return;
+  }
+
+  isCleanupRunning = true;
+
+  try {
+    Array.from(cleanupCallbacks).forEach((callback) => {
+      try {
+        callback();
+      } catch (error) {
+        console.warn("[Session Cleanup] cleanup callback failed", error);
+      }
+    });
+  } finally {
+    isCleanupRunning = false;
+  }
+}
+
+export function handleManageAuthBoundaryFailure(status: number): boolean {
+  if (
+    typeof window === "undefined" ||
+    !window.location.pathname.startsWith("/manage") ||
+    (status !== 401 && status !== 403)
+  ) {
+    return false;
+  }
+
+  runClientSessionCleanup();
+  window.location.href =
+    status === 403 ? "/manage/login?reason=forbidden" : "/manage/login";
+
+  return true;
+}

--- a/src/shared/api/session-cleanup.ts
+++ b/src/shared/api/session-cleanup.ts
@@ -35,11 +35,13 @@ export function runClientSessionCleanup(): void {
 }
 
 export function handleManageAuthBoundaryFailure(status: number): boolean {
-  if (
-    typeof window === "undefined" ||
-    !window.location.pathname.startsWith("/manage") ||
-    (status !== 401 && status !== 403)
-  ) {
+  if (typeof window === "undefined" || (status !== 401 && status !== 403)) {
+    return false;
+  }
+
+  const pathname = window.location.pathname;
+
+  if (!pathname.startsWith("/manage") || pathname === "/manage/login") {
     return false;
   }
 

--- a/src/widgets/admin-sidebar/ui/admin-sidebar.tsx
+++ b/src/widgets/admin-sidebar/ui/admin-sidebar.tsx
@@ -13,7 +13,6 @@ import logout2Linear from "@iconify-icons/solar/logout-2-linear";
 import notebookLinear from "@iconify-icons/solar/notebook-linear";
 import penNewRoundLinear from "@iconify-icons/solar/pen-new-round-linear";
 import sidebarMinimalisticLinear from "@iconify-icons/solar/sidebar-minimalistic-linear";
-import { useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { toast } from "sonner";
@@ -22,7 +21,7 @@ import {
   ADMIN_CHROME_STYLE,
 } from "@app/manage/ui/admin-shell-constants";
 import { logout } from "@entities/auth";
-import { clearCsrfToken } from "@shared/api";
+import { runClientSessionCleanup } from "@shared/api";
 import { cn } from "@shared/lib/style-utils";
 import { ThemeButton } from "@widgets/header/theme-button";
 import { LogoIcon } from "@widgets/logo/ui/logo-icon";
@@ -98,14 +97,12 @@ function AdminLogoutButton({
   className?: string;
 }) {
   const router = useRouter();
-  const queryClient = useQueryClient();
   const [isPending, startTransition] = useTransition();
 
   async function handleLogout() {
     try {
       await logout();
-      queryClient.clear();
-      clearCsrfToken();
+      runClientSessionCleanup();
       startTransition(() => {
         router.push("/manage/login");
         router.refresh();


### PR DESCRIPTION
## Summary

Closes #375

Admin authentication boundaries now run a shared client-session cleanup path so stale admin React Query data and cached CSRF token promises are cleared before login redirects or login-page rendering.

## Changes

| File | Change |
|------|--------|
| `src/shared/api/session-cleanup.ts` | Added a defensive cleanup registry plus a manage auth-boundary failure helper. |
| `src/shared/api/csrf.ts` | Registered `clearCsrfToken()` with the shared cleanup path. |
| `src/app-layer/provider/query-provider.tsx` | Registered `queryClient.clear()` as a cleanup callback. |
| `src/features/admin-login/ui/login-form.tsx` | Runs cleanup when the login page renders. |
| `src/shared/api/client.ts` | Runs cleanup before the existing admin 403 login redirect. |
| `src/entities/asset/api.ts` | Runs the same auth-boundary cleanup/redirect handling for XHR upload 401/403 failures. |
| `src/widgets/admin-sidebar/ui/admin-sidebar.tsx` | Reuses the shared cleanup helper after successful logout. |

## Verification

- `pnpm compile:types`
- `pnpm lint` (passes with existing warnings in unrelated files)
- `pnpm build`
