### PR TITLE
refactor: optimize public server fetch cache (#377)

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -16,7 +16,7 @@ export default async function PublicLayout({
   const [postsResponse, popularPosts, categories, tags, totalViews] =
     await Promise.all([
       fetchPosts({ limit: SIDEBAR_POST_LIMIT }).catch(() => ({ data: [] })),
-      fetchPopularPosts(7, undefined, SIDEBAR_POST_LIMIT).catch(() => null),
+      fetchPopularPosts(7, SIDEBAR_POST_LIMIT).catch(() => null),
       fetchCategories().catch(() => []),
       fetchTags().catch(() => []),
       fetchTotalViews().catch(() => null),

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -8,6 +8,8 @@ import {
 
 const RSS_POST_LIMIT = 20;
 
+export const dynamic = "force-dynamic";
+
 export async function GET() {
   const response = await fetchPosts({ limit: RSS_POST_LIMIT });
   const xml = buildRssXml(response.data);

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -9,6 +9,8 @@ const STATIC_ROUTES = [
   { path: "/tags", changeFrequency: "weekly", priority: 0.5 },
 ] as const;
 
+export const dynamic = "force-dynamic";
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const [slugsResponse, categories] = await Promise.all([
     fetchPublishedPostSlugs(),

--- a/src/entities/category/api.ts
+++ b/src/entities/category/api.ts
@@ -8,7 +8,13 @@ import type {
   UpdateCategoryOrderBody,
   UpdateCategoryTreeBody,
 } from "./model";
-import { clientFetch, clientMutate, serverFetch } from "@shared/api";
+import {
+  clientFetch,
+  clientMutate,
+  publicServerFetch,
+  serverFetch,
+  PUBLIC_CACHE_REVALIDATE_SECONDS,
+} from "@shared/api";
 
 interface CategoriesResponse {
   categories: Category[];
@@ -18,14 +24,10 @@ interface CategoryResponse {
   category: Category;
 }
 
-export async function fetchCategories(
-  cookieHeader?: string,
-): Promise<Category[]> {
-  const response = await serverFetch<CategoriesResponse>(
-    "/categories",
-    {},
-    cookieHeader,
-  );
+export async function fetchCategories(): Promise<Category[]> {
+  const response = await publicServerFetch<CategoriesResponse>("/categories", {
+    revalidate: PUBLIC_CACHE_REVALIDATE_SECONDS.taxonomy,
+  });
 
   return response.categories;
 }

--- a/src/entities/post/api.ts
+++ b/src/entities/post/api.ts
@@ -17,7 +17,9 @@ import {
   ApiResponseError,
   clientFetch,
   clientMutate,
+  publicServerFetch,
   serverFetch,
+  PUBLIC_CACHE_REVALIDATE_SECONDS,
 } from "@shared/api";
 import { normalizeOptionalAssetUrl } from "@shared/lib/asset-url";
 import { decodeSlug, encodeSlugPathSegment } from "@shared/lib/slug";
@@ -88,31 +90,28 @@ function buildSearchParams(
 
 export async function fetchPosts(
   params: FetchPostsParams = {},
-  cookieHeader?: string,
 ): Promise<PaginatedResponse<PublishedPostListItem>> {
   const queryString = buildPostSearchParams(params);
   const path = queryString ? `/posts?${queryString}` : "/posts";
 
-  const response = await serverFetch<PaginatedResponse<PublishedPostListItem>>(
-    path,
-    {},
-    cookieHeader,
-  );
+  const response = await publicServerFetch<
+    PaginatedResponse<PublishedPostListItem>
+  >(path, {
+    revalidate: PUBLIC_CACHE_REVALIDATE_SECONDS.postList,
+  });
 
   return normalizePostListResponse(response);
 }
 
 export async function fetchPostBySlug(
   slug: string,
-  cookieHeader?: string,
 ): Promise<PostDetailWithNavigationResponse> {
   const buildPath = (value: string) => `/posts/${encodeSlugPathSegment(value)}`;
 
   try {
-    const response = await serverFetch<PostDetailWithNavigationResponse>(
+    const response = await publicServerFetch<PostDetailWithNavigationResponse>(
       buildPath(slug),
-      {},
-      cookieHeader,
+      { revalidate: PUBLIC_CACHE_REVALIDATE_SECONDS.postDetail },
     );
 
     return {
@@ -130,10 +129,9 @@ export async function fetchPostBySlug(
       throw error;
     }
 
-    const response = await serverFetch<PostDetailWithNavigationResponse>(
+    const response = await publicServerFetch<PostDetailWithNavigationResponse>(
       buildPath(decodedSlug),
-      {},
-      cookieHeader,
+      { revalidate: PUBLIC_CACHE_REVALIDATE_SECONDS.postDetail },
     );
 
     return {
@@ -143,14 +141,10 @@ export async function fetchPostBySlug(
   }
 }
 
-export async function fetchPublishedPostSlugs(
-  cookieHeader?: string,
-): Promise<PublishedPostSlugsResponse> {
-  return serverFetch<PublishedPostSlugsResponse>(
-    "/posts/slugs",
-    {},
-    cookieHeader,
-  );
+export async function fetchPublishedPostSlugs(): Promise<PublishedPostSlugsResponse> {
+  return publicServerFetch<PublishedPostSlugsResponse>("/posts/slugs", {
+    revalidate: PUBLIC_CACHE_REVALIDATE_SECONDS.sitemap,
+  });
 }
 
 export async function fetchAdminPost(

--- a/src/entities/stat/api.ts
+++ b/src/entities/stat/api.ts
@@ -1,5 +1,9 @@
 import type { DashboardStats, PopularPost, TotalViewsStats } from "./model";
-import { clientFetch, serverFetch } from "@shared/api";
+import {
+  clientFetch,
+  publicServerFetch,
+  PUBLIC_CACHE_REVALIDATE_SECONDS,
+} from "@shared/api";
 
 interface PopularPostsResponse {
   data: PopularPost[];
@@ -20,13 +24,11 @@ export async function fetchDashboardStats(): Promise<DashboardStats> {
 
 export async function fetchPopularPosts(
   days: number,
-  cookieHeader?: string,
   limit = 10,
 ): Promise<PopularPost[]> {
-  const response = await serverFetch<PopularPostsResponse>(
+  const response = await publicServerFetch<PopularPostsResponse>(
     buildPopularPostsPath(days, limit),
-    {},
-    cookieHeader,
+    { revalidate: PUBLIC_CACHE_REVALIDATE_SECONDS.stats },
   );
 
   return response.data;
@@ -43,8 +45,8 @@ export async function fetchPopularPostsClient(
   return response.data;
 }
 
-export async function fetchTotalViews(
-  cookieHeader?: string,
-): Promise<TotalViewsStats> {
-  return serverFetch<TotalViewsStats>("/stats/total-views", {}, cookieHeader);
+export async function fetchTotalViews(): Promise<TotalViewsStats> {
+  return publicServerFetch<TotalViewsStats>("/stats/total-views", {
+    revalidate: PUBLIC_CACHE_REVALIDATE_SECONDS.stats,
+  });
 }

--- a/src/entities/tag/api.ts
+++ b/src/entities/tag/api.ts
@@ -1,12 +1,18 @@
 import type { Tag } from "./model";
-import { clientFetch, serverFetch } from "@shared/api";
+import {
+  clientFetch,
+  publicServerFetch,
+  PUBLIC_CACHE_REVALIDATE_SECONDS,
+} from "@shared/api";
 
 interface TagsResponse {
   tags: Tag[];
 }
 
-export async function fetchTags(cookieHeader?: string): Promise<Tag[]> {
-  const response = await serverFetch<TagsResponse>("/tags", {}, cookieHeader);
+export async function fetchTags(): Promise<Tag[]> {
+  const response = await publicServerFetch<TagsResponse>("/tags", {
+    revalidate: PUBLIC_CACHE_REVALIDATE_SECONDS.taxonomy,
+  });
 
   return response.tags;
 }

--- a/src/shared/api/cache-policy.ts
+++ b/src/shared/api/cache-policy.ts
@@ -1,0 +1,7 @@
+export const PUBLIC_CACHE_REVALIDATE_SECONDS = {
+  postList: 60,
+  postDetail: 60,
+  taxonomy: 300,
+  stats: 60,
+  sitemap: 300,
+} as const;

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -5,6 +5,23 @@ const PUBLIC_API_URL =
   process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5500";
 const INTERNAL_API_URL = process.env.API_URL ?? PUBLIC_API_URL;
 
+interface NextFetchConfig {
+  revalidate?: number | false;
+  tags?: string[];
+}
+
+export interface ServerFetchOptions extends RequestInit {
+  next?: NextFetchConfig;
+}
+
+interface PublicServerFetchOptions extends Omit<
+  ServerFetchOptions,
+  "cache" | "next"
+> {
+  revalidate: number;
+  tags?: string[];
+}
+
 function isJsonBody(body: BodyInit | null | undefined): boolean {
   if (!body) {
     return false;
@@ -55,16 +72,21 @@ async function handleResponse<T>(
   return response.json() as Promise<T>;
 }
 
+function shouldUseDefaultNoStore(options: ServerFetchOptions): boolean {
+  return options.cache === undefined && options.next?.revalidate === undefined;
+}
+
 /**
  * Server Components (RSC) 용 fetch. 쿠키를 headers에서 직접 전달.
  * context는 전달하지 않음 — 서버 사이드 에러 로깅은 이 이슈 범위 밖 (클라이언트 전용).
  */
 export async function serverFetch<T>(
   path: string,
-  options: RequestInit = {},
+  options: ServerFetchOptions = {},
   cookieHeader?: string,
 ): Promise<T> {
   const headers = new Headers(buildHeaders(options));
+  const cache = shouldUseDefaultNoStore(options) ? "no-store" : options.cache;
 
   if (cookieHeader) {
     headers.set("Cookie", cookieHeader);
@@ -73,10 +95,28 @@ export async function serverFetch<T>(
   const response = await fetch(`${INTERNAL_API_URL}${path}`, {
     ...options,
     headers,
-    cache: options.cache ?? "no-store",
+    ...(cache === undefined ? {} : { cache }),
   });
 
   return handleResponse<T>(response);
+}
+
+/**
+ * Public Server Components 용 fetch. 공개 데이터에만 시간 기반 revalidate를 명시한다.
+ */
+export async function publicServerFetch<T>(
+  path: string,
+  options: PublicServerFetchOptions,
+): Promise<T> {
+  const { revalidate, tags, ...requestOptions } = options;
+
+  return serverFetch<T>(path, {
+    ...requestOptions,
+    next: {
+      revalidate,
+      ...(tags ? { tags } : {}),
+    },
+  });
 }
 
 /**

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -1,4 +1,6 @@
-export { serverFetch, clientFetch } from "./client";
+export { serverFetch, publicServerFetch, clientFetch } from "./client";
+export type { ServerFetchOptions } from "./client";
+export { PUBLIC_CACHE_REVALIDATE_SECONDS } from "./cache-policy";
 export { ApiResponseError } from "./types";
 export type { PaginatedResponse, ApiError } from "./types";
 export { getCsrfToken, clearCsrfToken } from "./csrf";


### PR DESCRIPTION
## Summary

Closes #377

Public Server Component data fetches now opt into explicit time-based Next revalidation while the shared server fetch default stays `no-store` for admin/auth/user-specific data.

## Changes

| File | Change |
|------|--------|
| `src/shared/api/client.ts` | Added typed Next fetch options and `publicServerFetch()` so explicit `next.revalidate` does not get overwritten by the default `no-store`. |
| `src/shared/api/cache-policy.ts` | Added centralized public revalidate intervals for lists, detail, taxonomy, stats, and sitemap data. |
| `src/entities/post/api.ts` | Applied public cache policy to published list/detail/slugs fetches. |
| `src/entities/category/api.ts`, `src/entities/tag/api.ts`, `src/entities/stat/api.ts` | Applied public cache policy to public taxonomy/stat fetches while leaving admin/client fetches unchanged. |
| `src/app/rss.xml/route.ts`, `src/app/sitemap.ts` | Kept RSS and sitemap dynamic at build time so they do not require the API during `next build`. |
| `src/app/(public)/layout.tsx` | Updated the popular-post fetch call for the public-only signature. |

## Screenshots

Not applicable; no UI changes.

## Verification

- `pnpm compile:types`
- `pnpm lint` (passes with two existing warnings outside this change)
- `pnpm build`
