### PR TITLE
refactor: standardize query keys (#376)

### DIFF
--- a/src/app/manage/posts/[id]/edit/page.tsx
+++ b/src/app/manage/posts/[id]/edit/page.tsx
@@ -5,7 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useParams, useRouter } from "next/navigation";
 import { PostEditorScreen } from "../../post-editor-screen";
 import type { PostFormValues } from "@features/post-editor";
-import { fetchAdminPost } from "@entities/post";
+import { adminPostKeys, fetchAdminPost } from "@entities/post";
 import { ApiResponseError } from "@shared/api";
 
 function getErrorMessage(error: unknown, fallback: string): string {
@@ -26,7 +26,7 @@ export default function DashboardPostEditPage() {
   const postId = Number(params.id);
 
   const postQuery = useQuery({
-    queryKey: ["admin-post", postId],
+    queryKey: adminPostKeys.detail(postId),
     queryFn: () => fetchAdminPost(postId),
     enabled: Number.isInteger(postId) && postId > 0,
   });

--- a/src/app/manage/posts/page.tsx
+++ b/src/app/manage/posts/page.tsx
@@ -4,9 +4,14 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { toast } from "sonner";
-import { fetchCategoriesAdmin, type Category } from "@entities/category";
+import {
+  adminCategoryKeys,
+  fetchCategoriesAdmin,
+  type Category,
+} from "@entities/category";
 import {
   MAX_PINNED_POSTS,
+  adminPostKeys,
   bulkUpdatePosts,
   deletePost,
   fetchAdminPosts,
@@ -51,7 +56,7 @@ function hasBulkDetails(
   );
 }
 
-function getQueryKey(
+function getQueryParams(
   tab: AdminPostTab,
   page: number,
   status: AdminPostStatusFilter,
@@ -61,17 +66,17 @@ function getQueryKey(
   sort: FetchAdminPostsParams["sort"],
   order: SortOrder,
 ) {
-  return [
-    "admin-posts",
-    tab,
+  return {
     page,
-    status,
-    visibility,
+    limit: PAGE_SIZE,
+    status: status === "all" ? undefined : status,
+    visibility: visibility === "all" ? undefined : visibility,
     categoryId,
-    q,
+    q: q || undefined,
     sort,
     order,
-  ] as const;
+    deletedState: tab === "trash" ? "deleted" : undefined,
+  } satisfies FetchAdminPostsParams;
 }
 
 function flattenCategories(
@@ -109,7 +114,7 @@ export default function ManagePostsPage() {
   const [isRestoreCategoryPending, setIsRestoreCategoryPending] =
     useState(false);
 
-  const queryKey = getQueryKey(
+  const queryParams = getQueryParams(
     tab,
     page,
     status,
@@ -119,30 +124,20 @@ export default function ManagePostsPage() {
     sort,
     order,
   );
+  const queryKey = adminPostKeys.list(queryParams);
 
   const { data, isPending, isError, error, refetch, isFetching } = useQuery({
     queryKey,
-    queryFn: () =>
-      fetchAdminPosts({
-        page,
-        limit: PAGE_SIZE,
-        status: status === "all" ? undefined : status,
-        visibility: visibility === "all" ? undefined : visibility,
-        categoryId,
-        q: searchQuery || undefined,
-        sort,
-        order,
-        deletedState: tab === "trash" ? "deleted" : undefined,
-      }),
+    queryFn: () => fetchAdminPosts(queryParams),
   });
 
   const { data: categories = [] } = useQuery({
-    queryKey: ["categories-admin"],
+    queryKey: adminCategoryKeys.tree(),
     queryFn: (): Promise<Category[]> => fetchCategoriesAdmin(),
     staleTime: 5 * 60 * 1000,
   });
   const { data: pinnedCount } = useQuery({
-    queryKey: ["admin-posts", "pinned-count"],
+    queryKey: adminPostKeys.pinnedCount(),
     queryFn: fetchPinnedPostCount,
     staleTime: 30 * 1000,
   });
@@ -277,9 +272,9 @@ export default function ManagePostsPage() {
 
       await updatePost(post.id, { isPinned: nextPinned });
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["admin-posts"] }),
+        queryClient.invalidateQueries({ queryKey: adminPostKeys.all() }),
         queryClient.invalidateQueries({
-          queryKey: ["admin-posts", "pinned-count"],
+          queryKey: adminPostKeys.pinnedCount(),
         }),
       ]);
     } catch (err) {
@@ -313,9 +308,9 @@ export default function ManagePostsPage() {
 
   async function invalidatePostQueries() {
     await Promise.all([
-      queryClient.invalidateQueries({ queryKey: ["admin-posts"] }),
+      queryClient.invalidateQueries({ queryKey: adminPostKeys.all() }),
       queryClient.invalidateQueries({
-        queryKey: ["admin-posts", "pinned-count"],
+        queryKey: adminPostKeys.pinnedCount(),
       }),
     ]);
   }

--- a/src/entities/asset/index.ts
+++ b/src/entities/asset/index.ts
@@ -1,4 +1,5 @@
 export type { Asset, UploadedAsset } from "./model";
+export { adminAssetKeys } from "./query-keys";
 export { fetchAssets, uploadAssets, deleteAsset, deleteAssets } from "./api";
 export { AssetPickerModal } from "./ui/asset-picker-modal";
 export {

--- a/src/entities/asset/query-keys.ts
+++ b/src/entities/asset/query-keys.ts
@@ -1,0 +1,21 @@
+export interface AdminAssetListKeyParams {
+  page?: number;
+  limit?: number;
+}
+
+function normalizeAdminAssetListParams(params: AdminAssetListKeyParams = {}) {
+  return {
+    page: params.page,
+    limit: params.limit,
+  };
+}
+
+export const adminAssetKeys = {
+  all: () => ["admin", "assets"] as const,
+  list: (params: AdminAssetListKeyParams = {}) =>
+    [
+      ...adminAssetKeys.all(),
+      "list",
+      normalizeAdminAssetListParams(params),
+    ] as const,
+};

--- a/src/entities/asset/ui/asset-picker-modal.tsx
+++ b/src/entities/asset/ui/asset-picker-modal.tsx
@@ -8,6 +8,7 @@ import {
   formatAssetResolution,
   getAssetFilename,
 } from "../lib";
+import { adminAssetKeys } from "../query-keys";
 import type { Asset } from "../model";
 import { getErrorMessage } from "@shared/lib/get-error-message";
 import { cn } from "@shared/lib/style-utils";
@@ -30,7 +31,7 @@ export function AssetPickerModal({
   const [selectedAssetId, setSelectedAssetId] = useState<number | null>(null);
 
   const assetsQuery = useQuery({
-    queryKey: ["asset-picker-assets", page],
+    queryKey: adminAssetKeys.list({ page, limit: PAGE_SIZE }),
     queryFn: () => fetchAssets(page, PAGE_SIZE),
     enabled: isOpen,
   });

--- a/src/entities/category/index.ts
+++ b/src/entities/category/index.ts
@@ -10,6 +10,7 @@ export type {
   UpdateCategoryTreeBody,
 } from "./model";
 export { findCategoryBySlug, getCategoryAncestors } from "./lib";
+export { adminCategoryKeys, publicCategoryKeys } from "./query-keys";
 export {
   deleteCategories,
   createCategory,

--- a/src/entities/category/query-keys.ts
+++ b/src/entities/category/query-keys.ts
@@ -1,0 +1,9 @@
+export const publicCategoryKeys = {
+  all: () => ["public", "categories"] as const,
+  tree: () => [...publicCategoryKeys.all(), "tree"] as const,
+};
+
+export const adminCategoryKeys = {
+  all: () => ["admin", "categories"] as const,
+  tree: () => [...adminCategoryKeys.all(), "tree"] as const,
+};

--- a/src/entities/comment/index.ts
+++ b/src/entities/comment/index.ts
@@ -17,6 +17,7 @@ export type {
   AdminCommentStatus,
   FetchAdminCommentsParams,
 } from "./api";
+export { adminCommentKeys, publicCommentKeys } from "./query-keys";
 export {
   adminBulkOperateComments,
   adminDeleteComment,

--- a/src/entities/comment/query-keys.ts
+++ b/src/entities/comment/query-keys.ts
@@ -1,0 +1,53 @@
+import type { FetchAdminCommentsParams } from "./api";
+
+export interface PublicCommentListKeyParams {
+  page?: number;
+  limit?: number;
+}
+
+function normalizePublicCommentListParams(
+  params: PublicCommentListKeyParams = {},
+) {
+  return {
+    page: params.page,
+    limit: params.limit,
+  };
+}
+
+function normalizeAdminCommentListParams(
+  params: FetchAdminCommentsParams = {},
+) {
+  return {
+    page: params.page,
+    limit: params.limit,
+    postId: params.postId,
+    status: params.status,
+    authorType: params.authorType,
+    startDate: params.startDate,
+    endDate: params.endDate,
+  };
+}
+
+export const publicCommentKeys = {
+  all: () => ["public", "comments"] as const,
+  list: (postId: number, params: PublicCommentListKeyParams = {}) =>
+    [
+      ...publicCommentKeys.all(),
+      "list",
+      postId,
+      normalizePublicCommentListParams(params),
+    ] as const,
+};
+
+export const adminCommentKeys = {
+  all: () => ["admin", "comments"] as const,
+  list: (params: FetchAdminCommentsParams = {}) =>
+    [
+      ...adminCommentKeys.all(),
+      "list",
+      normalizeAdminCommentListParams(params),
+    ] as const,
+  thread: (id: number) => [...adminCommentKeys.all(), "thread", id] as const,
+  recentDashboard: () =>
+    [...adminCommentKeys.all(), "recent-dashboard"] as const,
+};

--- a/src/entities/comment/use-admin-comment-status-mutation.ts
+++ b/src/entities/comment/use-admin-comment-status-mutation.ts
@@ -9,13 +9,8 @@ import {
   adminRestoreComment,
   type AdminCommentItem,
 } from "./api";
+import { adminCommentKeys } from "./query-keys";
 import { getErrorMessage } from "@shared/lib/get-error-message";
-
-const ADMIN_COMMENTS_QUERY_KEY = ["admin-comments"] as const;
-const DASHBOARD_RECENT_COMMENTS_QUERY_KEY = [
-  "dashboard",
-  "recentComments",
-] as const;
 
 type AdminCommentStatusTransitionAction = "hide" | "restore" | "soft_delete";
 
@@ -126,9 +121,9 @@ export function useAdminCommentStatusMutation(
       options?.onSuccess?.(updatedComment);
 
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ADMIN_COMMENTS_QUERY_KEY }),
+        queryClient.invalidateQueries({ queryKey: adminCommentKeys.all() }),
         queryClient.invalidateQueries({
-          queryKey: DASHBOARD_RECENT_COMMENTS_QUERY_KEY,
+          queryKey: adminCommentKeys.recentDashboard(),
         }),
       ]);
 

--- a/src/entities/guestbook/index.ts
+++ b/src/entities/guestbook/index.ts
@@ -14,6 +14,7 @@ export type {
   FetchAdminGuestbookParams,
   GuestbookSettingsResponse,
 } from "./api";
+export { adminGuestbookKeys, publicGuestbookKeys } from "./query-keys";
 export {
   adminBulkDeleteGuestbookEntries,
   adminBulkPatchGuestbookEntries,

--- a/src/entities/guestbook/query-keys.ts
+++ b/src/entities/guestbook/query-keys.ts
@@ -1,0 +1,49 @@
+import type { FetchAdminGuestbookParams } from "./api";
+
+export interface PublicGuestbookListKeyParams {
+  page?: number;
+}
+
+function normalizePublicGuestbookListParams(
+  params: PublicGuestbookListKeyParams = {},
+) {
+  return {
+    page: params.page,
+  };
+}
+
+function normalizeAdminGuestbookListParams(
+  params: FetchAdminGuestbookParams = {},
+) {
+  return {
+    page: params.page,
+    limit: params.limit,
+    status: params.status,
+    authorType: params.authorType,
+    q: params.q,
+    startDate: params.startDate,
+    endDate: params.endDate,
+  };
+}
+
+export const publicGuestbookKeys = {
+  all: () => ["public", "guestbook"] as const,
+  list: (params: PublicGuestbookListKeyParams = {}) =>
+    [
+      ...publicGuestbookKeys.all(),
+      "list",
+      normalizePublicGuestbookListParams(params),
+    ] as const,
+  settings: () => [...publicGuestbookKeys.all(), "settings"] as const,
+};
+
+export const adminGuestbookKeys = {
+  all: () => ["admin", "guestbook"] as const,
+  list: (params: FetchAdminGuestbookParams = {}) =>
+    [
+      ...adminGuestbookKeys.all(),
+      "list",
+      normalizeAdminGuestbookListParams(params),
+    ] as const,
+  settings: () => [...adminGuestbookKeys.all(), "settings"] as const,
+};

--- a/src/entities/post/index.ts
+++ b/src/entities/post/index.ts
@@ -23,6 +23,7 @@ export type {
 export { SEARCH_FILTERS } from "./model";
 export { buildPostHref } from "@shared/lib/post-url";
 export { isPinnedPostLimitError, MAX_PINNED_POSTS } from "./lib";
+export { adminPostKeys, publicPostKeys } from "./query-keys";
 export {
   bulkUpdatePosts,
   fetchAdminPost,

--- a/src/entities/post/query-keys.ts
+++ b/src/entities/post/query-keys.ts
@@ -1,0 +1,56 @@
+import type { FetchAdminPostsParams, FetchPostsParams } from "./model";
+
+type PublicPostListKeyParams = FetchPostsParams & {
+  basePath?: string;
+};
+
+function normalizePublicPostListParams(params: PublicPostListKeyParams = {}) {
+  return {
+    page: params.page,
+    limit: params.limit,
+    categoryId: params.categoryId,
+    tagSlug: params.tagSlug,
+    q: params.q,
+    filter: params.filter,
+    basePath: params.basePath,
+  };
+}
+
+function normalizeAdminPostListParams(params: FetchAdminPostsParams = {}) {
+  return {
+    page: params.page,
+    limit: params.limit,
+    categoryId: params.categoryId,
+    tagSlug: params.tagSlug,
+    q: params.q,
+    status: params.status,
+    visibility: params.visibility,
+    sort: params.sort,
+    order: params.order,
+    includeDeleted: params.includeDeleted,
+    deletedState: params.deletedState,
+  };
+}
+
+export const publicPostKeys = {
+  all: () => ["public", "posts"] as const,
+  list: (params: PublicPostListKeyParams = {}) =>
+    [
+      ...publicPostKeys.all(),
+      "list",
+      normalizePublicPostListParams(params),
+    ] as const,
+  detail: (slug: string) => [...publicPostKeys.all(), "detail", slug] as const,
+};
+
+export const adminPostKeys = {
+  all: () => ["admin", "posts"] as const,
+  list: (params: FetchAdminPostsParams = {}) =>
+    [
+      ...adminPostKeys.all(),
+      "list",
+      normalizeAdminPostListParams(params),
+    ] as const,
+  detail: (id: number) => [...adminPostKeys.all(), "detail", id] as const,
+  pinnedCount: () => [...adminPostKeys.all(), "pinned-count"] as const,
+};

--- a/src/entities/stat/index.ts
+++ b/src/entities/stat/index.ts
@@ -1,4 +1,5 @@
 export type { DashboardStats, PopularPost, TotalViewsStats } from "./model";
+export { adminDashboardKeys } from "./query-keys";
 export {
   fetchDashboardStats,
   fetchPopularPosts,

--- a/src/entities/stat/query-keys.ts
+++ b/src/entities/stat/query-keys.ts
@@ -1,0 +1,4 @@
+export const adminDashboardKeys = {
+  all: () => ["admin", "dashboard"] as const,
+  stats: () => [...adminDashboardKeys.all(), "stats"] as const,
+};

--- a/src/entities/tag/index.ts
+++ b/src/entities/tag/index.ts
@@ -1,2 +1,3 @@
 export type { Tag } from "./model";
-export { fetchTags } from "./api";
+export { publicTagKeys } from "./query-keys";
+export { fetchTags, fetchTagsClient } from "./api";

--- a/src/entities/tag/query-keys.ts
+++ b/src/entities/tag/query-keys.ts
@@ -1,0 +1,4 @@
+export const publicTagKeys = {
+  all: () => ["public", "tags"] as const,
+  list: () => [...publicTagKeys.all(), "list"] as const,
+};

--- a/src/features/asset-uploader/ui/asset-uploader.tsx
+++ b/src/features/asset-uploader/ui/asset-uploader.tsx
@@ -7,6 +7,7 @@ import { AssetDetailModal } from "./asset-detail-modal";
 import { AssetGrid } from "./asset-grid";
 import { type PendingUploadFile, UploadZone } from "./upload-zone";
 import {
+  adminAssetKeys,
   buildAssetMarkdown,
   deleteAsset,
   deleteAssets,
@@ -28,7 +29,6 @@ const ACCEPTED_TYPES = new Set([
   "image/webp",
   "image/svg+xml",
 ]);
-const QUERY_KEY = ["admin-assets"] as const;
 const EMPTY_ASSETS: Asset[] = [];
 
 function generatePageNumbers(
@@ -73,7 +73,7 @@ export function AssetUploader() {
   } | null>(null);
 
   const assetsQuery = useQuery({
-    queryKey: [...QUERY_KEY, page],
+    queryKey: adminAssetKeys.list({ page, limit: PAGE_SIZE }),
     queryFn: () => fetchAssets(page, PAGE_SIZE),
   });
 
@@ -90,7 +90,7 @@ export function AssetUploader() {
       setUploadProgress(null);
       setPage(1);
       clearPendingFiles();
-      await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      await queryClient.invalidateQueries({ queryKey: adminAssetKeys.all() });
     },
     onError: (error) => {
       setUploadProgress(null);
@@ -139,7 +139,7 @@ export function AssetUploader() {
       setDetailDeleteIndex(null);
       setSelectedIds((current) => current.filter((id) => !deletedSet.has(id)));
 
-      await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      await queryClient.invalidateQueries({ queryKey: adminAssetKeys.all() });
     },
     onError: (error) => {
       toast.error(getErrorMessage(error, "에셋 삭제에 실패했습니다."));

--- a/src/features/category-manager/ui/category-manager.tsx
+++ b/src/features/category-manager/ui/category-manager.tsx
@@ -12,6 +12,7 @@ import {
 } from "./category-form-modal";
 import { CategoryTree } from "./category-tree";
 import {
+  adminCategoryKeys,
   createCategory,
   deleteCategories,
   deleteCategory,
@@ -21,11 +22,10 @@ import {
   type Category,
   type CategoryTreeChange,
   type DeleteCategoryOptions,
+  publicCategoryKeys,
 } from "@entities/category";
 import { getErrorMessage } from "@shared/lib/get-error-message";
 import { Skeleton } from "@shared/ui/libs";
-
-const QUERY_KEY = ["admin-categories"] as const;
 
 type FormMode = "create" | "edit";
 
@@ -45,7 +45,7 @@ export function CategoryManager() {
   );
 
   const categoriesQuery = useQuery({
-    queryKey: QUERY_KEY,
+    queryKey: adminCategoryKeys.tree(),
     queryFn: () => fetchCategoriesAdmin(),
   });
 
@@ -55,12 +55,19 @@ export function CategoryManager() {
     [categories, formState.category],
   );
 
+  async function invalidateCategoryQueries() {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: adminCategoryKeys.tree() }),
+      queryClient.invalidateQueries({ queryKey: publicCategoryKeys.tree() }),
+    ]);
+  }
+
   const createMutation = useMutation({
     mutationFn: (values: CategoryFormValues) =>
       createCategory(toCreateCategoryBody(values)),
     onSuccess: async () => {
       setFormState({ open: false, mode: "create", category: null });
-      await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      await invalidateCategoryQueries();
     },
     onError: (error) => {
       toast.error(getErrorMessage(error, "카테고리 추가에 실패했습니다."));
@@ -72,7 +79,7 @@ export function CategoryManager() {
       updateCategory(id, toUpdateCategoryBody(values)),
     onSuccess: async () => {
       setFormState({ open: false, mode: "create", category: null });
-      await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      await invalidateCategoryQueries();
     },
     onError: (error) => {
       toast.error(getErrorMessage(error, "카테고리 수정에 실패했습니다."));
@@ -89,7 +96,7 @@ export function CategoryManager() {
     }) => deleteCategory(id, options),
     onSuccess: async () => {
       setCategoryToDelete(null);
-      await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      await invalidateCategoryQueries();
     },
     onError: (error) => {
       toast.error(getErrorMessage(error, "카테고리 삭제에 실패했습니다."));
@@ -105,7 +112,7 @@ export function CategoryManager() {
       options: DeleteCategoryOptions;
     }) => deleteCategories(ids, options),
     onSuccess: async (_data, variables) => {
-      await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      await invalidateCategoryQueries();
       toast.success(
         `선택한 카테고리 ${variables.ids.length}개를 삭제했습니다.`,
       );
@@ -126,7 +133,7 @@ export function CategoryManager() {
       await Promise.all(ids.map((id) => updateCategory(id, { isVisible })));
     },
     onSuccess: async (_data, variables) => {
-      await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      await invalidateCategoryQueries();
       toast.success(
         variables.isVisible
           ? "선택한 카테고리를 표시했습니다."
@@ -144,7 +151,7 @@ export function CategoryManager() {
     mutationFn: (category: Category) =>
       updateCategory(category.id, { isVisible: !category.isVisible }),
     onSuccess: async (_data, category) => {
-      await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      await invalidateCategoryQueries();
       toast.success(
         category.isVisible
           ? "카테고리를 숨겼습니다."
@@ -161,7 +168,7 @@ export function CategoryManager() {
   const treeUpdateMutation = useMutation({
     mutationFn: (changes: CategoryTreeChange[]) => updateCategoryTree(changes),
     onSuccess: async (_data, changes) => {
-      await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      await invalidateCategoryQueries();
       toast.success(`배치 편집 변경사항 ${changes.length}건을 저장했습니다.`);
     },
     onError: (error) => {

--- a/src/features/guestbook-manager/ui/guestbook-manager.tsx
+++ b/src/features/guestbook-manager/ui/guestbook-manager.tsx
@@ -15,12 +15,14 @@ import {
 import { GuestbookDetailModal } from "./guestbook-detail-modal";
 import { GuestbookTable, type GuestbookPeriodFilter } from "./guestbook-table";
 import {
+  adminGuestbookKeys,
   adminBulkDeleteGuestbookEntries,
   adminBulkPatchGuestbookEntries,
   adminDeleteGuestbookEntry,
   adminPatchGuestbookEntry,
   fetchAdminGuestbook,
   fetchGuestbookSettings,
+  publicGuestbookKeys,
   type AdminGuestbookAuthorType,
   type AdminGuestbookFilterStatus,
   type AdminGuestbookItem,
@@ -32,9 +34,6 @@ import { Skeleton, Spinner } from "@shared/ui/libs";
 import { ToggleSwitch } from "@shared/ui/toggle-switch";
 
 const PAGE_SIZE = 10;
-const QUERY_KEY = ["admin-guestbook"] as const;
-const SETTINGS_QUERY_KEY = ["guestbook-settings"] as const;
-
 type ActionContext =
   | {
       type: "single";
@@ -204,15 +203,15 @@ export function GuestbookManager() {
   const period = detectPeriodFilter(startDate, endDate);
 
   const guestbookQuery = useQuery({
-    queryKey: [
-      ...QUERY_KEY,
+    queryKey: adminGuestbookKeys.list({
       page,
+      limit: PAGE_SIZE,
       status,
       authorType,
-      startDate,
-      endDate,
-      searchQuery,
-    ],
+      startDate: startDate || undefined,
+      endDate: endDate || undefined,
+      q: searchQuery || undefined,
+    }),
     queryFn: () =>
       fetchAdminGuestbook({
         page,
@@ -227,14 +226,15 @@ export function GuestbookManager() {
   });
 
   const settingsQuery = useQuery({
-    queryKey: SETTINGS_QUERY_KEY,
+    queryKey: adminGuestbookKeys.settings(),
     queryFn: () => fetchGuestbookSettings(),
   });
 
   const settingMutation = useMutation({
     mutationFn: updateGuestbookSettings,
     onSuccess: async (response) => {
-      queryClient.setQueryData(SETTINGS_QUERY_KEY, response);
+      queryClient.setQueryData(adminGuestbookKeys.settings(), response);
+      queryClient.setQueryData(publicGuestbookKeys.settings(), response);
       toast.success(
         response.enabled
           ? "방명록 기능을 활성화했습니다."
@@ -282,8 +282,8 @@ export function GuestbookManager() {
     },
     onSuccess: async (_data, variables) => {
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: QUERY_KEY }),
-        queryClient.invalidateQueries({ queryKey: ["guestbook"] }),
+        queryClient.invalidateQueries({ queryKey: adminGuestbookKeys.all() }),
+        queryClient.invalidateQueries({ queryKey: publicGuestbookKeys.all() }),
       ]);
       setSelectedItems((current) => {
         const next = { ...current };

--- a/src/features/post-editor/ui/image-gallery-modal.tsx
+++ b/src/features/post-editor/ui/image-gallery-modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { fetchAssets, type Asset } from "@entities/asset";
+import { adminAssetKeys, fetchAssets, type Asset } from "@entities/asset";
 import { getErrorMessage } from "@shared/lib/get-error-message";
 import { Modal } from "@shared/ui/libs";
 
@@ -19,7 +19,7 @@ export function ImageGalleryModal({
   onSelectLocalFiles,
 }: ImageGalleryModalProps) {
   const assetsQuery = useQuery({
-    queryKey: ["post-editor-assets"],
+    queryKey: adminAssetKeys.list({ page: 1, limit: 12 }),
     queryFn: () => fetchAssets(1, 12),
     enabled: isOpen,
   });

--- a/src/features/post-editor/ui/post-form.tsx
+++ b/src/features/post-editor/ui/post-form.tsx
@@ -40,8 +40,14 @@ import { attachScrollSync } from "../lib/scroll-sync";
 import type { EditorView } from "@codemirror/view";
 import { AssetPickerModal } from "@entities/asset";
 import { type Asset } from "@entities/asset";
-import { fetchCategoriesAdmin, type Category } from "@entities/category";
 import {
+  adminCategoryKeys,
+  fetchCategoriesAdmin,
+  publicCategoryKeys,
+  type Category,
+} from "@entities/category";
+import {
+  adminPostKeys,
   createPost,
   updatePost,
   type CreatePostBody,
@@ -664,7 +670,7 @@ export function PostForm({
   }, [activeTab, editorView, isDesktopPreview]);
 
   const categoriesQuery = useQuery({
-    queryKey: ["categories", "admin"],
+    queryKey: adminCategoryKeys.tree(),
     queryFn: () => fetchCategoriesAdmin(),
   });
 
@@ -712,9 +718,12 @@ export function PostForm({
         signature: JSON.stringify(persistedValues),
       };
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["admin-posts"] }),
-        queryClient.invalidateQueries({ queryKey: ["admin-post", post.id] }),
-        queryClient.invalidateQueries({ queryKey: ["categories"] }),
+        queryClient.invalidateQueries({ queryKey: adminPostKeys.all() }),
+        queryClient.invalidateQueries({
+          queryKey: adminPostKeys.detail(post.id),
+        }),
+        queryClient.invalidateQueries({ queryKey: adminCategoryKeys.all() }),
+        queryClient.invalidateQueries({ queryKey: publicCategoryKeys.all() }),
       ]);
       onSuccess?.(post);
     },

--- a/src/features/post-editor/ui/tag-chip-input.tsx
+++ b/src/features/post-editor/ui/tag-chip-input.tsx
@@ -3,7 +3,7 @@
 import type { KeyboardEvent } from "react";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { fetchTagsClient } from "@entities/tag/api";
+import { fetchTagsClient, publicTagKeys } from "@entities/tag";
 import { useImeSafeText } from "@shared/hooks/use-ime-safe-text";
 import { getErrorMessage } from "@shared/lib/get-error-message";
 
@@ -41,8 +41,9 @@ export function TagChipInput({
   });
 
   const tagsQuery = useQuery({
-    queryKey: ["tags"],
+    queryKey: publicTagKeys.list(),
     queryFn: fetchTagsClient,
+    enabled: isFocused || inputValue.trim().length > 0,
   });
 
   const existingNames = useMemo(

--- a/src/features/post-list/ui/post-list.tsx
+++ b/src/features/post-list/ui/post-list.tsx
@@ -7,9 +7,12 @@ import { useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";
 import { PostListItem } from "./post-list-item";
 import { PostListItemSkeleton } from "./post-list-item-skeleton";
-import type { PublishedPostListItem as PostListEntry } from "@entities/post";
 import type { PaginatedResponse } from "@shared/api";
-import { fetchPosts } from "@entities/post";
+import {
+  fetchPosts,
+  publicPostKeys,
+  type PublishedPostListItem as PostListEntry,
+} from "@entities/post";
 import { Pagination } from "@shared/ui/libs";
 
 interface PostListProps {
@@ -78,7 +81,7 @@ function PostListInner({
   const page = Math.max(1, Number(pageParam) || 1);
 
   const { data, isLoading, isError } = useQuery({
-    queryKey: ["posts", basePath, page],
+    queryKey: publicPostKeys.list({ basePath, page }),
     queryFn: () => fetchPosts({ page }),
     initialData: page === initialPage ? initialData : undefined,
     staleTime: 30_000,

--- a/src/widgets/admin-comments/ui/admin-comments-page.tsx
+++ b/src/widgets/admin-comments/ui/admin-comments-page.tsx
@@ -16,6 +16,7 @@ import type {
 } from "./comment-filters";
 import {
   adminBulkOperateComments,
+  adminCommentKeys,
   adminDeleteComment,
   adminRestoreComment,
   fetchAdminCommentThread,
@@ -28,7 +29,6 @@ import { cn } from "@shared/lib/style-utils";
 import { EmptyState, Skeleton } from "@shared/ui/libs";
 
 const PAGE_SIZE = 10;
-const QUERY_KEY = ["admin-comments"] as const;
 const EMPTY_COMMENT_ROWS: AdminCommentItem[] = [];
 
 interface FilterState {
@@ -139,7 +139,7 @@ export function AdminCommentsPage() {
   );
 
   const queryKey = useMemo(
-    () => [...QUERY_KEY, queryParams] as const,
+    () => adminCommentKeys.list(queryParams),
     [queryParams],
   );
 
@@ -234,7 +234,7 @@ export function AdminCommentsPage() {
       }
       setActionContext(null);
       setCascadeCount(undefined);
-      await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      await queryClient.invalidateQueries({ queryKey: adminCommentKeys.all() });
       const actionLabel =
         variables.action === "restore"
           ? "복원"

--- a/src/widgets/admin-post-preview/ui/post-preview.tsx
+++ b/src/widgets/admin-post-preview/ui/post-preview.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import type { PostDetail } from "@entities/post";
 import {
+  adminPostKeys,
   deletePost,
   fetchPinnedPostCount,
   isPinnedPostLimitError,
@@ -45,7 +46,7 @@ export function PostPreview({ post, renderedContent }: PostPreviewProps) {
   const [currentPost, setCurrentPost] = useState(post);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const { data: pinnedCount } = useQuery({
-    queryKey: ["admin-posts", "pinned-count"],
+    queryKey: adminPostKeys.pinnedCount(),
     queryFn: fetchPinnedPostCount,
     staleTime: 30 * 1000,
   });
@@ -56,9 +57,9 @@ export function PostPreview({ post, renderedContent }: PostPreviewProps) {
     onSuccess: (updated) => {
       setCurrentPost(updated);
       void Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["admin-posts"] }),
+        queryClient.invalidateQueries({ queryKey: adminPostKeys.all() }),
         queryClient.invalidateQueries({
-          queryKey: ["admin-posts", "pinned-count"],
+          queryKey: adminPostKeys.pinnedCount(),
         }),
       ]);
     },
@@ -78,9 +79,9 @@ export function PostPreview({ post, renderedContent }: PostPreviewProps) {
     onSuccess: () => {
       toast.success("글이 삭제되었습니다.");
       void Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["admin-posts"] }),
+        queryClient.invalidateQueries({ queryKey: adminPostKeys.all() }),
         queryClient.invalidateQueries({
-          queryKey: ["admin-posts", "pinned-count"],
+          queryKey: adminPostKeys.pinnedCount(),
         }),
       ]);
       router.push("/manage/posts");

--- a/src/widgets/dashboard/ui/post-status-section.tsx
+++ b/src/widgets/dashboard/ui/post-status-section.tsx
@@ -7,7 +7,7 @@ import documentTextLinear from "@iconify-icons/solar/document-text-linear";
 import penNewRoundLinear from "@iconify-icons/solar/pen-new-round-linear";
 import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
-import { fetchDashboardStats } from "@entities/stat";
+import { adminDashboardKeys, fetchDashboardStats } from "@entities/stat";
 import { formatNumber } from "@shared/lib/format-number";
 import { Skeleton } from "@shared/ui/libs";
 
@@ -51,7 +51,7 @@ function PostStatusError({ onRetry }: { onRetry: () => void }) {
 
 export function PostStatusSection() {
   const { data, isLoading, isError, refetch } = useQuery({
-    queryKey: ["dashboard", "stats"],
+    queryKey: adminDashboardKeys.stats(),
     queryFn: fetchDashboardStats,
   });
 

--- a/src/widgets/dashboard/ui/recent-comments-section.tsx
+++ b/src/widgets/dashboard/ui/recent-comments-section.tsx
@@ -8,6 +8,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import {
   adminDeleteComment,
+  adminCommentKeys,
   adminRestoreComment,
   fetchAdminComments,
   fetchAdminCommentThread,
@@ -169,9 +170,6 @@ function CommentRow({
   );
 }
 
-const QUERY_KEY = ["dashboard", "recentComments"] as const;
-const ADMIN_COMMENTS_QUERY_KEY = ["admin-comments"] as const;
-
 function getAllowedActionsForStatus(status: AdminCommentItem["status"]) {
   if (status === "deleted") {
     return ["restore", "hard_delete"] as const;
@@ -200,7 +198,7 @@ export function RecentCommentsSection() {
   const cascadeRequestSeqRef = useRef(0);
 
   const { data, isLoading, isError, error, refetch } = useQuery({
-    queryKey: QUERY_KEY,
+    queryKey: adminCommentKeys.recentDashboard(),
     queryFn: () => fetchAdminComments({ limit: 5 }),
   });
   const statusMutation = useAdminCommentStatusMutation({
@@ -237,9 +235,11 @@ export function RecentCommentsSection() {
 
       setActionContext(null);
       setCascadeCount(undefined);
-      await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
       await queryClient.invalidateQueries({
-        queryKey: ADMIN_COMMENTS_QUERY_KEY,
+        queryKey: adminCommentKeys.recentDashboard(),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: adminCommentKeys.all(),
       });
     },
     onError: (err) => {

--- a/src/widgets/dashboard/ui/stats-section.tsx
+++ b/src/widgets/dashboard/ui/stats-section.tsx
@@ -5,7 +5,7 @@ import chart2Linear from "@iconify-icons/solar/chart-2-linear";
 import eyeLinear from "@iconify-icons/solar/eye-linear";
 import graphUpLinear from "@iconify-icons/solar/graph-up-linear";
 import { useQuery } from "@tanstack/react-query";
-import { fetchDashboardStats } from "@entities/stat";
+import { adminDashboardKeys, fetchDashboardStats } from "@entities/stat";
 import { formatNumber } from "@shared/lib/format-number";
 import { Skeleton } from "@shared/ui/libs";
 
@@ -77,7 +77,7 @@ const STAT_CARDS = [
 
 export function StatsSection() {
   const { data, isLoading, isError, refetch } = useQuery({
-    queryKey: ["dashboard", "stats"],
+    queryKey: adminDashboardKeys.stats(),
     queryFn: fetchDashboardStats,
   });
 


### PR DESCRIPTION
## Summary

Closes #376

Standardizes React Query cache keys with explicit public/admin namespaces and shared entity-level factories.

## Changes

| File | Change |
|------|--------|
| `src/entities/*/query-keys.ts` | Added public/admin query key factories for posts, categories, tags, comments, guestbook, assets, and dashboard stats. |
| `src/app/manage/posts/*`, `src/features/post-editor/*`, `src/widgets/admin-post-preview/*` | Replaced admin post/category literal keys with shared factories and normalized list params. |
| `src/features/asset-uploader/*`, `src/entities/asset/ui/*`, `src/features/post-editor/ui/image-gallery-modal.tsx` | Unified admin asset list keys by page/limit. |
| `src/widgets/admin-comments/*`, `src/widgets/dashboard/*`, `src/entities/comment/*` | Unified admin comments and recent dashboard comment invalidation keys. |
| `src/features/guestbook-manager/*` | Unified admin guestbook list/settings keys and separated public invalidation. |
| `src/features/post-list/*`, `src/features/post-editor/ui/tag-chip-input.tsx` | Switched public post/tag keys to factories and lazy-enabled tag suggestion loading. |

## Screenshots

Not applicable - cache key refactor with no UI changes.
