### PR TITLE
feat: add asset category UX (#381)

### DIFF
--- a/src/entities/asset/api.ts
+++ b/src/entities/asset/api.ts
@@ -1,4 +1,12 @@
-import type { Asset, UploadedAsset, UploadAssetsResponse } from "./model";
+import type {
+  Asset,
+  AssetCategory,
+  AssetListParams,
+  AssetUploadMetadata,
+  UploadedAsset,
+  UpdateAssetBody,
+  UploadAssetsResponse,
+} from "./model";
 import type { PaginatedResponse } from "@shared/api";
 import {
   ApiResponseError,
@@ -13,11 +21,25 @@ import { normalizeAssetUrl } from "@shared/lib/asset-url";
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5500";
 
 export async function fetchAssets(
-  page = 1,
+  pageOrParams: number | AssetListParams = 1,
   limit = 20,
 ): Promise<PaginatedResponse<Asset>> {
+  const params =
+    typeof pageOrParams === "number"
+      ? { page: pageOrParams, limit }
+      : pageOrParams;
+  const searchParams = new URLSearchParams();
+  searchParams.set("page", String(params.page ?? 1));
+  searchParams.set("limit", String(params.limit ?? 20));
+  if (params.categoryId) {
+    searchParams.set("categoryId", String(params.categoryId));
+  }
+  if (params.q?.trim()) {
+    searchParams.set("q", params.q.trim());
+  }
+
   const response = await clientFetch<PaginatedResponse<Asset>>(
-    `/assets?page=${page}&limit=${limit}`,
+    `/assets?${searchParams.toString()}`,
   );
 
   return {
@@ -29,12 +51,16 @@ export async function fetchAssets(
 export async function uploadAssets(
   files: File[],
   onProgress?: (percent: number) => void,
+  metadata: AssetUploadMetadata[] = [],
 ): Promise<UploadedAsset[]> {
   const formData = new FormData();
 
   files.forEach((file) => {
     formData.append("files", file);
   });
+  if (metadata.length > 0) {
+    formData.append("metadata", JSON.stringify(metadata));
+  }
 
   const csrfToken = await getCsrfToken();
 
@@ -81,6 +107,61 @@ export async function uploadAssets(
     xhr.withCredentials = true;
     xhr.setRequestHeader("x-csrf-token", csrfToken);
     xhr.send(formData);
+  });
+}
+
+export async function fetchAssetCategories(): Promise<AssetCategory[]> {
+  const response = await clientFetch<{ data: AssetCategory[] }>(
+    "/assets/categories",
+  );
+
+  return response.data;
+}
+
+export async function createAssetCategory(
+  name: string,
+): Promise<AssetCategory> {
+  return clientMutate<AssetCategory>("/assets/categories", {
+    method: "POST",
+    body: JSON.stringify({ name }),
+  });
+}
+
+export async function updateAssetCategory(
+  id: number,
+  body: { name?: string; sortOrder?: number },
+): Promise<AssetCategory> {
+  return clientMutate<AssetCategory>(`/assets/categories/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function deleteAssetCategory(id: number): Promise<void> {
+  await clientMutate<void>(`/assets/categories/${id}`, {
+    method: "DELETE",
+  });
+}
+
+export async function updateAsset(
+  id: number,
+  body: UpdateAssetBody,
+): Promise<Asset> {
+  const asset = await clientMutate<Asset>(`/assets/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+
+  return normalizeAsset(asset);
+}
+
+export async function updateAssetsCategory(
+  ids: number[],
+  categoryId: number,
+): Promise<void> {
+  await clientMutate<void>("/assets/bulk/category", {
+    method: "PATCH",
+    body: JSON.stringify({ ids, categoryId }),
   });
 }
 

--- a/src/entities/asset/index.ts
+++ b/src/entities/asset/index.ts
@@ -1,11 +1,34 @@
-export type { Asset, UploadedAsset } from "./model";
+export type {
+  Asset,
+  AssetCategory,
+  AssetDefaultCategoryKey,
+  AssetListParams,
+  AssetUploadMetadata,
+  UploadedAsset,
+  UpdateAssetBody,
+} from "./model";
 export { adminAssetKeys } from "./query-keys";
-export { fetchAssets, uploadAssets, deleteAsset, deleteAssets } from "./api";
+export {
+  createAssetCategory,
+  deleteAsset,
+  deleteAssetCategory,
+  deleteAssets,
+  fetchAssetCategories,
+  fetchAssets,
+  updateAsset,
+  updateAssetCategory,
+  updateAssetsCategory,
+  uploadAssets,
+} from "./api";
 export { AssetPickerModal } from "./ui/asset-picker-modal";
 export {
   buildAssetMarkdown,
+  findAssetCategoryByKey,
   formatAssetDate,
   formatAssetFileSize,
   formatAssetResolution,
+  getAssetCategoryTone,
+  getAssetDisplayName,
   getAssetFilename,
+  getInitialAssetDisplayName,
 } from "./lib";

--- a/src/entities/asset/lib.ts
+++ b/src/entities/asset/lib.ts
@@ -1,4 +1,4 @@
-import type { Asset } from "./model";
+import type { Asset, AssetCategory, AssetDefaultCategoryKey } from "./model";
 import { toCanonicalAssetUrl } from "@shared/lib/asset-url";
 
 const assetDateFormatter = new Intl.DateTimeFormat("ko-KR", {
@@ -43,8 +43,48 @@ export function formatAssetDate(createdAt: string): string {
   return assetDateFormatter.format(new Date(createdAt));
 }
 
-export function buildAssetMarkdown(asset: Pick<Asset, "url">): string {
+export function buildAssetMarkdown(
+  asset: Pick<Asset, "url"> & Partial<Pick<Asset, "displayName">>,
+): string {
   const canonicalUrl = toCanonicalAssetUrl(asset.url);
 
-  return `![${getAssetFilename(canonicalUrl)}](${canonicalUrl})`;
+  return `![${getAssetDisplayName({
+    url: canonicalUrl,
+    displayName: asset.displayName ?? null,
+  })}](${canonicalUrl})`;
+}
+
+export function getAssetDisplayName(
+  asset: Pick<Asset, "displayName" | "url">,
+): string {
+  return asset.displayName?.trim() || getAssetFilename(asset.url);
+}
+
+export function findAssetCategoryByKey(
+  categories: AssetCategory[],
+  key: AssetDefaultCategoryKey,
+): AssetCategory | null {
+  return categories.find((category) => category.key === key) ?? null;
+}
+
+export function getAssetCategoryTone(category: AssetCategory): string {
+  if (category.key === "thumbnail") {
+    return "border-primary-1/20 bg-primary-1/10 text-primary-1";
+  }
+
+  if (category.key === "default") {
+    return "border-positive-1/20 bg-positive-1/10 text-positive-1";
+  }
+
+  if (category.key === "uncategorized") {
+    return "border-border-3 bg-background-3 text-text-3";
+  }
+
+  return "border-info-1/20 bg-info-1/10 text-info-1";
+}
+
+export function getInitialAssetDisplayName(filename: string): string {
+  const withoutExtension = filename.replace(/\.[^./\\]+$/, "").trim();
+
+  return withoutExtension || filename;
 }

--- a/src/entities/asset/model.ts
+++ b/src/entities/asset/model.ts
@@ -1,6 +1,20 @@
+export type AssetDefaultCategoryKey = "thumbnail" | "default" | "uncategorized";
+
+export interface AssetCategory {
+  id: number;
+  key: AssetDefaultCategoryKey | (string & {}) | null;
+  name: string;
+  sortOrder: number;
+  isProtected: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface UploadedAsset {
   id: number;
   url: string;
+  displayName: string | null;
+  category: AssetCategory;
   mimeType: string;
   sizeBytes: number;
   width?: number;
@@ -13,4 +27,21 @@ export interface Asset extends UploadedAsset {
 
 export interface UploadAssetsResponse {
   assets: UploadedAsset[];
+}
+
+export interface AssetUploadMetadata {
+  displayName?: string | null;
+  categoryId?: number;
+}
+
+export interface AssetListParams {
+  page?: number;
+  limit?: number;
+  categoryId?: number | null;
+  q?: string;
+}
+
+export interface UpdateAssetBody {
+  displayName?: string | null;
+  categoryId?: number;
 }

--- a/src/entities/asset/query-keys.ts
+++ b/src/entities/asset/query-keys.ts
@@ -1,12 +1,16 @@
 export interface AdminAssetListKeyParams {
   page?: number;
   limit?: number;
+  categoryId?: number | null;
+  q?: string;
 }
 
 function normalizeAdminAssetListParams(params: AdminAssetListKeyParams = {}) {
   return {
     page: params.page,
     limit: params.limit,
+    categoryId: params.categoryId ?? null,
+    q: params.q?.trim() || undefined,
   };
 }
 
@@ -18,4 +22,5 @@ export const adminAssetKeys = {
       "list",
       normalizeAdminAssetListParams(params),
     ] as const,
+  categories: () => [...adminAssetKeys.all(), "categories"] as const,
 };

--- a/src/entities/asset/ui/asset-picker-modal.tsx
+++ b/src/entities/asset/ui/asset-picker-modal.tsx
@@ -1,15 +1,18 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { fetchAssets } from "../api";
+import { fetchAssetCategories, fetchAssets } from "../api";
 import {
   formatAssetFileSize,
   formatAssetResolution,
+  getAssetCategoryTone,
+  getAssetDisplayName,
   getAssetFilename,
 } from "../lib";
 import { adminAssetKeys } from "../query-keys";
-import type { Asset } from "../model";
+import type { Asset, AssetCategory } from "../model";
+import { normalizeAssetUrl, toCanonicalAssetUrl } from "@shared/lib/asset-url";
 import { getErrorMessage } from "@shared/lib/get-error-message";
 import { cn } from "@shared/lib/style-utils";
 import { Modal } from "@shared/ui/libs";
@@ -20,24 +23,74 @@ interface AssetPickerModalProps {
   isOpen: boolean;
   onSelect: (url: string) => void;
   onClose: () => void;
+  priorityUrls?: string[];
 }
 
 export function AssetPickerModal({
   isOpen,
   onSelect,
   onClose,
+  priorityUrls = [],
 }: AssetPickerModalProps) {
   const [page, setPage] = useState(1);
   const [selectedAssetId, setSelectedAssetId] = useState<number | null>(null);
+  const [categoryId, setCategoryId] = useState<number | null>(null);
+  const [search, setSearch] = useState("");
+  const [currentPostFirst, setCurrentPostFirst] = useState(true);
 
-  const assetsQuery = useQuery({
-    queryKey: adminAssetKeys.list({ page, limit: PAGE_SIZE }),
-    queryFn: () => fetchAssets(page, PAGE_SIZE),
+  const trimmedSearch = search.trim();
+  const priorityUrlSet = useMemo(
+    () =>
+      new Set(
+        priorityUrls
+          .map((url) => toCanonicalAssetUrl(url))
+          .filter((url) => url.length > 0),
+      ),
+    [priorityUrls],
+  );
+
+  const categoriesQuery = useQuery({
+    queryKey: adminAssetKeys.categories(),
+    queryFn: fetchAssetCategories,
     enabled: isOpen,
   });
 
-  const assets = assetsQuery.data?.data ?? [];
+  const assetsQuery = useQuery({
+    queryKey: adminAssetKeys.list({
+      page,
+      limit: PAGE_SIZE,
+      categoryId,
+      q: trimmedSearch,
+    }),
+    queryFn: () =>
+      fetchAssets({
+        page,
+        limit: PAGE_SIZE,
+        categoryId,
+        q: trimmedSearch || undefined,
+      }),
+    enabled: isOpen,
+  });
+
+  const rawAssets = assetsQuery.data?.data ?? [];
+  const assets = useMemo(() => {
+    if (!currentPostFirst || priorityUrlSet.size === 0) {
+      return rawAssets;
+    }
+
+    return [...rawAssets].sort((left, right) => {
+      const leftPriority = priorityUrlSet.has(toCanonicalAssetUrl(left.url));
+      const rightPriority = priorityUrlSet.has(toCanonicalAssetUrl(right.url));
+
+      if (leftPriority === rightPriority) {
+        return 0;
+      }
+
+      return leftPriority ? -1 : 1;
+    });
+  }, [currentPostFirst, priorityUrlSet, rawAssets]);
   const meta = assetsQuery.data?.meta;
+  const categories = categoriesQuery.data ?? [];
   const selectedAsset =
     assets.find((asset) => asset.id === selectedAssetId) ?? null;
 
@@ -45,14 +98,23 @@ export function AssetPickerModal({
     if (!isOpen) {
       setPage(1);
       setSelectedAssetId(null);
+      setCategoryId(null);
+      setSearch("");
+      setCurrentPostFirst(true);
     }
   }, [isOpen]);
 
   useEffect(() => {
+    setPage(1);
+  }, [categoryId, trimmedSearch]);
+
+  useEffect(() => {
     setSelectedAssetId((current) =>
-      current && assets.some((asset) => asset.id === current) ? current : null,
+      current && rawAssets.some((asset) => asset.id === current)
+        ? current
+        : null,
     );
-  }, [assets]);
+  }, [rawAssets]);
 
   return (
     <Modal
@@ -60,32 +122,90 @@ export function AssetPickerModal({
       onClose={onClose}
       withBackground
       aria-label="에셋 선택"
-      className="w-[min(94vw,72rem)] p-0 text-left"
+      className="w-[min(94vw,72rem)] p-0 text-left max-sm:w-screen max-sm:max-w-none"
     >
-      <div className="flex h-[min(88vh,56rem)] flex-col overflow-hidden rounded-[1.5rem] bg-background-1">
-        <div className="flex items-start justify-between gap-4 border-b border-border-3 px-6 py-5">
-          <div>
-            <p className="text-body-xs uppercase tracking-[0.2em] text-text-4">
-              Asset picker
-            </p>
-            <h2 className="mt-2 text-xl font-semibold text-text-1">
-              에셋 선택
-            </h2>
-            <p className="mt-1 text-sm text-text-3">
-              썸네일로 사용할 이미지를 선택하세요.
-            </p>
+      <div className="flex h-[min(88vh,56rem)] flex-col overflow-hidden rounded-[1.5rem] bg-background-1 max-sm:h-dvh max-sm:rounded-none">
+        <div className="border-b border-border-3 px-6 py-5">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-body-xs uppercase tracking-[0.2em] text-text-4">
+                Asset picker
+              </p>
+              <h2 className="mt-2 text-xl font-semibold text-text-1">
+                에셋 선택
+              </h2>
+              <p className="mt-1 text-sm text-text-3">
+                썸네일로 사용할 이미지를 선택하세요.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border-3 text-text-3 transition-colors hover:border-border-2 hover:text-text-1"
+              aria-label="에셋 선택 닫기"
+            >
+              ×
+            </button>
           </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border-3 text-text-3 transition-colors hover:border-border-2 hover:text-text-1"
-            aria-label="에셋 선택 닫기"
-          >
-            ×
-          </button>
+
+          <div className="mt-5 grid gap-3 lg:grid-cols-[minmax(0,1fr)_16rem]">
+            <CategoryChips
+              categories={categories}
+              selectedCategoryId={categoryId}
+              totalCount={meta?.total}
+              onSelect={setCategoryId}
+            />
+            <SelectedAssetSummary asset={selectedAsset} />
+          </div>
+
+          <div className="mt-3 grid gap-2 md:grid-cols-[minmax(0,1fr)_10rem] lg:grid-cols-[minmax(0,1fr)_12rem_10rem]">
+            <input
+              type="search"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="별명 또는 파일명 검색"
+              className="h-10 rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1"
+            />
+            <select
+              value={categoryId ?? ""}
+              onChange={(event) =>
+                setCategoryId(
+                  event.target.value ? Number(event.target.value) : null,
+                )
+              }
+              className="h-10 rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors focus:border-primary-1"
+              aria-label="에셋 카테고리"
+            >
+              <option value="">전체 카테고리</option>
+              {categories.map((category) => (
+                <option key={category.id} value={category.id}>
+                  {category.name}
+                </option>
+              ))}
+            </select>
+            <label className="inline-flex h-10 items-center gap-2 rounded-[0.75rem] border border-border-3 px-3 text-sm text-text-2">
+              <input
+                type="checkbox"
+                checked={currentPostFirst}
+                disabled={priorityUrlSet.size === 0}
+                onChange={(event) => setCurrentPostFirst(event.target.checked)}
+                className="accent-primary-1"
+              />
+              현재 글 우선
+            </label>
+          </div>
         </div>
 
         <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
+          {categoriesQuery.isError ? (
+            <div className="mb-4 rounded-[1rem] border border-warning-1/20 bg-warning-1/10 px-4 py-3 text-sm text-warning-1">
+              {getErrorMessage(
+                categoriesQuery.error,
+                "에셋 카테고리를 불러오지 못했습니다.",
+              )}
+            </div>
+          ) : null}
+
           {assetsQuery.isPending ? (
             <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
               {Array.from({ length: 6 }).map((_, index) => (
@@ -111,10 +231,10 @@ export function AssetPickerModal({
           assets.length === 0 ? (
             <div className="rounded-[1.25rem] border border-dashed border-border-3 px-6 py-12 text-center">
               <p className="text-lg font-semibold text-text-1">
-                에셋이 없습니다.
+                표시할 에셋이 없습니다.
               </p>
               <p className="mt-2 text-sm text-text-4">
-                먼저 에셋 관리 페이지에서 이미지를 업로드해 주세요.
+                검색어 또는 카테고리 필터를 변경해 보세요.
               </p>
             </div>
           ) : null}
@@ -127,6 +247,9 @@ export function AssetPickerModal({
                 <AssetPickerCard
                   key={asset.id}
                   asset={asset}
+                  isPriority={priorityUrlSet.has(
+                    toCanonicalAssetUrl(asset.url),
+                  )}
                   isSelected={selectedAssetId === asset.id}
                   onSelect={() => setSelectedAssetId(asset.id)}
                 />
@@ -140,7 +263,7 @@ export function AssetPickerModal({
             {meta
               ? meta.total === 0
                 ? "표시할 에셋이 없습니다."
-                : `총 ${meta.total}개 중 ${(meta.page - 1) * meta.limit + 1}-${(meta.page - 1) * meta.limit + assets.length}`
+                : `총 ${meta.total}개 중 ${(meta.page - 1) * meta.limit + 1}-${(meta.page - 1) * meta.limit + rawAssets.length}`
               : "페이지 정보를 불러오는 중입니다."}
           </div>
 
@@ -149,7 +272,7 @@ export function AssetPickerModal({
               type="button"
               onClick={() => setPage((current) => Math.max(1, current - 1))}
               disabled={!meta || meta.page <= 1}
-              className="inline-flex items-center justify-center rounded-[0.85rem] border border-border-3 px-3 py-2 text-sm text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex items-center justify-center rounded-[0.75rem] border border-border-3 px-3 py-2 text-sm text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
             >
               이전
             </button>
@@ -164,14 +287,14 @@ export function AssetPickerModal({
                 )
               }
               disabled={!meta || meta.page >= meta.totalPages}
-              className="inline-flex items-center justify-center rounded-[0.85rem] border border-border-3 px-3 py-2 text-sm text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex items-center justify-center rounded-[0.75rem] border border-border-3 px-3 py-2 text-sm text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
             >
               다음
             </button>
             <button
               type="button"
               onClick={onClose}
-              className="inline-flex items-center justify-center rounded-[0.85rem] border border-border-3 px-4 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
+              className="inline-flex items-center justify-center rounded-[0.75rem] border border-border-3 px-4 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
             >
               취소
             </button>
@@ -179,7 +302,7 @@ export function AssetPickerModal({
               type="button"
               onClick={() => selectedAsset && onSelect(selectedAsset.url)}
               disabled={!selectedAsset}
-              className="inline-flex items-center justify-center rounded-[0.85rem] bg-primary-1 px-4 py-2 text-sm font-semibold text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center justify-center rounded-[0.75rem] bg-primary-1 px-4 py-2 text-sm font-semibold text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
             >
               선택
             </button>
@@ -190,12 +313,101 @@ export function AssetPickerModal({
   );
 }
 
+function CategoryChips({
+  categories,
+  selectedCategoryId,
+  totalCount,
+  onSelect,
+}: {
+  categories: AssetCategory[];
+  selectedCategoryId: number | null;
+  totalCount?: number;
+  onSelect: (id: number | null) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <button
+        type="button"
+        onClick={() => onSelect(null)}
+        className={cn(
+          "inline-flex h-9 items-center gap-2 rounded-full border px-3 text-sm font-medium transition-colors",
+          selectedCategoryId === null
+            ? "border-primary-1/30 bg-primary-1/10 text-primary-1"
+            : "border-border-4 bg-background-1 text-text-2 hover:border-border-3 hover:bg-background-3",
+        )}
+      >
+        전체
+        {totalCount !== undefined ? (
+          <span className="text-xs opacity-70">{totalCount}</span>
+        ) : null}
+      </button>
+      {categories.map((category) => (
+        <button
+          key={category.id}
+          type="button"
+          onClick={() => onSelect(category.id)}
+          className={cn(
+            "inline-flex h-9 items-center gap-2 rounded-full border px-3 text-sm font-medium transition-colors",
+            selectedCategoryId === category.id
+              ? getAssetCategoryTone(category)
+              : "border-border-4 bg-background-1 text-text-2 hover:border-border-3 hover:bg-background-3",
+          )}
+        >
+          <span
+            className={cn(
+              "h-2 w-2 rounded-full",
+              category.key === "thumbnail" && "bg-primary-1",
+              category.key === "default" && "bg-positive-1",
+              category.key === "uncategorized" && "bg-text-4",
+              !category.key && "bg-info-1",
+            )}
+          />
+          {category.name}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function SelectedAssetSummary({ asset }: { asset: Asset | null }) {
+  if (!asset) {
+    return (
+      <div className="flex min-h-16 items-center rounded-[1rem] border border-border-4 bg-background-2 px-4 text-sm text-text-4">
+        선택된 에셋이 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-16 items-center gap-3 rounded-[1rem] border border-border-4 bg-background-2 p-3">
+      <div className="h-12 w-16 shrink-0 overflow-hidden rounded-[0.75rem] bg-background-3">
+        {/* eslint-disable-next-line @next/next/no-img-element -- arbitrary admin asset hosts are allowed */}
+        <img
+          src={normalizeAssetUrl(asset.url)}
+          alt=""
+          className="h-full w-full object-cover"
+        />
+      </div>
+      <div className="min-w-0">
+        <p className="truncate text-sm font-semibold text-text-1">
+          {getAssetDisplayName(asset)}
+        </p>
+        <p className="truncate text-xs text-text-4">
+          {getAssetFilename(asset.url)}
+        </p>
+      </div>
+    </div>
+  );
+}
+
 function AssetPickerCard({
   asset,
+  isPriority,
   isSelected,
   onSelect,
 }: {
   asset: Asset;
+  isPriority: boolean;
   isSelected: boolean;
   onSelect: () => void;
 }) {
@@ -222,12 +434,12 @@ function AssetPickerCard({
           // eslint-disable-next-line @next/next/no-img-element -- arbitrary admin asset hosts are allowed
           <img
             src={asset.url}
-            alt={getAssetFilename(asset.url)}
+            alt={getAssetDisplayName(asset)}
             className="h-full w-full object-cover"
             onError={() => setHasError(true)}
           />
         )}
-        <div className="absolute left-3 top-3">
+        <div className="absolute left-3 top-3 flex flex-wrap gap-2">
           <span
             className={cn(
               "inline-flex min-h-8 min-w-8 items-center justify-center rounded-full border px-2 text-xs font-semibold backdrop-blur",
@@ -238,12 +450,32 @@ function AssetPickerCard({
           >
             {isSelected ? "선택" : ""}
           </span>
+          {isPriority ? (
+            <span className="inline-flex min-h-8 items-center rounded-full border border-primary-1/25 bg-background-1/85 px-2 text-xs font-semibold text-primary-1 backdrop-blur">
+              현재 글
+            </span>
+          ) : null}
         </div>
       </div>
-      <div className="space-y-1 px-4 py-3">
-        <p className="truncate text-sm font-medium text-text-1">
-          {getAssetFilename(asset.url)}
-        </p>
+      <div className="space-y-2 px-4 py-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium text-text-1">
+              {getAssetDisplayName(asset)}
+            </p>
+            <p className="truncate text-xs text-text-4">
+              {getAssetFilename(asset.url)}
+            </p>
+          </div>
+          <span
+            className={cn(
+              "shrink-0 rounded-full border px-2 py-1 text-[11px] font-semibold",
+              getAssetCategoryTone(asset.category),
+            )}
+          >
+            {asset.category.name}
+          </span>
+        </div>
         <p className="text-xs text-text-4">
           {formatAssetFileSize(asset.sizeBytes)} ·{" "}
           {formatAssetResolution(asset.width, asset.height)}

--- a/src/features/asset-uploader/ui/asset-category-manager-modal.tsx
+++ b/src/features/asset-uploader/ui/asset-category-manager-modal.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Icon } from "@iconify/react/offline";
+import closeCircleLinear from "@iconify-icons/solar/close-circle-linear";
+import trashBinMinimalisticLinear from "@iconify-icons/solar/trash-bin-minimalistic-linear";
+import type { AssetCategory } from "@entities/asset";
+import { getAssetCategoryTone } from "@entities/asset";
+import { cn } from "@shared/lib/style-utils";
+import { Modal, Spinner } from "@shared/ui/libs";
+
+interface AssetCategoryManagerModalProps {
+  isOpen: boolean;
+  categories: AssetCategory[];
+  pendingCategoryId: number | null;
+  isMutating: boolean;
+  onClose: () => void;
+  onCreate: (name: string) => void;
+  onRename: (category: AssetCategory, name: string) => void;
+  onDelete: (category: AssetCategory) => void;
+}
+
+export function AssetCategoryManagerModal({
+  isOpen,
+  categories,
+  pendingCategoryId,
+  isMutating,
+  onClose,
+  onCreate,
+  onRename,
+  onDelete,
+}: AssetCategoryManagerModalProps) {
+  const [newName, setNewName] = useState("");
+  const [draftNames, setDraftNames] = useState<Record<number, string>>({});
+
+  useEffect(() => {
+    if (!isOpen) {
+      setNewName("");
+      setDraftNames({});
+
+      return;
+    }
+
+    setDraftNames(
+      Object.fromEntries(
+        categories.map((category) => [category.id, category.name]),
+      ),
+    );
+  }, [categories, isOpen]);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      withBackground
+      aria-label="에셋 카테고리 관리"
+      className="w-[min(100%,38rem)] p-0 text-left"
+    >
+      <div className="flex max-h-[86vh] flex-col overflow-hidden rounded-[1.5rem] bg-background-1">
+        <div className="flex items-start justify-between gap-4 border-b border-border-3 px-6 py-5">
+          <div>
+            <p className="text-body-xs uppercase tracking-[0.2em] text-text-4">
+              Asset categories
+            </p>
+            <h2 className="mt-2 text-xl font-semibold text-text-1">
+              에셋 카테고리 관리
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-lg text-text-3 transition-colors hover:bg-background-2 hover:text-text-1"
+            aria-label="카테고리 관리 닫기"
+          >
+            <Icon icon={closeCircleLinear} width="22" />
+          </button>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+          <form
+            className="mb-5 flex gap-2"
+            onSubmit={(event) => {
+              event.preventDefault();
+              const trimmed = newName.trim();
+              if (!trimmed) {
+                return;
+              }
+              onCreate(trimmed);
+              setNewName("");
+            }}
+          >
+            <input
+              type="text"
+              value={newName}
+              onChange={(event) => setNewName(event.target.value)}
+              disabled={isMutating}
+              placeholder="새 카테고리 이름"
+              className="h-10 min-w-0 flex-1 rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+            />
+            <button
+              type="submit"
+              disabled={isMutating || newName.trim().length === 0}
+              className="inline-flex h-10 items-center justify-center rounded-[0.75rem] bg-primary-1 px-4 text-sm font-semibold text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              추가
+            </button>
+          </form>
+
+          <div className="space-y-3">
+            {categories.map((category) => {
+              const draft = draftNames[category.id] ?? category.name;
+              const isPending = pendingCategoryId === category.id;
+              const isChanged = draft.trim() !== category.name;
+
+              return (
+                <div
+                  key={category.id}
+                  className="rounded-[1rem] border border-border-4 bg-background-2 p-3"
+                >
+                  <div className="mb-3 flex flex-wrap items-center gap-2">
+                    <span
+                      className={cn(
+                        "rounded-full border px-2 py-1 text-[11px] font-semibold",
+                        getAssetCategoryTone(category),
+                      )}
+                    >
+                      {category.name}
+                    </span>
+                    {category.isProtected ? (
+                      <span className="rounded-full border border-border-3 px-2 py-1 text-[11px] text-text-4">
+                        고정
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto_auto]">
+                    <input
+                      type="text"
+                      value={draft}
+                      onChange={(event) =>
+                        setDraftNames((current) => ({
+                          ...current,
+                          [category.id]: event.target.value,
+                        }))
+                      }
+                      disabled={isMutating}
+                      className="h-10 rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+                      aria-label={`${category.name} 이름`}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => onRename(category, draft.trim())}
+                      disabled={isMutating || !isChanged || !draft.trim()}
+                      className="inline-flex h-10 items-center justify-center rounded-[0.75rem] border border-border-3 px-3 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {isPending ? <Spinner size="sm" /> : null}
+                      저장
+                    </button>
+                    {!category.isProtected ? (
+                      <button
+                        type="button"
+                        onClick={() => onDelete(category)}
+                        disabled={isMutating}
+                        className="inline-flex h-10 items-center justify-center gap-1.5 rounded-[0.75rem] border border-negative-1/25 px-3 text-sm font-medium text-negative-1 transition-colors hover:bg-negative-1/10 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        <Icon icon={trashBinMinimalisticLinear} width="15" />
+                        삭제
+                      </button>
+                    ) : null}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/features/asset-uploader/ui/asset-detail-modal.tsx
+++ b/src/features/asset-uploader/ui/asset-detail-modal.tsx
@@ -6,12 +6,14 @@ import closeCircleLinear from "@iconify-icons/solar/close-circle-linear";
 import codeSquareLinear from "@iconify-icons/solar/code-square-linear";
 import linkMinimalistic2Linear from "@iconify-icons/solar/link-minimalistic-2-linear";
 import trashBinMinimalisticLinear from "@iconify-icons/solar/trash-bin-minimalistic-linear";
-import type { Asset } from "@entities/asset";
+import type { Asset, AssetCategory } from "@entities/asset";
 import {
   buildAssetMarkdown,
   formatAssetDate,
   formatAssetFileSize,
   formatAssetResolution,
+  getAssetCategoryTone,
+  getAssetDisplayName,
   getAssetFilename,
 } from "@entities/asset";
 import { cn } from "@shared/lib/style-utils";
@@ -19,23 +21,34 @@ import { Modal } from "@shared/ui/libs";
 
 interface AssetDetailModalProps {
   assets: Asset[];
+  categories: AssetCategory[];
   assetId: number | null;
   copiedType: "url" | "markdown" | null;
+  isSavingMetadata: boolean;
   onClose: () => void;
   onCopy: (asset: Asset, type: "url" | "markdown") => void;
+  onUpdateMetadata: (
+    asset: Asset,
+    metadata: { displayName: string | null; categoryId: number },
+  ) => void;
   onRequestDelete: (asset: Asset) => void;
   onSelectAsset: (assetId: number) => void;
 }
 
 export function AssetDetailModal({
   assets,
+  categories,
   assetId,
   copiedType,
+  isSavingMetadata,
   onClose,
   onCopy,
+  onUpdateMetadata,
   onRequestDelete,
   onSelectAsset,
 }: AssetDetailModalProps) {
+  const [displayNameDraft, setDisplayNameDraft] = useState("");
+  const [categoryIdDraft, setCategoryIdDraft] = useState<number | null>(null);
   const currentIndex = useMemo(
     () => assets.findIndex((asset) => asset.id === assetId),
     [assetId, assets],
@@ -46,6 +59,10 @@ export function AssetDetailModal({
     currentIndex >= 0 && currentIndex < assets.length - 1
       ? assets[currentIndex + 1]
       : null;
+  const isMetadataChanged =
+    asset !== null &&
+    (displayNameDraft.trim() !== (asset.displayName ?? "") ||
+      categoryIdDraft !== asset.category.id);
 
   useEffect(() => {
     if (!asset) {
@@ -71,6 +88,11 @@ export function AssetDetailModal({
     };
   }, [asset, nextAsset, onSelectAsset, prevAsset]);
 
+  useEffect(() => {
+    setDisplayNameDraft(asset?.displayName ?? "");
+    setCategoryIdDraft(asset?.category.id ?? null);
+  }, [asset]);
+
   if (!asset) {
     return null;
   }
@@ -86,7 +108,7 @@ export function AssetDetailModal({
       <div className="flex max-h-[90vh] flex-col overflow-hidden rounded-[1.5rem] bg-background-1">
         <div className="flex items-center justify-between gap-4 border-b border-border-3 px-6 py-4">
           <h3 className="truncate text-lg font-bold text-text-1">
-            {getAssetFilename(asset.url)}
+            {getAssetDisplayName(asset)}
           </h3>
           <button
             type="button"
@@ -141,6 +163,8 @@ export function AssetDetailModal({
           </div>
 
           <dl className="mb-6 grid grid-cols-2 gap-x-6 gap-y-3">
+            <InfoRow label="별명" value={asset.displayName ?? "-"} />
+            <InfoRow label="카테고리" value={asset.category.name} />
             <InfoRow label="파일명" value={getAssetFilename(asset.url)} />
             <InfoRow label="형식" value={asset.mimeType} />
             <InfoRow
@@ -156,6 +180,83 @@ export function AssetDetailModal({
               value={formatAssetDate(asset.createdAt)}
             />
           </dl>
+
+          <div className="mb-6 rounded-[1rem] border border-border-3 bg-background-2 p-4">
+            <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-text-4">
+                  Metadata
+                </p>
+                <p className="mt-1 text-sm text-text-3">
+                  별명과 카테고리는 검색과 필터에만 사용됩니다.
+                </p>
+              </div>
+              <span
+                className={cn(
+                  "rounded-full border px-2 py-1 text-[11px] font-semibold",
+                  getAssetCategoryTone(asset.category),
+                )}
+              >
+                {asset.category.name}
+              </span>
+            </div>
+            <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_12rem]">
+              <label className="grid gap-1.5">
+                <span className="text-[12px] text-text-3">별명</span>
+                <input
+                  type="text"
+                  value={displayNameDraft}
+                  maxLength={200}
+                  onChange={(event) => setDisplayNameDraft(event.target.value)}
+                  disabled={isSavingMetadata}
+                  className="h-10 rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+                  placeholder={getAssetFilename(asset.url)}
+                />
+              </label>
+              <label className="grid gap-1.5">
+                <span className="text-[12px] text-text-3">카테고리</span>
+                <select
+                  value={categoryIdDraft ?? ""}
+                  onChange={(event) =>
+                    setCategoryIdDraft(
+                      event.target.value ? Number(event.target.value) : null,
+                    )
+                  }
+                  disabled={isSavingMetadata}
+                  className="h-10 rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {categories.map((category) => (
+                    <option key={category.id} value={category.id}>
+                      {category.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            <div className="mt-4 flex justify-end">
+              <button
+                type="button"
+                onClick={() => {
+                  if (categoryIdDraft === null) {
+                    return;
+                  }
+
+                  onUpdateMetadata(asset, {
+                    displayName: displayNameDraft.trim() || null,
+                    categoryId: categoryIdDraft,
+                  });
+                }}
+                disabled={
+                  isSavingMetadata ||
+                  !isMetadataChanged ||
+                  categoryIdDraft === null
+                }
+                className="inline-flex h-9 items-center justify-center rounded-[0.75rem] bg-primary-1 px-4 text-sm font-semibold text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isSavingMetadata ? "저장 중" : "저장"}
+              </button>
+            </div>
+          </div>
 
           <div className="space-y-4">
             <CodeInfoBlock
@@ -257,7 +358,7 @@ function AssetPreview({ asset }: { asset: Asset }) {
     // eslint-disable-next-line @next/next/no-img-element -- arbitrary admin asset hosts are allowed
     <img
       src={asset.url}
-      alt={getAssetFilename(asset.url)}
+      alt={getAssetDisplayName(asset)}
       className="w-full object-contain"
       style={{ maxHeight: "60vh" }}
       onError={() => setHasError(true)}

--- a/src/features/asset-uploader/ui/asset-grid.tsx
+++ b/src/features/asset-uploader/ui/asset-grid.tsx
@@ -11,6 +11,8 @@ import {
   formatAssetDate,
   formatAssetFileSize,
   formatAssetResolution,
+  getAssetCategoryTone,
+  getAssetDisplayName,
   getAssetFilename,
 } from "@entities/asset";
 import { cn } from "@shared/lib/style-utils";
@@ -226,9 +228,24 @@ function AssetGridCard({
 
         <div className="p-3">
           <div className="space-y-1">
-            <p className="truncate text-[13px] font-medium leading-none text-text-1">
-              {getAssetFilename(asset.url)}
-            </p>
+            <div className="flex items-start justify-between gap-2">
+              <div className="min-w-0">
+                <p className="truncate text-[13px] font-medium leading-none text-text-1">
+                  {getAssetDisplayName(asset)}
+                </p>
+                <p className="mt-1 truncate text-[12px] leading-none text-text-4">
+                  {getAssetFilename(asset.url)}
+                </p>
+              </div>
+              <span
+                className={cn(
+                  "shrink-0 rounded-full border px-2 py-0.5 text-[11px] font-semibold leading-none",
+                  getAssetCategoryTone(asset.category),
+                )}
+              >
+                {asset.category.name}
+              </span>
+            </div>
             <p className="truncate text-[12px] leading-none text-text-4">
               {formatAssetFileSize(asset.sizeBytes)} /{" "}
               {formatAssetResolution(asset.width, asset.height)} /{" "}
@@ -264,7 +281,7 @@ function AssetCardMedia({ asset }: { asset: Asset }) {
         // eslint-disable-next-line @next/next/no-img-element -- arbitrary admin asset hosts are allowed
         <img
           src={asset.url}
-          alt={getAssetFilename(asset.url)}
+          alt={getAssetDisplayName(asset)}
           className="h-full w-full object-cover transition duration-300 group-hover:scale-[1.03]"
           onError={() => setHasError(true)}
         />

--- a/src/features/asset-uploader/ui/asset-uploader.tsx
+++ b/src/features/asset-uploader/ui/asset-uploader.tsx
@@ -3,17 +3,27 @@
 import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { AssetCategoryManagerModal } from "./asset-category-manager-modal";
 import { AssetDetailModal } from "./asset-detail-modal";
 import { AssetGrid } from "./asset-grid";
 import { type PendingUploadFile, UploadZone } from "./upload-zone";
 import {
   adminAssetKeys,
   buildAssetMarkdown,
+  createAssetCategory,
   deleteAsset,
+  deleteAssetCategory,
   deleteAssets,
+  fetchAssetCategories,
   fetchAssets,
+  findAssetCategoryByKey,
+  getInitialAssetDisplayName,
+  updateAsset,
+  updateAssetCategory,
+  updateAssetsCategory,
   uploadAssets,
   type Asset,
+  type AssetCategory,
 } from "@entities/asset";
 import { toCanonicalAssetUrl } from "@shared/lib/asset-url";
 import { getErrorMessage } from "@shared/lib/get-error-message";
@@ -55,6 +65,16 @@ function generatePageNumbers(
 export function AssetUploader() {
   const queryClient = useQueryClient();
   const [page, setPage] = useState(1);
+  const [categoryFilterId, setCategoryFilterId] = useState<number | null>(null);
+  const [search, setSearch] = useState("");
+  const [defaultUploadCategoryId, setDefaultUploadCategoryId] = useState<
+    number | null
+  >(null);
+  const [bulkCategoryId, setBulkCategoryId] = useState<number | null>(null);
+  const [isCategoryManagerOpen, setIsCategoryManagerOpen] = useState(false);
+  const [pendingCategoryId, setPendingCategoryId] = useState<number | null>(
+    null,
+  );
   const [pendingFiles, setPendingFiles] = useState<PendingUploadFile[]>([]);
   const [uploadProgress, setUploadProgress] = useState<number | null>(null);
   const [selectionMode, setSelectionMode] = useState(false);
@@ -71,17 +91,41 @@ export function AssetUploader() {
     id: number;
     type: "url" | "markdown";
   } | null>(null);
+  const trimmedSearch = search.trim();
+
+  const categoriesQuery = useQuery({
+    queryKey: adminAssetKeys.categories(),
+    queryFn: fetchAssetCategories,
+  });
 
   const assetsQuery = useQuery({
-    queryKey: adminAssetKeys.list({ page, limit: PAGE_SIZE }),
-    queryFn: () => fetchAssets(page, PAGE_SIZE),
+    queryKey: adminAssetKeys.list({
+      page,
+      limit: PAGE_SIZE,
+      categoryId: categoryFilterId,
+      q: trimmedSearch,
+    }),
+    queryFn: () =>
+      fetchAssets({
+        page,
+        limit: PAGE_SIZE,
+        categoryId: categoryFilterId,
+        q: trimmedSearch || undefined,
+      }),
   });
 
   const uploadMutation = useMutation({
-    mutationFn: (files: File[]) => {
+    mutationFn: (files: PendingUploadFile[]) => {
       setUploadProgress(0);
 
-      return uploadAssets(files, setUploadProgress);
+      return uploadAssets(
+        files.map((item) => item.file),
+        setUploadProgress,
+        files.map((item) => ({
+          displayName: item.displayName.trim() || null,
+          categoryId: item.categoryId ?? undefined,
+        })),
+      );
     },
     onSuccess: async () => {
       toast.success(
@@ -100,6 +144,11 @@ export function AssetUploader() {
 
   const assets = assetsQuery.data?.data ?? EMPTY_ASSETS;
   const meta = assetsQuery.data?.meta;
+  const categories = categoriesQuery.data ?? [];
+  const fallbackDefaultCategory =
+    findAssetCategoryByKey(categories, "default") ?? categories[0] ?? null;
+  const selectedUploadCategoryId =
+    defaultUploadCategoryId ?? fallbackDefaultCategory?.id ?? null;
 
   const deleteMutation = useMutation({
     mutationFn: async (ids: number[]) => {
@@ -146,11 +195,127 @@ export function AssetUploader() {
     },
   });
 
+  const updateAssetMutation = useMutation({
+    mutationFn: ({
+      assetId,
+      displayName,
+      categoryId,
+    }: {
+      assetId: number;
+      displayName: string | null;
+      categoryId: number;
+    }) => updateAsset(assetId, { displayName, categoryId }),
+    onSuccess: async () => {
+      toast.success("에셋 정보를 저장했습니다.");
+      await queryClient.invalidateQueries({ queryKey: adminAssetKeys.all() });
+    },
+    onError: (error) => {
+      toast.error(getErrorMessage(error, "에셋 정보 저장에 실패했습니다."));
+    },
+  });
+
+  const bulkCategoryMutation = useMutation({
+    mutationFn: ({ ids, categoryId }: { ids: number[]; categoryId: number }) =>
+      updateAssetsCategory(ids, categoryId),
+    onSuccess: async (_, variables) => {
+      toast.success(
+        `${variables.ids.length}개의 에셋 카테고리를 변경했습니다.`,
+      );
+      setSelectedIds([]);
+      setLastSelectedIndex(null);
+      setBulkCategoryId(null);
+      await queryClient.invalidateQueries({ queryKey: adminAssetKeys.all() });
+    },
+    onError: (error) => {
+      toast.error(getErrorMessage(error, "카테고리 일괄 변경에 실패했습니다."));
+    },
+  });
+
+  const createCategoryMutation = useMutation({
+    mutationFn: createAssetCategory,
+    onSuccess: async () => {
+      toast.success("에셋 카테고리를 추가했습니다.");
+      await queryClient.invalidateQueries({
+        queryKey: adminAssetKeys.categories(),
+      });
+    },
+    onError: (error) => {
+      toast.error(getErrorMessage(error, "카테고리 추가에 실패했습니다."));
+    },
+  });
+
+  const updateCategoryMutation = useMutation({
+    mutationFn: ({ id, name }: { id: number; name: string }) =>
+      updateAssetCategory(id, { name }),
+    onMutate: (variables) => {
+      setPendingCategoryId(variables.id);
+    },
+    onSuccess: async () => {
+      toast.success("에셋 카테고리를 저장했습니다.");
+      await queryClient.invalidateQueries({
+        queryKey: adminAssetKeys.categories(),
+      });
+    },
+    onError: (error) => {
+      toast.error(getErrorMessage(error, "카테고리 저장에 실패했습니다."));
+    },
+    onSettled: () => {
+      setPendingCategoryId(null);
+    },
+  });
+
+  const deleteCategoryMutation = useMutation({
+    mutationFn: deleteAssetCategory,
+    onMutate: (id) => {
+      setPendingCategoryId(id);
+    },
+    onSuccess: async () => {
+      toast.success(
+        "에셋 카테고리를 삭제했습니다. 연결된 에셋은 미분류로 이동했습니다.",
+      );
+      setCategoryFilterId(null);
+      await queryClient.invalidateQueries({ queryKey: adminAssetKeys.all() });
+    },
+    onError: (error) => {
+      toast.error(getErrorMessage(error, "카테고리 삭제에 실패했습니다."));
+    },
+    onSettled: () => {
+      setPendingCategoryId(null);
+    },
+  });
+
   useEffect(() => {
     if (meta && meta.totalPages > 0 && page > meta.totalPages) {
       setPage(meta.totalPages);
     }
   }, [meta, page]);
+
+  useEffect(() => {
+    setPage(1);
+    setSelectedIds([]);
+    setLastSelectedIndex(null);
+    setSelectionMode(false);
+  }, [categoryFilterId, trimmedSearch]);
+
+  useEffect(() => {
+    if (defaultUploadCategoryId !== null) {
+      return;
+    }
+
+    const defaultCategory = findAssetCategoryByKey(categories, "default");
+    if (defaultCategory) {
+      setDefaultUploadCategoryId(defaultCategory.id);
+    }
+  }, [categories, defaultUploadCategoryId]);
+
+  useEffect(() => {
+    if (
+      bulkCategoryId !== null &&
+      !categories.some((category) => category.id === bulkCategoryId)
+    ) {
+      setBulkCategoryId(null);
+    }
+  }, [bulkCategoryId, categories]);
 
   useEffect(() => {
     setSelectedIds((current) => {
@@ -260,6 +425,8 @@ export function AssetUploader() {
         next.push({
           id: `${file.name}-${file.lastModified}-${file.size}`,
           file,
+          displayName: getInitialAssetDisplayName(file.name),
+          categoryId: selectedUploadCategoryId,
           previewUrl:
             file.type === "image/svg+xml"
               ? undefined
@@ -269,6 +436,26 @@ export function AssetUploader() {
 
       return next;
     });
+  }
+
+  function updatePendingFileMetadata(
+    id: string,
+    metadata: { displayName?: string; categoryId?: number | null },
+  ) {
+    setPendingFiles((current) =>
+      current.map((item) =>
+        item.id === id
+          ? {
+              ...item,
+              displayName: metadata.displayName ?? item.displayName,
+              categoryId:
+                metadata.categoryId !== undefined
+                  ? metadata.categoryId
+                  : item.categoryId,
+            }
+          : item,
+      ),
+    );
   }
 
   function removePendingFile(id: string) {
@@ -366,14 +553,72 @@ export function AssetUploader() {
     setSelectionMode(false);
   }
 
+  function handleRenameCategory(category: AssetCategory, name: string) {
+    const trimmed = name.trim();
+    if (!trimmed || trimmed === category.name) {
+      return;
+    }
+
+    updateCategoryMutation.mutate({ id: category.id, name: trimmed });
+  }
+
+  function handleDeleteCategory(category: AssetCategory) {
+    if (category.isProtected) {
+      return;
+    }
+
+    deleteCategoryMutation.mutate(category.id);
+  }
+
   return (
     <div className="space-y-6">
+      <section className="rounded-[1rem] border border-border-4 bg-background-2 p-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <p className="text-sm font-semibold text-text-1">업로드 기본값</p>
+            <p className="mt-1 text-xs text-text-4">
+              에셋 관리에서 직접 추가하는 파일은 선택한 카테고리로 대기열에
+              들어갑니다.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <select
+              value={selectedUploadCategoryId ?? ""}
+              onChange={(event) =>
+                setDefaultUploadCategoryId(
+                  event.target.value ? Number(event.target.value) : null,
+                )
+              }
+              disabled={categoriesQuery.isPending || uploadMutation.isPending}
+              className="h-10 min-w-[12rem] rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+              aria-label="업로드 기본 카테고리"
+            >
+              {categories.length === 0 ? <option value="">기본</option> : null}
+              {categories.map((category) => (
+                <option key={category.id} value={category.id}>
+                  {category.name}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={() => setIsCategoryManagerOpen(true)}
+              className="inline-flex h-10 items-center justify-center rounded-[0.75rem] border border-border-3 px-3 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
+            >
+              카테고리 관리
+            </button>
+          </div>
+        </div>
+      </section>
+
       <UploadZone
         files={pendingFiles}
         isUploading={uploadMutation.isPending}
         uploadProgress={uploadProgress}
         errorMessage={null}
+        categories={categories}
         onFilesAdded={addFiles}
+        onUpdateFileMetadata={updatePendingFileMetadata}
         onRemoveFile={removePendingFile}
         onClear={clearPendingFiles}
         onUpload={() => {
@@ -383,7 +628,7 @@ export function AssetUploader() {
             return;
           }
 
-          uploadMutation.mutate(pendingFiles.map((item) => item.file));
+          uploadMutation.mutate(pendingFiles);
         }}
       />
 
@@ -409,6 +654,45 @@ export function AssetUploader() {
 
       {!assetsQuery.isPending && !assetsQuery.isError ? (
         <>
+          <section className="rounded-[1rem] border border-border-4 bg-background-2 p-4">
+            <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_14rem_auto]">
+              <input
+                type="search"
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="별명 또는 파일명 검색"
+                className="h-10 rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1"
+              />
+              <select
+                value={categoryFilterId ?? ""}
+                onChange={(event) =>
+                  setCategoryFilterId(
+                    event.target.value ? Number(event.target.value) : null,
+                  )
+                }
+                className="h-10 rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors focus:border-primary-1"
+                aria-label="카테고리 필터"
+              >
+                <option value="">전체 카테고리</option>
+                {categories.map((category) => (
+                  <option key={category.id} value={category.id}>
+                    {category.name}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                onClick={() => {
+                  setSearch("");
+                  setCategoryFilterId(null);
+                }}
+                className="inline-flex h-10 items-center justify-center rounded-[0.75rem] border border-border-3 px-3 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
+              >
+                필터 초기화
+              </button>
+            </div>
+          </section>
+
           <AssetGrid
             assets={assets}
             totalCount={meta?.total ?? assets.length}
@@ -432,6 +716,54 @@ export function AssetUploader() {
                     선택됨 {selectedIds.length}개
                   </span>
                   <div className="ml-auto flex flex-wrap items-center gap-2">
+                    <select
+                      value={bulkCategoryId ?? ""}
+                      onChange={(event) =>
+                        setBulkCategoryId(
+                          event.target.value
+                            ? Number(event.target.value)
+                            : null,
+                        )
+                      }
+                      disabled={
+                        selectedIds.length === 0 ||
+                        bulkCategoryMutation.isPending
+                      }
+                      className="h-9 rounded-[0.7rem] border border-border-3 bg-background-1 px-2 text-sm text-text-2 outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                      aria-label="선택 에셋 카테고리"
+                    >
+                      <option value="">카테고리 변경</option>
+                      {categories.map((category) => (
+                        <option key={category.id} value={category.id}>
+                          {category.name}
+                        </option>
+                      ))}
+                    </select>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (bulkCategoryId === null) {
+                          toast.error("변경할 카테고리를 선택하세요.");
+
+                          return;
+                        }
+
+                        bulkCategoryMutation.mutate({
+                          ids: selectedIds,
+                          categoryId: bulkCategoryId,
+                        });
+                      }}
+                      disabled={
+                        selectedIds.length === 0 ||
+                        bulkCategoryId === null ||
+                        bulkCategoryMutation.isPending
+                      }
+                      className="inline-flex h-9 cursor-pointer items-center rounded-[0.7rem] border border-border-3 px-3 text-sm text-text-2 transition-colors hover:bg-background-1 disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      {bulkCategoryMutation.isPending
+                        ? "변경 중"
+                        : "카테고리 적용"}
+                    </button>
                     <button
                       type="button"
                       onClick={() =>
@@ -566,12 +898,36 @@ export function AssetUploader() {
 
       <AssetDetailModal
         assets={assets}
+        categories={categories}
         assetId={deleteTargetIds.length > 0 ? null : detailAssetId}
         copiedType={copiedState?.id === detailAssetId ? copiedState.type : null}
+        isSavingMetadata={updateAssetMutation.isPending}
         onClose={() => setDetailAssetId(null)}
         onCopy={(asset, type) => void handleCopy(asset, type)}
+        onUpdateMetadata={(asset, metadata) =>
+          updateAssetMutation.mutate({
+            assetId: asset.id,
+            displayName: metadata.displayName,
+            categoryId: metadata.categoryId,
+          })
+        }
         onRequestDelete={requestDeleteFromDetail}
         onSelectAsset={setDetailAssetId}
+      />
+
+      <AssetCategoryManagerModal
+        isOpen={isCategoryManagerOpen}
+        categories={categories}
+        pendingCategoryId={pendingCategoryId}
+        isMutating={
+          createCategoryMutation.isPending ||
+          updateCategoryMutation.isPending ||
+          deleteCategoryMutation.isPending
+        }
+        onClose={() => setIsCategoryManagerOpen(false)}
+        onCreate={(name) => createCategoryMutation.mutate(name)}
+        onRename={handleRenameCategory}
+        onDelete={handleDeleteCategory}
       />
     </div>
   );

--- a/src/features/asset-uploader/ui/upload-zone.tsx
+++ b/src/features/asset-uploader/ui/upload-zone.tsx
@@ -7,6 +7,7 @@ import galleryWideLinear from "@iconify-icons/solar/gallery-wide-linear";
 import linkMinimalistic2Linear from "@iconify-icons/solar/link-minimalistic-2-linear";
 import trashBinMinimalisticLinear from "@iconify-icons/solar/trash-bin-minimalistic-linear";
 import uploadMinimalisticLinear from "@iconify-icons/solar/upload-minimalistic-linear";
+import type { AssetCategory } from "@entities/asset";
 import { cn } from "@shared/lib/style-utils";
 import { Spinner } from "@shared/ui/libs";
 
@@ -14,6 +15,8 @@ export interface PendingUploadFile {
   id: string;
   file: File;
   previewUrl?: string;
+  displayName: string;
+  categoryId: number | null;
 }
 
 interface UploadZoneProps {
@@ -21,7 +24,12 @@ interface UploadZoneProps {
   isUploading: boolean;
   uploadProgress: number | null;
   errorMessage: string | null;
+  categories: AssetCategory[];
   onFilesAdded: (files: FileList | File[]) => void;
+  onUpdateFileMetadata: (
+    id: string,
+    metadata: { displayName?: string; categoryId?: number | null },
+  ) => void;
   onRemoveFile: (id: string) => void;
   onClear: () => void;
   onUpload: () => void;
@@ -32,7 +40,9 @@ export function UploadZone({
   isUploading,
   uploadProgress,
   errorMessage,
+  categories,
   onFilesAdded,
+  onUpdateFileMetadata,
   onRemoveFile,
   onClear,
   onUpload,
@@ -132,12 +142,12 @@ export function UploadZone({
           </div>
         ) : null}
 
-        <div className="flex flex-row flex-wrap gap-3">
+        <div className="grid gap-3">
           {hasFiles ? (
             files.map((item) => (
               <div
                 key={item.id}
-                className="flex items-center gap-3 rounded-lg border border-border-4 bg-background-1 px-3 py-2"
+                className="grid gap-3 rounded-lg border border-border-4 bg-background-1 px-3 py-3 md:grid-cols-[auto_minmax(0,1fr)_9rem_auto] md:items-center"
               >
                 <div className="flex h-12 w-16 shrink-0 items-center justify-center overflow-hidden rounded bg-background-3">
                   {item.previewUrl ? (
@@ -169,6 +179,39 @@ export function UploadZone({
                     </div>
                   ) : null}
                 </div>
+                <input
+                  type="text"
+                  value={item.displayName}
+                  onChange={(event) =>
+                    onUpdateFileMetadata(item.id, {
+                      displayName: event.target.value,
+                    })
+                  }
+                  disabled={isUploading}
+                  aria-label={`${item.file.name} 별명`}
+                  placeholder="별명"
+                  className="h-9 min-w-0 rounded-lg border border-border-3 bg-background-1 px-3 text-[13px] text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+                />
+                <select
+                  value={item.categoryId ?? ""}
+                  onChange={(event) =>
+                    onUpdateFileMetadata(item.id, {
+                      categoryId: event.target.value
+                        ? Number(event.target.value)
+                        : null,
+                    })
+                  }
+                  disabled={isUploading}
+                  aria-label={`${item.file.name} 카테고리`}
+                  className="h-9 min-w-0 rounded-lg border border-border-3 bg-background-1 px-3 text-[13px] text-text-2 outline-none transition-colors focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  <option value="">기본</option>
+                  {categories.map((category) => (
+                    <option key={category.id} value={category.id}>
+                      {category.name}
+                    </option>
+                  ))}
+                </select>
                 {isUploading ? (
                   <Spinner size="sm" className="shrink-0 text-primary-1" />
                 ) : (

--- a/src/features/post-editor/ui/image-gallery-modal.tsx
+++ b/src/features/post-editor/ui/image-gallery-modal.tsx
@@ -1,8 +1,16 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { adminAssetKeys, fetchAssets, type Asset } from "@entities/asset";
+import {
+  adminAssetKeys,
+  fetchAssets,
+  getAssetCategoryTone,
+  getAssetDisplayName,
+  getAssetFilename,
+  type Asset,
+} from "@entities/asset";
 import { getErrorMessage } from "@shared/lib/get-error-message";
+import { cn } from "@shared/lib/style-utils";
 import { Modal } from "@shared/ui/libs";
 
 interface ImageGalleryModalProps {
@@ -104,6 +112,7 @@ export function ImageGalleryModal({
                   className="overflow-hidden rounded-[1.25rem] border border-border-3 bg-background-2 text-left transition-colors hover:border-primary-1"
                 >
                   <div className="aspect-[4/3] bg-background-3">
+                    {/* eslint-disable-next-line @next/next/no-img-element -- arbitrary admin asset hosts are allowed */}
                     <img
                       src={asset.url}
                       alt=""
@@ -111,9 +120,24 @@ export function ImageGalleryModal({
                     />
                   </div>
                   <div className="space-y-1 px-4 py-3">
-                    <p className="truncate text-sm font-medium text-text-1">
-                      {getAssetLabel(asset)}
-                    </p>
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-medium text-text-1">
+                          {getAssetDisplayName(asset)}
+                        </p>
+                        <p className="truncate text-xs text-text-4">
+                          {getAssetFilename(asset.url)}
+                        </p>
+                      </div>
+                      <span
+                        className={cn(
+                          "shrink-0 rounded-full border px-2 py-0.5 text-[11px] font-semibold",
+                          getAssetCategoryTone(asset.category),
+                        )}
+                      >
+                        {asset.category.name}
+                      </span>
+                    </div>
                     <p className="text-xs text-text-4">{asset.mimeType}</p>
                   </div>
                 </button>
@@ -124,10 +148,4 @@ export function ImageGalleryModal({
       </div>
     </Modal>
   );
-}
-
-function getAssetLabel(asset: Asset): string {
-  const segment = asset.url.split("/").pop()?.trim();
-
-  return segment || `asset-${asset.id}`;
 }

--- a/src/features/post-editor/ui/post-form.tsx
+++ b/src/features/post-editor/ui/post-form.tsx
@@ -155,6 +155,22 @@ function buildPayload(values: PostFormValues): CreatePostBody {
   };
 }
 
+function extractMarkdownImageUrls(contentMd: string): string[] {
+  const urls: string[] = [];
+  const imagePattern = /!\[[^\]]*]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+
+  contentMd.replace(imagePattern, (_match, url: string) => {
+    const normalized = toCanonicalAssetUrl(url);
+    if (normalized && !normalized.startsWith("pending-upload:")) {
+      urls.push(normalized);
+    }
+
+    return "";
+  });
+
+  return [...new Set(urls)];
+}
+
 function sortCategories(categories: Category[]): Category[] {
   return [...categories]
     .sort((left, right) => left.sortOrder - right.sortOrder)
@@ -781,6 +797,10 @@ export function PostForm({
   const previewContent = useMemo(
     () => resolvePreviewContent(values.contentMd, pendingImages),
     [pendingImages, values.contentMd],
+  );
+  const currentPostAssetUrls = useMemo(
+    () => extractMarkdownImageUrls(values.contentMd),
+    [values.contentMd],
   );
   const pendingImageCount = useMemo(
     () =>
@@ -1481,6 +1501,7 @@ export function PostForm({
       <AssetPickerModal
         isOpen={showThumbnailPicker}
         onClose={() => setShowThumbnailPicker(false)}
+        priorityUrls={currentPostAssetUrls}
         onSelect={(url) => {
           handleFieldChange("thumbnailUrl", toCanonicalAssetUrl(url));
           setShowThumbnailPicker(false);

--- a/src/features/post-editor/ui/thumbnail-uploader.tsx
+++ b/src/features/post-editor/ui/thumbnail-uploader.tsx
@@ -5,8 +5,16 @@ import { Icon } from "@iconify/react/offline";
 import clipboardLinear from "@iconify-icons/solar/clipboard-linear";
 import galleryWideLinear from "@iconify-icons/solar/gallery-wide-linear";
 import linkMinimalistic2Linear from "@iconify-icons/solar/link-minimalistic-2-linear";
+import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { AssetPickerModal, uploadAssets } from "@entities/asset";
+import {
+  adminAssetKeys,
+  AssetPickerModal,
+  fetchAssetCategories,
+  findAssetCategoryByKey,
+  getInitialAssetDisplayName,
+  uploadAssets,
+} from "@entities/asset";
 import { normalizeAssetUrl, toCanonicalAssetUrl } from "@shared/lib/asset-url";
 import { cn } from "@shared/lib/style-utils";
 import { Spinner } from "@shared/ui/libs";
@@ -40,6 +48,14 @@ export function ThumbnailUploader({ value, onChange }: ThumbnailUploaderProps) {
   const [showUrlInput, setShowUrlInput] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const categoriesQuery = useQuery({
+    queryKey: adminAssetKeys.categories(),
+    queryFn: fetchAssetCategories,
+  });
+  const thumbnailCategoryId = findAssetCategoryByKey(
+    categoriesQuery.data ?? [],
+    "thumbnail",
+  )?.id;
 
   useEffect(() => {
     setUrlDraft(value);
@@ -124,7 +140,12 @@ export function ThumbnailUploader({ value, onChange }: ThumbnailUploaderProps) {
     setIsUploading(true);
 
     try {
-      const [asset] = await uploadAssets([file]);
+      const [asset] = await uploadAssets([file], undefined, [
+        {
+          displayName: getInitialAssetDisplayName(file.name),
+          categoryId: thumbnailCategoryId,
+        },
+      ]);
       onChange(toCanonicalAssetUrl(asset.url));
       setPendingFile(null);
       toast.success("썸네일을 업로드했습니다.");


### PR DESCRIPTION
## Summary

Closes #381

Admin asset management and thumbnail asset picking now use backend asset metadata categories and display names so images can be filtered, searched, renamed, and bulk categorized.

## Changes

| File | Change |
|------|--------|
| `src/entities/asset/*` | Added asset category/displayName types, query keys, API clients, metadata upload payloads, update helpers, and display-name/category utilities. |
| `src/entities/asset/ui/asset-picker-modal.tsx` | Added category filters, display-name search, selected summary, category badges, and current-post priority sorting. |
| `src/features/asset-uploader/ui/*` | Added upload queue metadata inputs, upload default category selection, list filters, category manager modal, detail metadata editing, and bulk category changes. |
| `src/features/post-editor/ui/*` | Sends thumbnail uploads to the protected thumbnail category, prioritizes current post assets in thumbnail picking, and displays asset display names/categories in image selection. |

## Screenshots

Not captured in this headless pipeline run.
