### PR TITLE
refactor: inject admin edit initial data (#378)

### DIFF
--- a/src/app/manage/posts/[id]/admin-post-cookie.ts
+++ b/src/app/manage/posts/[id]/admin-post-cookie.ts
@@ -1,0 +1,13 @@
+import { cookies } from "next/headers";
+
+export async function toAdminPostCookieHeader(): Promise<string | undefined> {
+  // await is a no-op in Next.js 14 but required in Next.js 15 where cookies() returns a Promise.
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get("sessionId");
+
+  if (!sessionCookie) {
+    return undefined;
+  }
+
+  return `${sessionCookie.name}=${encodeURIComponent(sessionCookie.value)}`;
+}

--- a/src/app/manage/posts/[id]/edit/page.tsx
+++ b/src/app/manage/posts/[id]/edit/page.tsx
@@ -1,87 +1,58 @@
-"use client";
-
-import { useMemo } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { useParams, useRouter } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { PostEditorScreen } from "../../post-editor-screen";
-import type { PostFormValues } from "@features/post-editor";
-import { adminPostKeys, fetchAdminPost } from "@entities/post";
+import { toAdminPostCookieHeader } from "../admin-post-cookie";
+import { fetchAdminPost } from "@entities/post";
+import { mapPostToFormValues } from "@features/post-editor/lib/post-form-values";
 import { ApiResponseError } from "@shared/api";
 
-function getErrorMessage(error: unknown, fallback: string): string {
-  if (error instanceof ApiResponseError) {
-    return error.message;
-  }
+export const dynamic = "force-dynamic";
 
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  return fallback;
+interface DashboardPostEditPageProps {
+  // Next.js 15: params is a Promise. await is a no-op in Next.js 14.
+  params: Promise<{ id: string }>;
 }
 
-export default function DashboardPostEditPage() {
-  const params = useParams<{ id: string }>();
-  const router = useRouter();
-  const postId = Number(params.id);
-
-  const postQuery = useQuery({
-    queryKey: adminPostKeys.detail(postId),
-    queryFn: () => fetchAdminPost(postId),
-    enabled: Number.isInteger(postId) && postId > 0,
-  });
-
-  const initialValues = useMemo<Partial<PostFormValues> | undefined>(() => {
-    if (!postQuery.data) {
-      return undefined;
-    }
-
-    return {
-      title: postQuery.data.title,
-      categoryId: postQuery.data.categoryId,
-      tags: postQuery.data.tags.map((tag) => tag.name),
-      status: postQuery.data.status,
-      visibility: postQuery.data.visibility,
-      commentStatus: postQuery.data.commentStatus ?? "open",
-      thumbnailUrl: postQuery.data.thumbnailUrl ?? "",
-      summary: postQuery.data.summary ?? "",
-      description: postQuery.data.description ?? "",
-      contentMd: postQuery.data.contentMd,
-    };
-  }, [postQuery.data]);
+export default async function DashboardPostEditPage({
+  params,
+}: DashboardPostEditPageProps) {
+  const { id: rawId } = await params;
+  const postId = Number(rawId);
 
   if (!Number.isInteger(postId) || postId <= 0) {
-    return (
-      <div className="rounded-[1.75rem] border border-negative-1/20 bg-negative-1/10 px-6 py-8">
-        <h1 className="text-lg font-semibold text-negative-1">
-          잘못된 글 ID입니다.
-        </h1>
-        <p className="mt-2 text-sm text-negative-1">
-          수정할 글을 다시 선택해 주세요.
-        </p>
-        <button
-          type="button"
-          onClick={() => router.push("/manage/posts")}
-          className="mt-4 inline-flex rounded-[0.75rem] border border-negative-1/20 px-4 py-2 text-sm font-medium text-negative-1 transition-colors hover:bg-negative-1/10"
-        >
-          목록으로 돌아가기
-        </button>
-      </div>
-    );
+    notFound();
   }
 
-  return (
-    <PostEditorScreen
-      mode="edit"
-      postId={postId}
-      initialValues={initialValues}
-      isPending={postQuery.isPending}
-      errorMessage={
-        postQuery.isError
-          ? getErrorMessage(postQuery.error, "잠시 후 다시 시도해 주세요.")
-          : null
+  const cookieHeader = await toAdminPostCookieHeader();
+
+  if (!cookieHeader) {
+    redirect("/manage/login");
+  }
+
+  try {
+    const post = await fetchAdminPost(postId, cookieHeader);
+
+    return (
+      <PostEditorScreen
+        mode="edit"
+        postId={postId}
+        initialValues={mapPostToFormValues(post)}
+      />
+    );
+  } catch (error) {
+    if (error instanceof ApiResponseError) {
+      if (error.statusCode === 404) {
+        notFound();
       }
-      onRetry={() => void postQuery.refetch()}
-    />
-  );
+
+      if (error.statusCode === 401) {
+        redirect("/manage/login");
+      }
+
+      if (error.statusCode === 403) {
+        redirect("/manage/login?reason=forbidden");
+      }
+    }
+
+    throw error;
+  }
 }

--- a/src/app/manage/posts/[id]/edit/page.tsx
+++ b/src/app/manage/posts/[id]/edit/page.tsx
@@ -2,7 +2,7 @@ import { notFound, redirect } from "next/navigation";
 import { PostEditorScreen } from "../../post-editor-screen";
 import { toAdminPostCookieHeader } from "../admin-post-cookie";
 import { fetchAdminPost } from "@entities/post";
-import { mapPostToFormValues } from "@features/post-editor/lib/post-form-values";
+import { mapPostToFormValues } from "@features/post-editor";
 import { ApiResponseError } from "@shared/api";
 
 export const dynamic = "force-dynamic";

--- a/src/app/manage/posts/[id]/preview/page.tsx
+++ b/src/app/manage/posts/[id]/preview/page.tsx
@@ -1,5 +1,5 @@
-import { cookies } from "next/headers";
 import { notFound } from "next/navigation";
+import { toAdminPostCookieHeader } from "../admin-post-cookie";
 import { fetchAdminPost } from "@entities/post";
 import { ApiResponseError } from "@shared/api";
 import { renderMarkdown } from "@shared/lib/markdown";
@@ -8,18 +8,6 @@ import { PostPreview } from "@widgets/admin-post-preview";
 interface PostPreviewPageProps {
   // Next.js 15: params is a Promise. await is a no-op in Next.js 14.
   params: Promise<{ id: string }>;
-}
-
-async function toCookieHeader(): Promise<string | undefined> {
-  // await is a no-op in Next.js 14 but required in Next.js 15 where cookies() returns a Promise.
-  const cookieStore = await cookies();
-  const sessionCookie = cookieStore.get("sessionId");
-
-  if (!sessionCookie) {
-    return undefined;
-  }
-
-  return `${sessionCookie.name}=${encodeURIComponent(sessionCookie.value)}`;
 }
 
 export default async function PostPreviewPage({
@@ -32,7 +20,7 @@ export default async function PostPreviewPage({
     notFound();
   }
 
-  const cookieHeader = await toCookieHeader();
+  const cookieHeader = await toAdminPostCookieHeader();
 
   try {
     const post = await fetchAdminPost(id, cookieHeader);

--- a/src/features/post-editor/index.ts
+++ b/src/features/post-editor/index.ts
@@ -1,7 +1,10 @@
 export { MarkdownEditor } from "./ui/markdown-editor";
 export { MarkdownPreview } from "./ui/markdown-preview";
 export { PostForm } from "./ui/post-form";
-export type { PostFormValues } from "./ui/post-form";
+export {
+  mapPostToFormValues,
+  type PostFormValues,
+} from "./lib/post-form-values";
 export {
   resolvePreviewContent,
   uploadPendingImages,

--- a/src/features/post-editor/lib/post-form-values.ts
+++ b/src/features/post-editor/lib/post-form-values.ts
@@ -1,0 +1,29 @@
+import type { PostDetail } from "@entities/post";
+
+export interface PostFormValues {
+  title: string;
+  categoryId: number | null;
+  tags: string[];
+  status: PostDetail["status"];
+  visibility: PostDetail["visibility"];
+  commentStatus: "open" | "locked" | "disabled";
+  thumbnailUrl: string;
+  summary: string;
+  description: string;
+  contentMd: string;
+}
+
+export function mapPostToFormValues(post: PostDetail): PostFormValues {
+  return {
+    title: post.title,
+    categoryId: post.categoryId,
+    tags: post.tags.map((tag) => tag.name),
+    status: post.status,
+    visibility: post.visibility,
+    commentStatus: post.commentStatus ?? "open",
+    thumbnailUrl: post.thumbnailUrl ?? "",
+    summary: post.summary ?? "",
+    description: post.description ?? "",
+    contentMd: post.contentMd,
+  };
+}

--- a/src/features/post-editor/ui/post-form.tsx
+++ b/src/features/post-editor/ui/post-form.tsx
@@ -36,6 +36,10 @@ import {
   insertMarkdownImage,
   insertMarkdownImages,
 } from "../lib/markdown-commands";
+import {
+  mapPostToFormValues,
+  type PostFormValues,
+} from "../lib/post-form-values";
 import { attachScrollSync } from "../lib/scroll-sync";
 import type { EditorView } from "@codemirror/view";
 import { AssetPickerModal } from "@entities/asset";
@@ -65,19 +69,6 @@ type SubmitIntent =
   | "archive"
   | "restore-draft"
   | "unpublish";
-
-export interface PostFormValues {
-  title: string;
-  categoryId: number | null;
-  tags: string[];
-  status: PostDetail["status"];
-  visibility: PostDetail["visibility"];
-  commentStatus: "open" | "locked" | "disabled";
-  thumbnailUrl: string;
-  summary: string;
-  description: string;
-  contentMd: string;
-}
 
 interface PostFormProps {
   mode?: "create" | "edit";
@@ -159,21 +150,6 @@ function buildPayload(values: PostFormValues): CreatePostBody {
     tags: values.tags.length > 0 ? values.tags : undefined,
     summary: normalizeOptionalText(values.summary),
     description: normalizeOptionalText(values.description),
-  };
-}
-
-function mapPostToFormValues(post: PostDetail): PostFormValues {
-  return {
-    title: post.title,
-    categoryId: post.categoryId,
-    tags: post.tags.map((tag) => tag.name),
-    status: post.status,
-    visibility: post.visibility,
-    commentStatus: post.commentStatus ?? "open",
-    thumbnailUrl: post.thumbnailUrl ?? "",
-    summary: post.summary ?? "",
-    description: post.description ?? "",
-    contentMd: post.contentMd,
   };
 }
 


### PR DESCRIPTION
## Summary

Closes #378

Moves the admin post edit page initial detail load into the Server Component render path so the edit form can receive hydrated initial values without a browser-side `/admin/posts/:id` waterfall.

## Changes

| File | Change |
|------|--------|
| `src/app/manage/posts/[id]/edit/page.tsx` | Converted edit route to a dynamic Server Component, validates IDs with `notFound()`, forwards only the `sessionId` cookie to the internal admin fetch, redirects auth failures, and passes initial form values directly to `PostEditorScreen`. |
| `src/app/manage/posts/[id]/admin-post-cookie.ts` | Added a shared helper for building the admin post cookie header from `cookies()`. |
| `src/app/manage/posts/[id]/preview/page.tsx` | Reused the shared cookie helper. |
| `src/features/post-editor/lib/post-form-values.ts` | Moved the `PostDetail` to `PostFormValues` mapper into a pure helper usable from server and client code. |
| `src/features/post-editor/ui/post-form.tsx` | Reused the shared mapper after save hydration. |

## Verification

- `pnpm compile:types`
- `pnpm lint` (passes with existing warnings in `image-gallery-modal.tsx` and `error-boundary.tsx`)
- `pnpm build`
