### PR TITLE
에셋 업로더와 공용 UI 구조 정리

### DIFF
--- a/src/app/(public)/categories/[slug]/page.tsx
+++ b/src/app/(public)/categories/[slug]/page.tsx
@@ -132,7 +132,7 @@ export default async function CategoryPage({
   ];
 
   return (
-    <main className="flex min-h-screen flex-col pt-8 pb-16">
+    <div className="flex flex-col">
       {siteUrl ? (
         <JsonLd data={buildBreadcrumbJsonLd(breadcrumbItems, siteUrl)} />
       ) : null}
@@ -184,7 +184,7 @@ export default async function CategoryPage({
         />
       </div>
       <ScrollToTop />
-    </main>
+    </div>
   );
 }
 

--- a/src/app/(public)/categories/page.tsx
+++ b/src/app/(public)/categories/page.tsx
@@ -24,7 +24,7 @@ export default async function CategoriesPage() {
   const headerSummary = `총 ${formatNumber(visibleCategoryCount)}개 분류`;
 
   return (
-    <main className="flex min-h-screen flex-col pt-8 pb-16">
+    <div className="flex flex-col">
       <ArchiveHeader
         variant="category"
         eyebrow="Category Directory"
@@ -64,6 +64,6 @@ export default async function CategoriesPage() {
         />
       )}
       <ScrollToTop />
-    </main>
+    </div>
   );
 }

--- a/src/app/(public)/guestbook/page.tsx
+++ b/src/app/(public)/guestbook/page.tsx
@@ -48,7 +48,7 @@ function GuestbookPageStatus({
   description: string;
 }) {
   return (
-    <main className="mx-auto flex min-h-screen w-full max-w-[67.5rem] flex-col px-4 py-12 md:px-6">
+    <div className="flex w-full flex-col">
       <header>
         <div className="flex flex-wrap items-baseline justify-between gap-4">
           <h1 className="text-body-lg font-bold tracking-tight text-text-1 sm:text-h1">
@@ -62,7 +62,7 @@ function GuestbookPageStatus({
       <section className="mt-8">
         <EmptyState variant="page" title={title} description={description} />
       </section>
-    </main>
+    </div>
   );
 }
 

--- a/src/app/(public)/layout-shell.tsx
+++ b/src/app/(public)/layout-shell.tsx
@@ -88,7 +88,7 @@ export function PublicLayoutShell({
         </aside>
 
         {/* Page content */}
-        <div className="min-w-0 flex-1 lg:pl-8">{children}</div>
+        <main className="min-w-0 flex-1 pt-8 pb-16 lg:pl-8">{children}</main>
       </div>
 
       {/* Mobile slide-in sidebar */}

--- a/src/app/(public)/posts/[slug]/page.tsx
+++ b/src/app/(public)/posts/[slug]/page.tsx
@@ -209,7 +209,7 @@ export default async function PostDetailPage({ params }: PostDetailPageProps) {
     : [];
 
   return (
-    <main className="w-full pt-8 pb-16">
+    <div className="w-full">
       {siteUrl && post.searchIndexable ? (
         <JsonLd data={buildBlogPostingJsonLd(post, siteUrl)} />
       ) : null}
@@ -325,7 +325,7 @@ export default async function PostDetailPage({ params }: PostDetailPageProps) {
         />
       ) : null}
       <ScrollToTop />
-    </main>
+    </div>
   );
 }
 

--- a/src/app/(public)/posts/[slug]/page.tsx
+++ b/src/app/(public)/posts/[slug]/page.tsx
@@ -219,8 +219,8 @@ export default async function PostDetailPage({ params }: PostDetailPageProps) {
       <ViewCounter postId={post.id} />
       <article className="motion-reveal">
         {post.thumbnailUrl && (
-          <div className="mb-6 overflow-hidden rounded-[1.5rem] bg-background-3">
-            <div className="relative aspect-[16/9] w-full">
+          <div className="mb-6 overflow-hidden rounded-3xl bg-background-3">
+            <div className="relative aspect-video w-full">
               <Image
                 src={post.thumbnailUrl}
                 alt={post.title}
@@ -257,7 +257,7 @@ export default async function PostDetailPage({ params }: PostDetailPageProps) {
             </div>
 
             <h1
-              className="font-serif-content break-keep text-[1.5rem] leading-[1.95rem] text-text-1 md:text-h1"
+              className="font-serif-content break-keep text-2xl leading-[1.95rem] text-text-1 md:text-h1"
               style={{ fontWeight: 700 }}
             >
               {post.title}
@@ -275,7 +275,7 @@ export default async function PostDetailPage({ params }: PostDetailPageProps) {
                   <Link
                     key={tag.id}
                     href={`/tags/${tag.slug}`}
-                    className="inline-flex rounded-full border border-border-3 px-2.5 py-1 text-ui-xs font-medium text-text-3 transition-all duration-[200ms] ease-[cubic-bezier(0.16,1,0.3,1)] hover:border-primary-1 hover:bg-primary-1/6 hover:text-primary-1"
+                    className="inline-flex rounded-full border border-border-3 px-2.5 py-1 text-ui-xs font-medium text-text-3 transition-all duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] hover:border-primary-1 hover:bg-primary-1/6 hover:text-primary-1"
                   >
                     #{tag.name}
                   </Link>

--- a/src/app/(public)/search/page.tsx
+++ b/src/app/(public)/search/page.tsx
@@ -76,7 +76,7 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
 
   if (!query) {
     return (
-      <main className="mx-auto flex min-h-[100dvh] w-full max-w-[67.5rem] flex-col gap-6 px-4 pb-16 pt-8 md:px-6">
+      <div className="flex flex-col gap-6">
         <Suspense>
           <SearchForm currentFilter={filter} initialQuery="" />
         </Suspense>
@@ -85,7 +85,7 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
           title="검색어를 입력해 주세요"
           description="제목, 내용, 태그, 카테고리, 댓글로 검색할 수 있습니다"
         />
-      </main>
+      </div>
     );
   }
 
@@ -95,7 +95,7 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
   const { meta } = response;
 
   return (
-    <main className="mx-auto flex min-h-[100dvh] w-full max-w-[67.5rem] flex-col gap-6 px-4 pb-16 pt-8 md:px-6">
+    <div className="flex flex-col gap-6">
       <Suspense>
         <SearchForm currentFilter={filter} initialQuery={query} />
       </Suspense>
@@ -129,6 +129,6 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
         />
       )}
       <ScrollToTop />
-    </main>
+    </div>
   );
 }

--- a/src/app/(public)/tags/[slug]/page.tsx
+++ b/src/app/(public)/tags/[slug]/page.tsx
@@ -102,7 +102,7 @@ export default async function TagPostsPage({
   ];
 
   return (
-    <main className="flex min-h-screen flex-col pt-8 pb-16">
+    <div className="flex flex-col">
       {siteUrl ? (
         <JsonLd data={buildBreadcrumbJsonLd(breadcrumbItems, siteUrl)} />
       ) : null}
@@ -140,6 +140,6 @@ export default async function TagPostsPage({
         />
       </div>
       <ScrollToTop />
-    </main>
+    </div>
   );
 }

--- a/src/app/(public)/tags/page.tsx
+++ b/src/app/(public)/tags/page.tsx
@@ -23,7 +23,7 @@ export default async function TagsPage() {
   );
 
   return (
-    <main className="flex min-h-screen flex-col pt-8 pb-16">
+    <div className="flex flex-col">
       <ArchiveHeader
         variant="tag"
         eyebrow="Tag Directory"
@@ -52,6 +52,6 @@ export default async function TagsPage() {
         />
       )}
       <ScrollToTop />
-    </main>
+    </div>
   );
 }

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,59 +1,30 @@
+import { PostListSkeleton } from "@features/post-list/ui/post-list-skeleton";
 import { Skeleton } from "@shared/ui/libs";
-
-const placeholderItems = Array.from({ length: 5 }, (_, index) => index);
 
 export default function Loading() {
   return (
-    <main
-      aria-busy="true"
-      className="mx-auto flex min-h-[100dvh] w-full max-w-[67.5rem] flex-col gap-8 px-4 pb-16 pt-8 md:px-6"
-    >
-      <div className="motion-reveal rounded-4xl border border-border-3 bg-background-2/90 p-6 shadow-[0_16px_48px_rgba(0,0,0,0.06)] md:p-8">
-        <div className="space-y-3">
-          <Skeleton height="1rem" width="7rem" tone="soft" />
-          <Skeleton
-            height="2.5rem"
-            className="max-w-xs rounded-2xl"
-            tone="strong"
-          />
-          <Skeleton
-            height="1rem"
-            className="max-w-lg rounded-full"
-            repeat={2}
-            tone="soft"
-          />
+    <div className="mx-auto flex min-h-[100dvh] w-full max-w-[67.5rem] px-4 md:px-6">
+      <aside aria-hidden="true" className="hidden w-[240px] shrink-0 lg:block">
+        <div className="border-r border-border-3 pt-8 pb-16 pr-8">
+          <div className="space-y-8">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <div key={index} className="space-y-3">
+                <Skeleton height="0.75rem" width="4rem" tone="soft" />
+                <Skeleton repeat={3} height="0.875rem" tone="soft" />
+              </div>
+            ))}
+          </div>
         </div>
-      </div>
+      </aside>
 
-      <ul className="space-y-4">
-        {placeholderItems.map((item) => (
-          <li
-            key={item}
-            className="rounded-3xl border border-border-3 bg-background-2/90 p-5 shadow-[0_12px_32px_rgba(0,0,0,0.04)] sm:p-6"
-          >
-            <div className="mb-4 flex items-center gap-3">
-              <Skeleton
-                height="1.5rem"
-                width="5rem"
-                className="rounded-md"
-                tone="soft"
-              />
-              <Skeleton height="0.875rem" width="4.5rem" tone="soft" />
-            </div>
-            <div className="mb-3">
-              <Skeleton
-                height="1.75rem"
-                className="max-w-[26rem] rounded-[0.875rem]"
-                tone="strong"
-              />
-            </div>
-            <div className="space-y-2">
-              <Skeleton repeat={2} tone="soft" />
-              <Skeleton width="70%" tone="soft" />
-            </div>
-          </li>
-        ))}
-      </ul>
-    </main>
+      <main aria-busy="true" className="min-w-0 flex-1 pt-8 pb-16 lg:pl-8">
+        <div className="flex w-full flex-col gap-3">
+          <header className="pb-1">
+            <Skeleton height="1.938rem" width="6rem" className="rounded-lg" />
+          </header>
+          <PostListSkeleton />
+        </div>
+      </main>
+    </div>
   );
 }

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -8,17 +8,17 @@ export default function Loading() {
       aria-busy="true"
       className="mx-auto flex min-h-[100dvh] w-full max-w-[67.5rem] flex-col gap-8 px-4 pb-16 pt-8 md:px-6"
     >
-      <div className="motion-reveal rounded-[2rem] border border-border-3 bg-background-2/90 p-6 shadow-[0_16px_48px_rgba(0,0,0,0.06)] md:p-8">
+      <div className="motion-reveal rounded-4xl border border-border-3 bg-background-2/90 p-6 shadow-[0_16px_48px_rgba(0,0,0,0.06)] md:p-8">
         <div className="space-y-3">
           <Skeleton height="1rem" width="7rem" tone="soft" />
           <Skeleton
             height="2.5rem"
-            className="max-w-[20rem] rounded-[1rem]"
+            className="max-w-xs rounded-2xl"
             tone="strong"
           />
           <Skeleton
             height="1rem"
-            className="max-w-[32rem] rounded-full"
+            className="max-w-lg rounded-full"
             repeat={2}
             tone="soft"
           />
@@ -29,7 +29,7 @@ export default function Loading() {
         {placeholderItems.map((item) => (
           <li
             key={item}
-            className="rounded-[1.5rem] border border-border-3 bg-background-2/90 p-5 shadow-[0_12px_32px_rgba(0,0,0,0.04)] sm:p-6"
+            className="rounded-3xl border border-border-3 bg-background-2/90 p-5 shadow-[0_12px_32px_rgba(0,0,0,0.04)] sm:p-6"
           >
             <div className="mb-4 flex items-center gap-3">
               <Skeleton

--- a/src/app/manage/layout-shell.tsx
+++ b/src/app/manage/layout-shell.tsx
@@ -102,7 +102,7 @@ export function ManageLayoutShell({ children }: { children: React.ReactNode }) {
       >
         <header
           className={cn(
-            "sticky top-0 z-10 box-border flex items-center gap-4 border-b border-border-4 bg-[rgba(249,249,250,0.8)] px-4 backdrop-blur-[16px] backdrop-saturate-[1.4] dark:bg-[rgba(19,20,21,0.85)] md:px-6",
+            "sticky top-0 z-10 box-border flex items-center gap-4 border-b border-border-4 bg-[rgba(249,249,250,0.8)] px-4 backdrop-blur-lg backdrop-saturate-[1.4] dark:bg-[rgba(19,20,21,0.85)] md:px-6",
             ADMIN_CHROME_HEIGHT_CLASS,
           )}
           style={ADMIN_CHROME_STYLE}

--- a/src/app/manage/layout-shell.tsx
+++ b/src/app/manage/layout-shell.tsx
@@ -52,8 +52,17 @@ function getPageTitle(pathname: string) {
   return PAGE_TITLES.find((entry) => entry.match(pathname))?.title ?? "관리자";
 }
 
+function hasMainPadding(pathname: string) {
+  return (
+    pathname !== "/manage/posts/new" &&
+    !/^\/manage\/posts\/[^/]+\/edit$/.test(pathname)
+  );
+}
+
 export function ManageLayoutShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
+  const mainHasPadding = hasMainPadding(pathname);
+  const mainHeight = `calc(100dvh - ${ADMIN_CHROME_HEIGHT})`;
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const hamburgerRef = useRef<HTMLButtonElement>(null);
@@ -123,8 +132,13 @@ export function ManageLayoutShell({ children }: { children: React.ReactNode }) {
         </header>
 
         <main
-          className="px-4 py-6 md:px-6"
-          style={{ minHeight: `calc(100dvh - ${ADMIN_CHROME_HEIGHT})` }}
+          className={cn(
+            mainHasPadding ? "px-4 py-6 md:px-6" : "overflow-hidden",
+          )}
+          style={{
+            minHeight: mainHeight,
+            height: mainHasPadding ? undefined : mainHeight,
+          }}
         >
           {children}
         </main>

--- a/src/app/manage/loading.tsx
+++ b/src/app/manage/loading.tsx
@@ -3,60 +3,66 @@ import { Skeleton } from "@shared/ui/libs";
 export default function DashboardLoading() {
   return (
     <div aria-busy="true" className="space-y-8">
-      <div className="motion-reveal rounded-[1.75rem] border border-border-3 bg-background-2/90 p-6 shadow-[0_16px_48px_rgba(0,0,0,0.06)]">
-        <div className="space-y-3">
-          <Skeleton height="1rem" width="6rem" tone="soft" />
-          <Skeleton
-            height="2.25rem"
-            width="12rem"
-            className="rounded-2xl"
-            tone="strong"
-          />
-          <Skeleton width="18rem" tone="soft" />
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div
+            key={index}
+            className="rounded-xl border border-border-4 bg-background-2 p-5"
+          >
+            <Skeleton
+              height="2.5rem"
+              width="2.5rem"
+              className="rounded-[0.625rem]"
+            />
+            <div className="mt-5">
+              <Skeleton height="1.75rem" width="5rem" />
+            </div>
+            <div className="mt-3">
+              <Skeleton height="0.875rem" width="4.5rem" />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div
+            key={index}
+            className="rounded-xl border border-border-4 bg-background-2 p-5"
+          >
+            <div className="flex items-center gap-2">
+              <Skeleton height="1rem" width="1rem" />
+              <Skeleton height="1rem" width="4rem" />
+            </div>
+            <div className="mt-5">
+              <Skeleton height="1.75rem" width="3rem" />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <section className="rounded-xl border border-border-4 bg-background-2 p-5">
+        <div className="mb-4 flex items-center gap-3">
+          <Skeleton height="1.25rem" width="5rem" />
+          <Skeleton height="1.25rem" width="3rem" className="rounded-md" />
+          <Skeleton height="1rem" width="4rem" className="ml-auto" />
         </div>
-      </div>
-
-      <div className="grid grid-cols-2 gap-4 md:grid-cols-3 xl:grid-cols-5">
-        {Array.from({ length: 5 }).map((_, index) => (
-          <div
-            key={index}
-            className="rounded-3xl border border-border-3 bg-background-2/90 p-6 shadow-[0_12px_32px_rgba(0,0,0,0.04)]"
-          >
-            <div className="mb-4">
-              <Skeleton height="1rem" width="5rem" tone="soft" />
+        <div className="space-y-1">
+          {Array.from({ length: 5 }).map((_, index) => (
+            <div key={index} className="flex gap-3 rounded-lg px-2 py-3">
+              <Skeleton height="2rem" width="2rem" className="rounded-full" />
+              <div className="flex-1 space-y-2">
+                <div className="flex gap-2">
+                  <Skeleton height="1rem" width="2.25rem" />
+                  <Skeleton height="1rem" width="4rem" />
+                  <Skeleton height="1rem" width="10rem" />
+                </div>
+                <Skeleton height="1rem" />
+              </div>
             </div>
-            <div className="mb-3">
-              <Skeleton height="2.5rem" width="6rem" tone="strong" />
-            </div>
-            <Skeleton tone="soft" />
-          </div>
-        ))}
-      </div>
-
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
-        {Array.from({ length: 2 }).map((_, index) => (
-          <div
-            key={index}
-            className="rounded-3xl border border-border-3 bg-background-2/90 p-6 shadow-[0_12px_32px_rgba(0,0,0,0.04)]"
-          >
-            <Skeleton height="1rem" width="7rem" tone="soft" />
-            <div className="mt-4">
-              <Skeleton height="2rem" width="10rem" tone="strong" />
-            </div>
-            <div className="mt-6 space-y-3">
-              {Array.from({ length: 3 }).map((__, innerIndex) => (
-                <Skeleton
-                  key={innerIndex}
-                  variant="rect"
-                  height="4.5rem"
-                  className="rounded-2xl"
-                  tone="soft"
-                />
-              ))}
-            </div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/app/manage/loading.tsx
+++ b/src/app/manage/loading.tsx
@@ -9,7 +9,7 @@ export default function DashboardLoading() {
           <Skeleton
             height="2.25rem"
             width="12rem"
-            className="rounded-[1rem]"
+            className="rounded-2xl"
             tone="strong"
           />
           <Skeleton width="18rem" tone="soft" />
@@ -20,7 +20,7 @@ export default function DashboardLoading() {
         {Array.from({ length: 5 }).map((_, index) => (
           <div
             key={index}
-            className="rounded-[1.5rem] border border-border-3 bg-background-2/90 p-6 shadow-[0_12px_32px_rgba(0,0,0,0.04)]"
+            className="rounded-3xl border border-border-3 bg-background-2/90 p-6 shadow-[0_12px_32px_rgba(0,0,0,0.04)]"
           >
             <div className="mb-4">
               <Skeleton height="1rem" width="5rem" tone="soft" />
@@ -37,7 +37,7 @@ export default function DashboardLoading() {
         {Array.from({ length: 2 }).map((_, index) => (
           <div
             key={index}
-            className="rounded-[1.5rem] border border-border-3 bg-background-2/90 p-6 shadow-[0_12px_32px_rgba(0,0,0,0.04)]"
+            className="rounded-3xl border border-border-3 bg-background-2/90 p-6 shadow-[0_12px_32px_rgba(0,0,0,0.04)]"
           >
             <Skeleton height="1rem" width="7rem" tone="soft" />
             <div className="mt-4">
@@ -49,7 +49,7 @@ export default function DashboardLoading() {
                   key={innerIndex}
                   variant="rect"
                   height="4.5rem"
-                  className="rounded-[1rem]"
+                  className="rounded-2xl"
                   tone="soft"
                 />
               ))}

--- a/src/app/manage/posts/page.tsx
+++ b/src/app/manage/posts/page.tsx
@@ -25,7 +25,7 @@ import {
   type PostListItem,
 } from "@entities/post";
 import { getErrorMessage } from "@shared/lib/get-error-message";
-import { Modal, Spinner } from "@shared/ui/libs";
+import { DropSelect, Modal, Spinner } from "@shared/ui/libs";
 import {
   BulkActions,
   PostFilters,
@@ -709,26 +709,29 @@ export default function ManagePostsPage() {
             >
               복원할 카테고리
             </label>
-            <select
+            <DropSelect
               id="restore-category"
-              value={restoreCategoryId ?? ""}
-              onChange={(event) =>
-                setRestoreCategoryId(
-                  event.target.value ? Number(event.target.value) : null,
-                )
+              value={
+                restoreCategoryId === null ? "" : String(restoreCategoryId)
+              }
+              onChange={(value) =>
+                setRestoreCategoryId(value ? Number(value) : null)
               }
               disabled={isRestoreCategoryPending}
-              className="w-full rounded-[0.9rem] border border-border-3 bg-background-1 px-4 py-3 text-sm text-text-1 outline-none transition-colors focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              <option value="">
-                {UNCATEGORIZED_LABEL} 글의 카테고리를 선택하세요
-              </option>
-              {flatCategories.map((category) => (
-                <option key={category.id} value={category.id}>
-                  {`${"— ".repeat(category.depth)}${category.name}`}
-                </option>
-              ))}
-            </select>
+              ariaLabel="복원할 카테고리"
+              className="w-full"
+              triggerClassName="h-auto rounded-[0.9rem] px-4 py-3 text-sm text-text-1"
+              options={[
+                {
+                  label: `${UNCATEGORIZED_LABEL} 글의 카테고리를 선택하세요`,
+                  value: "",
+                },
+                ...flatCategories.map((category) => ({
+                  label: `${"— ".repeat(category.depth)}${category.name}`,
+                  value: String(category.id),
+                })),
+              ]}
+            />
             <p className="text-xs text-text-4">
               선택한 카테고리가 카테고리 없는 글에 일괄 적용된 뒤 복원이
               진행됩니다.

--- a/src/app/manage/posts/page.tsx
+++ b/src/app/manage/posts/page.tsx
@@ -688,7 +688,7 @@ export default function ManagePostsPage() {
         withBackground
         aria-label="복원 카테고리 선택"
       >
-        <div className="w-full max-w-xl rounded-[1.5rem] bg-background-1 p-6 text-left">
+        <div className="w-full max-w-xl rounded-3xl bg-background-1 p-6 text-left">
           <div className="space-y-2">
             <p className="text-xs uppercase tracking-[0.24em] text-text-4">
               Restore

--- a/src/app/manage/posts/post-editor-screen.tsx
+++ b/src/app/manage/posts/post-editor-screen.tsx
@@ -17,7 +17,7 @@ function EditorSkeleton() {
     <div className="flex h-full flex-col gap-4 bg-background-1 p-4 md:p-6">
       <div className="h-14 animate-pulse rounded-2xl bg-background-2" />
       <div className="grid min-h-0 flex-1 gap-4 xl:grid-cols-[24rem_minmax(0,1fr)]">
-        <div className="space-y-4 rounded-[1.5rem] bg-background-2 p-5">
+        <div className="space-y-4 rounded-3xl bg-background-2 p-5">
           {Array.from({ length: 7 }).map((_, index) => (
             <div
               key={index}
@@ -25,8 +25,8 @@ function EditorSkeleton() {
             />
           ))}
         </div>
-        <div className="rounded-[1.5rem] bg-background-2 p-5">
-          <div className="h-full min-h-[24rem] animate-pulse rounded-xl bg-background-3" />
+        <div className="rounded-3xl bg-background-2 p-5">
+          <div className="h-full min-h-96 animate-pulse rounded-xl bg-background-3" />
         </div>
       </div>
     </div>
@@ -44,7 +44,7 @@ function EditorError({
 
   return (
     <div className="flex h-full items-center justify-center bg-background-1 p-4 md:p-6">
-      <div className="w-full max-w-lg rounded-[1.5rem] border border-negative-1/20 bg-negative-1/10 px-6 py-8">
+      <div className="w-full max-w-lg rounded-3xl border border-negative-1/20 bg-negative-1/10 px-6 py-8">
         <h1 className="text-lg font-semibold text-negative-1">
           글을 불러오지 못했습니다.
         </h1>
@@ -54,7 +54,7 @@ function EditorError({
             <button
               type="button"
               onClick={onRetry}
-              className="inline-flex rounded-[0.75rem] border border-negative-1/20 px-4 py-2 text-sm font-medium text-negative-1 transition-colors hover:bg-negative-1/10"
+              className="inline-flex rounded-xl border border-negative-1/20 px-4 py-2 text-sm font-medium text-negative-1 transition-colors hover:bg-negative-1/10"
             >
               다시 시도
             </button>
@@ -62,7 +62,7 @@ function EditorError({
           <button
             type="button"
             onClick={() => router.push("/manage/posts")}
-            className="inline-flex rounded-[0.75rem] border border-border-3 px-4 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
+            className="inline-flex rounded-xl border border-border-3 px-4 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
           >
             목록으로
           </button>

--- a/src/app/manage/posts/post-editor-screen.tsx
+++ b/src/app/manage/posts/post-editor-screen.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { ADMIN_CHROME_HEIGHT } from "../ui/admin-shell-constants";
 import { PostForm, type PostFormValues } from "@features/post-editor";
 
 interface PostEditorScreenProps {
@@ -11,17 +10,6 @@ interface PostEditorScreenProps {
   isPending?: boolean;
   errorMessage?: string | null;
   onRetry?: () => void;
-}
-
-function FullBleedFrame({ children }: { children: React.ReactNode }) {
-  return (
-    <div
-      className="-mx-4 -my-6 h-full w-full md:-mx-6"
-      style={{ height: `calc(100dvh - ${ADMIN_CHROME_HEIGHT})` }}
-    >
-      <div className="h-full w-full">{children}</div>
-    </div>
-  );
 }
 
 function EditorSkeleton() {
@@ -95,7 +83,7 @@ export function PostEditorScreen({
   const router = useRouter();
 
   return (
-    <FullBleedFrame>
+    <div className="h-full min-h-0 w-full">
       {isPending ? (
         <EditorSkeleton />
       ) : errorMessage ? (
@@ -110,6 +98,6 @@ export function PostEditorScreen({
           onSuccess={() => router.push("/manage/posts")}
         />
       )}
-    </FullBleedFrame>
+    </div>
   );
 }

--- a/src/entities/asset/ui/asset-picker-modal.tsx
+++ b/src/entities/asset/ui/asset-picker-modal.tsx
@@ -15,7 +15,7 @@ import type { Asset, AssetCategory } from "../model";
 import { normalizeAssetUrl, toCanonicalAssetUrl } from "@shared/lib/asset-url";
 import { getErrorMessage } from "@shared/lib/get-error-message";
 import { cn } from "@shared/lib/style-utils";
-import { Modal } from "@shared/ui/libs";
+import { DropSelect, Modal } from "@shared/ui/libs";
 
 const PAGE_SIZE = 18;
 
@@ -166,23 +166,20 @@ export function AssetPickerModal({
               placeholder="별명 또는 파일명 검색"
               className="h-10 rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1"
             />
-            <select
-              value={categoryId ?? ""}
-              onChange={(event) =>
-                setCategoryId(
-                  event.target.value ? Number(event.target.value) : null,
-                )
-              }
-              className="h-10 rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors focus:border-primary-1"
-              aria-label="에셋 카테고리"
-            >
-              <option value="">전체 카테고리</option>
-              {categories.map((category) => (
-                <option key={category.id} value={category.id}>
-                  {category.name}
-                </option>
-              ))}
-            </select>
+            <DropSelect
+              value={categoryId === null ? "" : String(categoryId)}
+              onChange={(value) => setCategoryId(value ? Number(value) : null)}
+              className="w-full"
+              triggerClassName="h-10 rounded-[0.75rem] text-sm text-text-2"
+              ariaLabel="에셋 카테고리"
+              options={[
+                { label: "전체 카테고리", value: "" },
+                ...categories.map((category) => ({
+                  label: category.name,
+                  value: String(category.id),
+                })),
+              ]}
+            />
             <label className="inline-flex h-10 items-center gap-2 rounded-[0.75rem] border border-border-3 px-3 text-sm text-text-2">
               <input
                 type="checkbox"

--- a/src/entities/asset/ui/asset-picker-modal.tsx
+++ b/src/entities/asset/ui/asset-picker-modal.tsx
@@ -124,7 +124,7 @@ export function AssetPickerModal({
       aria-label="에셋 선택"
       className="w-[min(94vw,72rem)] p-0 text-left max-sm:w-screen max-sm:max-w-none"
     >
-      <div className="flex h-[min(88vh,56rem)] flex-col overflow-hidden rounded-[1.5rem] bg-background-1 max-sm:h-dvh max-sm:rounded-none">
+      <div className="flex h-[min(88vh,56rem)] flex-col overflow-hidden rounded-3xl bg-background-1 max-sm:h-dvh max-sm:rounded-none">
         <div className="border-b border-border-3 px-6 py-5">
           <div className="flex items-start justify-between gap-4">
             <div>
@@ -164,13 +164,13 @@ export function AssetPickerModal({
               value={search}
               onChange={(event) => setSearch(event.target.value)}
               placeholder="별명 또는 파일명 검색"
-              className="h-10 rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1"
+              className="h-10 rounded-xl border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1"
             />
             <DropSelect
               value={categoryId === null ? "" : String(categoryId)}
               onChange={(value) => setCategoryId(value ? Number(value) : null)}
               className="w-full"
-              triggerClassName="h-10 rounded-[0.75rem] text-sm text-text-2"
+              triggerClassName="h-10 rounded-xl text-sm text-text-2"
               ariaLabel="에셋 카테고리"
               options={[
                 { label: "전체 카테고리", value: "" },
@@ -180,7 +180,7 @@ export function AssetPickerModal({
                 })),
               ]}
             />
-            <label className="inline-flex h-10 items-center gap-2 rounded-[0.75rem] border border-border-3 px-3 text-sm text-text-2">
+            <label className="inline-flex h-10 items-center gap-2 rounded-xl border border-border-3 px-3 text-sm text-text-2">
               <input
                 type="checkbox"
                 checked={currentPostFirst}
@@ -195,7 +195,7 @@ export function AssetPickerModal({
 
         <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
           {categoriesQuery.isError ? (
-            <div className="mb-4 rounded-[1rem] border border-warning-1/20 bg-warning-1/10 px-4 py-3 text-sm text-warning-1">
+            <div className="mb-4 rounded-2xl border border-warning-1/20 bg-warning-1/10 px-4 py-3 text-sm text-warning-1">
               {getErrorMessage(
                 categoriesQuery.error,
                 "에셋 카테고리를 불러오지 못했습니다.",
@@ -208,14 +208,14 @@ export function AssetPickerModal({
               {Array.from({ length: 6 }).map((_, index) => (
                 <div
                   key={index}
-                  className="aspect-[4/3] animate-pulse rounded-[1.25rem] bg-background-2"
+                  className="aspect-4/3 animate-pulse rounded-[1.25rem] bg-background-2"
                 />
               ))}
             </div>
           ) : null}
 
           {assetsQuery.isError ? (
-            <div className="rounded-[1rem] border border-negative-1/20 bg-negative-1/5 px-4 py-3 text-sm text-negative-1">
+            <div className="rounded-2xl border border-negative-1/20 bg-negative-1/5 px-4 py-3 text-sm text-negative-1">
               {getErrorMessage(
                 assetsQuery.error,
                 "에셋 목록을 불러오지 못했습니다.",
@@ -269,7 +269,7 @@ export function AssetPickerModal({
               type="button"
               onClick={() => setPage((current) => Math.max(1, current - 1))}
               disabled={!meta || meta.page <= 1}
-              className="inline-flex items-center justify-center rounded-[0.75rem] border border-border-3 px-3 py-2 text-sm text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex items-center justify-center rounded-xl border border-border-3 px-3 py-2 text-sm text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
             >
               이전
             </button>
@@ -284,14 +284,14 @@ export function AssetPickerModal({
                 )
               }
               disabled={!meta || meta.page >= meta.totalPages}
-              className="inline-flex items-center justify-center rounded-[0.75rem] border border-border-3 px-3 py-2 text-sm text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex items-center justify-center rounded-xl border border-border-3 px-3 py-2 text-sm text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
             >
               다음
             </button>
             <button
               type="button"
               onClick={onClose}
-              className="inline-flex items-center justify-center rounded-[0.75rem] border border-border-3 px-4 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
+              className="inline-flex items-center justify-center rounded-xl border border-border-3 px-4 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
             >
               취소
             </button>
@@ -299,7 +299,7 @@ export function AssetPickerModal({
               type="button"
               onClick={() => selectedAsset && onSelect(selectedAsset.url)}
               disabled={!selectedAsset}
-              className="inline-flex items-center justify-center rounded-[0.75rem] bg-primary-1 px-4 py-2 text-sm font-semibold text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center justify-center rounded-xl bg-primary-1 px-4 py-2 text-sm font-semibold text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
             >
               선택
             </button>
@@ -369,15 +369,15 @@ function CategoryChips({
 function SelectedAssetSummary({ asset }: { asset: Asset | null }) {
   if (!asset) {
     return (
-      <div className="flex min-h-16 items-center rounded-[1rem] border border-border-4 bg-background-2 px-4 text-sm text-text-4">
+      <div className="flex min-h-16 items-center rounded-2xl border border-border-4 bg-background-2 px-4 text-sm text-text-4">
         선택된 에셋이 없습니다.
       </div>
     );
   }
 
   return (
-    <div className="flex min-h-16 items-center gap-3 rounded-[1rem] border border-border-4 bg-background-2 p-3">
-      <div className="h-12 w-16 shrink-0 overflow-hidden rounded-[0.75rem] bg-background-3">
+    <div className="flex min-h-16 items-center gap-3 rounded-2xl border border-border-4 bg-background-2 p-3">
+      <div className="h-12 w-16 shrink-0 overflow-hidden rounded-xl bg-background-3">
         {/* eslint-disable-next-line @next/next/no-img-element -- arbitrary admin asset hosts are allowed */}
         <img
           src={normalizeAssetUrl(asset.url)}
@@ -422,7 +422,7 @@ function AssetPickerCard({
       )}
       aria-pressed={isSelected}
     >
-      <div className="relative aspect-[4/3] overflow-hidden bg-background-3">
+      <div className="relative aspect-4/3 overflow-hidden bg-background-3">
         {hasError ? (
           <div className="flex h-full items-center justify-center px-4 text-sm text-text-4">
             미리보기 실패

--- a/src/features/admin-login/ui/login-form.tsx
+++ b/src/features/admin-login/ui/login-form.tsx
@@ -68,7 +68,7 @@ export function LoginForm() {
             onChange={(event) => setUsername(event.target.value)}
             placeholder="사용자명을 입력하세요"
             disabled={busy}
-            className="mt-2 w-full rounded-[1rem] border border-border-3 bg-background-1 px-4 py-3 text-body-sm text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+            className="mt-2 w-full rounded-2xl border border-border-3 bg-background-1 px-4 py-3 text-body-sm text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
             required
             autoCapitalize="none"
             autoCorrect="off"
@@ -88,7 +88,7 @@ export function LoginForm() {
             onChange={(event) => setPassword(event.target.value)}
             placeholder="비밀번호를 입력하세요"
             disabled={busy}
-            className="mt-2 w-full rounded-[1rem] border border-border-3 bg-background-1 px-4 py-3 text-body-sm text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+            className="mt-2 w-full rounded-2xl border border-border-3 bg-background-1 px-4 py-3 text-body-sm text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
             required
           />
         </label>
@@ -97,7 +97,7 @@ export function LoginForm() {
       <button
         type="submit"
         disabled={busy}
-        className="mt-8 inline-flex w-full items-center justify-center rounded-[1rem] bg-primary-1 px-4 py-3 text-body-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+        className="mt-8 inline-flex w-full items-center justify-center rounded-2xl bg-primary-1 px-4 py-3 text-body-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
       >
         {busy ? (
           <>

--- a/src/features/asset-uploader/ui/asset-bulk-action-bar.tsx
+++ b/src/features/asset-uploader/ui/asset-bulk-action-bar.tsx
@@ -1,4 +1,5 @@
 import type { AssetCategory } from "@entities/asset";
+import { DropSelect } from "@shared/ui/libs";
 
 interface AssetBulkActionBarProps {
   selectedCount: number;
@@ -34,24 +35,23 @@ export function AssetBulkActionBar({
           선택됨 {selectedCount}개
         </span>
         <div className="ml-auto flex flex-wrap items-center gap-2">
-          <select
-            value={bulkCategoryId ?? ""}
-            onChange={(event) =>
-              onBulkCategoryChange(
-                event.target.value ? Number(event.target.value) : null,
-              )
+          <DropSelect
+            value={bulkCategoryId === null ? "" : String(bulkCategoryId)}
+            onChange={(value) =>
+              onBulkCategoryChange(value ? Number(value) : null)
             }
             disabled={selectedCount === 0 || isApplyingCategory}
-            className="h-9 rounded-[0.7rem] border border-border-3 bg-background-1 px-2 text-sm text-text-2 outline-none disabled:cursor-not-allowed disabled:opacity-50"
-            aria-label="선택 에셋 카테고리"
-          >
-            <option value="">카테고리 변경</option>
-            {categories.map((category) => (
-              <option key={category.id} value={category.id}>
-                {category.name}
-              </option>
-            ))}
-          </select>
+            ariaLabel="선택 에셋 카테고리"
+            className="min-w-36"
+            triggerClassName="h-9 rounded-[0.7rem] px-2 pr-8 text-sm text-text-2 disabled:opacity-50"
+            options={[
+              { label: "카테고리 변경", value: "" },
+              ...categories.map((category) => ({
+                label: category.name,
+                value: String(category.id),
+              })),
+            ]}
+          />
           <button
             type="button"
             onClick={onApplyCategory}

--- a/src/features/asset-uploader/ui/asset-bulk-action-bar.tsx
+++ b/src/features/asset-uploader/ui/asset-bulk-action-bar.tsx
@@ -30,7 +30,7 @@ export function AssetBulkActionBar({
 }: AssetBulkActionBarProps) {
   return (
     <div className="fixed bottom-0 left-0 right-0 z-20 md:left-[var(--admin-sidebar-offset)]">
-      <div className="flex flex-wrap items-center gap-3 border-t border-border-3 bg-[rgba(241,242,243,0.95)] px-4 py-3 backdrop-blur-[12px] md:px-6 dark:bg-[rgba(19,20,21,0.94)]">
+      <div className="flex flex-wrap items-center gap-3 border-t border-border-3 bg-[rgba(241,242,243,0.95)] px-4 py-3 backdrop-blur-md md:px-6 dark:bg-[rgba(19,20,21,0.94)]">
         <span className="text-sm font-medium text-text-1">
           선택됨 {selectedCount}개
         </span>

--- a/src/features/asset-uploader/ui/asset-bulk-action-bar.tsx
+++ b/src/features/asset-uploader/ui/asset-bulk-action-bar.tsx
@@ -1,0 +1,93 @@
+import type { AssetCategory } from "@entities/asset";
+
+interface AssetBulkActionBarProps {
+  selectedCount: number;
+  categories: AssetCategory[];
+  bulkCategoryId: number | null;
+  isApplyingCategory: boolean;
+  isDeleting: boolean;
+  isPageFullySelected: boolean;
+  onBulkCategoryChange: (categoryId: number | null) => void;
+  onApplyCategory: () => void;
+  onToggleSelectAll: () => void;
+  onRequestDelete: () => void;
+  onDone: () => void;
+}
+
+export function AssetBulkActionBar({
+  selectedCount,
+  categories,
+  bulkCategoryId,
+  isApplyingCategory,
+  isDeleting,
+  isPageFullySelected,
+  onBulkCategoryChange,
+  onApplyCategory,
+  onToggleSelectAll,
+  onRequestDelete,
+  onDone,
+}: AssetBulkActionBarProps) {
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-20 md:left-[var(--admin-sidebar-offset)]">
+      <div className="flex flex-wrap items-center gap-3 border-t border-border-3 bg-[rgba(241,242,243,0.95)] px-4 py-3 backdrop-blur-[12px] md:px-6 dark:bg-[rgba(19,20,21,0.94)]">
+        <span className="text-sm font-medium text-text-1">
+          선택됨 {selectedCount}개
+        </span>
+        <div className="ml-auto flex flex-wrap items-center gap-2">
+          <select
+            value={bulkCategoryId ?? ""}
+            onChange={(event) =>
+              onBulkCategoryChange(
+                event.target.value ? Number(event.target.value) : null,
+              )
+            }
+            disabled={selectedCount === 0 || isApplyingCategory}
+            className="h-9 rounded-[0.7rem] border border-border-3 bg-background-1 px-2 text-sm text-text-2 outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label="선택 에셋 카테고리"
+          >
+            <option value="">카테고리 변경</option>
+            {categories.map((category) => (
+              <option key={category.id} value={category.id}>
+                {category.name}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={onApplyCategory}
+            disabled={
+              selectedCount === 0 ||
+              bulkCategoryId === null ||
+              isApplyingCategory
+            }
+            className="inline-flex h-9 cursor-pointer items-center rounded-[0.7rem] border border-border-3 px-3 text-sm text-text-2 transition-colors hover:bg-background-1 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {isApplyingCategory ? "변경 중" : "카테고리 적용"}
+          </button>
+          <button
+            type="button"
+            onClick={onToggleSelectAll}
+            className="cursor-pointer px-2 py-1.5 text-sm text-primary-1 transition-colors hover:text-primary-1/80"
+          >
+            {isPageFullySelected ? "전체 해제" : "전체 선택"}
+          </button>
+          <button
+            type="button"
+            onClick={onRequestDelete}
+            disabled={selectedCount === 0 || isDeleting}
+            className="inline-flex h-9 cursor-pointer items-center rounded-[0.7rem] border border-negative-1/30 px-3 text-sm text-negative-1 transition-colors hover:bg-negative-1/10 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            삭제
+          </button>
+          <button
+            type="button"
+            onClick={onDone}
+            className="inline-flex h-9 cursor-pointer items-center rounded-[0.7rem] bg-primary-1 px-3 text-sm text-white transition-opacity hover:opacity-90"
+          >
+            완료
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/asset-uploader/ui/asset-category-manager-modal.tsx
+++ b/src/features/asset-uploader/ui/asset-category-manager-modal.tsx
@@ -56,7 +56,7 @@ export function AssetCategoryManagerModal({
       aria-label="에셋 카테고리 관리"
       className="w-[min(100%,38rem)] p-0 text-left"
     >
-      <div className="flex max-h-[86vh] flex-col overflow-hidden rounded-[1.5rem] bg-background-1">
+      <div className="flex max-h-[86vh] flex-col overflow-hidden rounded-3xl bg-background-1">
         <div className="flex items-start justify-between gap-4 border-b border-border-3 px-6 py-5">
           <div>
             <p className="text-body-xs uppercase tracking-[0.2em] text-text-4">
@@ -95,12 +95,12 @@ export function AssetCategoryManagerModal({
               onChange={(event) => setNewName(event.target.value)}
               disabled={isMutating}
               placeholder="새 카테고리 이름"
-              className="h-10 min-w-0 flex-1 rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+              className="h-10 min-w-0 flex-1 rounded-xl border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
             />
             <button
               type="submit"
               disabled={isMutating || newName.trim().length === 0}
-              className="inline-flex h-10 items-center justify-center rounded-[0.75rem] bg-primary-1 px-4 text-sm font-semibold text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex h-10 items-center justify-center rounded-xl bg-primary-1 px-4 text-sm font-semibold text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
             >
               추가
             </button>
@@ -115,7 +115,7 @@ export function AssetCategoryManagerModal({
               return (
                 <div
                   key={category.id}
-                  className="rounded-[1rem] border border-border-4 bg-background-2 p-3"
+                  className="rounded-2xl border border-border-4 bg-background-2 p-3"
                 >
                   <div className="mb-3 flex flex-wrap items-center gap-2">
                     <span
@@ -143,14 +143,14 @@ export function AssetCategoryManagerModal({
                         }))
                       }
                       disabled={isMutating}
-                      className="h-10 rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+                      className="h-10 rounded-xl border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
                       aria-label={`${category.name} 이름`}
                     />
                     <button
                       type="button"
                       onClick={() => onRename(category, draft.trim())}
                       disabled={isMutating || !isChanged || !draft.trim()}
-                      className="inline-flex h-10 items-center justify-center rounded-[0.75rem] border border-border-3 px-3 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
+                      className="inline-flex h-10 items-center justify-center rounded-xl border border-border-3 px-3 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       {isPending ? <Spinner size="sm" /> : null}
                       저장
@@ -160,7 +160,7 @@ export function AssetCategoryManagerModal({
                         type="button"
                         onClick={() => onDelete(category)}
                         disabled={isMutating}
-                        className="inline-flex h-10 items-center justify-center gap-1.5 rounded-[0.75rem] border border-negative-1/25 px-3 text-sm font-medium text-negative-1 transition-colors hover:bg-negative-1/10 disabled:cursor-not-allowed disabled:opacity-50"
+                        className="inline-flex h-10 items-center justify-center gap-1.5 rounded-xl border border-negative-1/25 px-3 text-sm font-medium text-negative-1 transition-colors hover:bg-negative-1/10 disabled:cursor-not-allowed disabled:opacity-50"
                       >
                         <Icon icon={trashBinMinimalisticLinear} width="15" />
                         삭제

--- a/src/features/asset-uploader/ui/asset-detail-modal.tsx
+++ b/src/features/asset-uploader/ui/asset-detail-modal.tsx
@@ -105,7 +105,7 @@ export function AssetDetailModal({
       aria-label="에셋 상세 보기"
       className="w-[min(94vw,42rem)] p-0 text-left"
     >
-      <div className="flex max-h-[90vh] flex-col overflow-hidden rounded-[1.5rem] bg-background-1">
+      <div className="flex max-h-[90vh] flex-col overflow-hidden rounded-3xl bg-background-1">
         <div className="flex items-center justify-between gap-4 border-b border-border-3 px-6 py-4">
           <h3 className="truncate text-lg font-bold text-text-1">
             {getAssetDisplayName(asset)}
@@ -181,7 +181,7 @@ export function AssetDetailModal({
             />
           </dl>
 
-          <div className="mb-6 rounded-[1rem] border border-border-3 bg-background-2 p-4">
+          <div className="mb-6 rounded-2xl border border-border-3 bg-background-2 p-4">
             <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
               <div>
                 <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-text-4">
@@ -209,7 +209,7 @@ export function AssetDetailModal({
                   maxLength={200}
                   onChange={(event) => setDisplayNameDraft(event.target.value)}
                   disabled={isSavingMetadata}
-                  className="h-10 rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+                  className="h-10 rounded-xl border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
                   placeholder={getAssetFilename(asset.url)}
                 />
               </label>
@@ -225,7 +225,7 @@ export function AssetDetailModal({
                   disabled={isSavingMetadata}
                   ariaLabel="카테고리"
                   className="w-full"
-                  triggerClassName="h-10 rounded-[0.75rem] text-sm text-text-2"
+                  triggerClassName="h-10 rounded-xl text-sm text-text-2"
                   placeholder="카테고리 선택"
                   options={categories.map((category) => ({
                     label: category.name,
@@ -252,7 +252,7 @@ export function AssetDetailModal({
                   !isMetadataChanged ||
                   categoryIdDraft === null
                 }
-                className="inline-flex h-9 items-center justify-center rounded-[0.75rem] bg-primary-1 px-4 text-sm font-semibold text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+                className="inline-flex h-9 items-center justify-center rounded-xl bg-primary-1 px-4 text-sm font-semibold text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
               >
                 {isSavingMetadata ? "저장 중" : "저장"}
               </button>
@@ -308,9 +308,7 @@ function CodeInfoBlock({
   return (
     <div>
       <div className="mb-2 flex items-center justify-between gap-3">
-        <p className="text-[12px] font-normal leading-none text-text-3">
-          {label}
-        </p>
+        <p className="text-xs font-normal leading-none text-text-3">{label}</p>
         <button
           type="button"
           onClick={onCopy}
@@ -330,10 +328,10 @@ function CodeInfoBlock({
 function InfoRow({ label, value }: { label: string; value: string }) {
   return (
     <div>
-      <dt className="mb-1.5 text-[12px] font-normal leading-none text-text-3">
+      <dt className="mb-1.5 text-xs font-normal leading-none text-text-3">
         {label}
       </dt>
-      <dd className="pl-2 text-[14px] font-normal leading-[1.25rem] text-text-1">
+      <dd className="pl-2 text-sm font-normal leading-5 text-text-1">
         {value}
       </dd>
     </div>
@@ -349,7 +347,7 @@ function AssetPreview({ asset }: { asset: Asset }) {
 
   if (hasError) {
     return (
-      <div className="flex min-h-[18rem] items-center justify-center px-6 py-10 text-sm text-text-4">
+      <div className="flex min-h-72 items-center justify-center px-6 py-10 text-sm text-text-4">
         이미지를 불러오지 못했습니다.
       </div>
     );

--- a/src/features/asset-uploader/ui/asset-detail-modal.tsx
+++ b/src/features/asset-uploader/ui/asset-detail-modal.tsx
@@ -162,7 +162,7 @@ export function AssetDetailModal({
             </button>
           </div>
 
-          <dl className="mb-6 grid grid-cols-2 gap-x-6 gap-y-3">
+          <dl className="mb-4 grid grid-cols-2 gap-x-6 gap-y-3">
             <InfoRow label="별명" value={asset.displayName ?? "-"} />
             <InfoRow label="카테고리" value={asset.category.name} />
             <InfoRow label="파일명" value={getAssetFilename(asset.url)} />
@@ -181,84 +181,6 @@ export function AssetDetailModal({
             />
           </dl>
 
-          <div className="mb-6 rounded-2xl border border-border-3 bg-background-2 p-4">
-            <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
-              <div>
-                <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-text-4">
-                  Metadata
-                </p>
-                <p className="mt-1 text-sm text-text-3">
-                  별명과 카테고리는 검색과 필터에만 사용됩니다.
-                </p>
-              </div>
-              <span
-                className={cn(
-                  "rounded-full border px-2 py-1 text-[11px] font-semibold",
-                  getAssetCategoryTone(asset.category),
-                )}
-              >
-                {asset.category.name}
-              </span>
-            </div>
-            <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_12rem]">
-              <label className="grid gap-1.5">
-                <span className="text-[12px] text-text-3">별명</span>
-                <input
-                  type="text"
-                  value={displayNameDraft}
-                  maxLength={200}
-                  onChange={(event) => setDisplayNameDraft(event.target.value)}
-                  disabled={isSavingMetadata}
-                  className="h-10 rounded-xl border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
-                  placeholder={getAssetFilename(asset.url)}
-                />
-              </label>
-              <label className="grid gap-1.5">
-                <span className="text-[12px] text-text-3">카테고리</span>
-                <DropSelect
-                  value={
-                    categoryIdDraft === null ? "" : String(categoryIdDraft)
-                  }
-                  onChange={(value) =>
-                    setCategoryIdDraft(value ? Number(value) : null)
-                  }
-                  disabled={isSavingMetadata}
-                  ariaLabel="카테고리"
-                  className="w-full"
-                  triggerClassName="h-10 rounded-xl text-sm text-text-2"
-                  placeholder="카테고리 선택"
-                  options={categories.map((category) => ({
-                    label: category.name,
-                    value: String(category.id),
-                  }))}
-                />
-              </label>
-            </div>
-            <div className="mt-4 flex justify-end">
-              <button
-                type="button"
-                onClick={() => {
-                  if (categoryIdDraft === null) {
-                    return;
-                  }
-
-                  onUpdateMetadata(asset, {
-                    displayName: displayNameDraft.trim() || null,
-                    categoryId: categoryIdDraft,
-                  });
-                }}
-                disabled={
-                  isSavingMetadata ||
-                  !isMetadataChanged ||
-                  categoryIdDraft === null
-                }
-                className="inline-flex h-9 items-center justify-center rounded-xl bg-primary-1 px-4 text-sm font-semibold text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {isSavingMetadata ? "저장 중" : "저장"}
-              </button>
-            </div>
-          </div>
-
           <div className="space-y-4">
             <CodeInfoBlock
               label="URL"
@@ -276,7 +198,71 @@ export function AssetDetailModal({
             />
           </div>
 
-          <div className="mt-6 flex justify-end">
+          <div className="mt-4 grid gap-3 md:grid-cols-[minmax(0,1fr)_12rem]">
+            <label className="grid gap-1.5">
+              <span className="text-[12px] text-text-3">별명</span>
+              <input
+                type="text"
+                value={displayNameDraft}
+                maxLength={200}
+                onChange={(event) => setDisplayNameDraft(event.target.value)}
+                disabled={isSavingMetadata}
+                className="h-10 rounded-xl border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+                placeholder={getAssetFilename(asset.url)}
+              />
+            </label>
+            <label className="grid gap-1.5">
+              <div>
+                <span className="text-[12px] text-text-3 mr-1">카테고리</span>
+                <span
+                  className={cn(
+                    "rounded-full border px-2 py-1 text-[11px] font-semibold",
+                    getAssetCategoryTone(asset.category),
+                  )}
+                >
+                  {asset.category.name}
+                </span>
+              </div>
+              <DropSelect
+                value={categoryIdDraft === null ? "" : String(categoryIdDraft)}
+                onChange={(value) =>
+                  setCategoryIdDraft(value ? Number(value) : null)
+                }
+                disabled={isSavingMetadata}
+                ariaLabel="카테고리"
+                className="w-full"
+                triggerClassName="h-10 rounded-xl text-sm text-text-2"
+                placeholder="카테고리 선택"
+                options={categories.map((category) => ({
+                  label: category.name,
+                  value: String(category.id),
+                }))}
+              />
+            </label>
+          </div>
+
+          <div className="mt-6 flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={() => {
+                if (categoryIdDraft === null) {
+                  return;
+                }
+
+                onUpdateMetadata(asset, {
+                  displayName: displayNameDraft.trim() || null,
+                  categoryId: categoryIdDraft,
+                });
+              }}
+              disabled={
+                isSavingMetadata ||
+                !isMetadataChanged ||
+                categoryIdDraft === null
+              }
+              className="inline-flex h-9 items-center justify-center rounded-xl bg-primary-1 px-4 text-sm font-semibold text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isSavingMetadata ? "저장 중" : "저장"}
+            </button>
             <button
               type="button"
               onClick={() => onRequestDelete(asset)}

--- a/src/features/asset-uploader/ui/asset-detail-modal.tsx
+++ b/src/features/asset-uploader/ui/asset-detail-modal.tsx
@@ -17,7 +17,7 @@ import {
   getAssetFilename,
 } from "@entities/asset";
 import { cn } from "@shared/lib/style-utils";
-import { Modal } from "@shared/ui/libs";
+import { DropSelect, Modal } from "@shared/ui/libs";
 
 interface AssetDetailModalProps {
   assets: Asset[];
@@ -215,22 +215,23 @@ export function AssetDetailModal({
               </label>
               <label className="grid gap-1.5">
                 <span className="text-[12px] text-text-3">카테고리</span>
-                <select
-                  value={categoryIdDraft ?? ""}
-                  onChange={(event) =>
-                    setCategoryIdDraft(
-                      event.target.value ? Number(event.target.value) : null,
-                    )
+                <DropSelect
+                  value={
+                    categoryIdDraft === null ? "" : String(categoryIdDraft)
+                  }
+                  onChange={(value) =>
+                    setCategoryIdDraft(value ? Number(value) : null)
                   }
                   disabled={isSavingMetadata}
-                  className="h-10 rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
-                >
-                  {categories.map((category) => (
-                    <option key={category.id} value={category.id}>
-                      {category.name}
-                    </option>
-                  ))}
-                </select>
+                  ariaLabel="카테고리"
+                  className="w-full"
+                  triggerClassName="h-10 rounded-[0.75rem] text-sm text-text-2"
+                  placeholder="카테고리 선택"
+                  options={categories.map((category) => ({
+                    label: category.name,
+                    value: String(category.id),
+                  }))}
+                />
               </label>
             </div>
             <div className="mt-4 flex justify-end">

--- a/src/features/asset-uploader/ui/asset-grid-skeleton.tsx
+++ b/src/features/asset-uploader/ui/asset-grid-skeleton.tsx
@@ -7,7 +7,7 @@ export function AssetGridSkeleton() {
             key={index}
             className="overflow-hidden rounded-[1.4rem] border border-border-3 bg-background-1"
           >
-            <div className="aspect-[4/3] animate-pulse bg-background-3" />
+            <div className="aspect-4/3 animate-pulse bg-background-3" />
             <div className="space-y-3 p-4">
               <div className="h-4 w-2/3 animate-pulse rounded bg-background-3" />
               <div className="h-3 w-1/2 animate-pulse rounded bg-background-3" />

--- a/src/features/asset-uploader/ui/asset-grid-skeleton.tsx
+++ b/src/features/asset-uploader/ui/asset-grid-skeleton.tsx
@@ -1,16 +1,32 @@
 export function AssetGridSkeleton() {
   return (
-    <section className="rounded-[1.75rem] border border-border-3 bg-background-2 p-6">
+    <section aria-busy="true" className="space-y-6">
+      <div className="border-b border-border-4 pb-6">
+        <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_14rem_auto]">
+          <div className="flex min-w-0 gap-2">
+            <div className="h-10 w-[5.75rem] shrink-0 animate-pulse rounded-xl bg-background-3" />
+            <div className="h-10 min-w-0 flex-1 animate-pulse rounded-xl bg-background-3" />
+          </div>
+          <div className="h-10 animate-pulse rounded-xl bg-background-3" />
+          <div className="h-10 animate-pulse rounded-xl bg-background-3 lg:w-[5.75rem]" />
+        </div>
+      </div>
       <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
         {Array.from({ length: 6 }).map((_, index) => (
           <div
             key={index}
-            className="overflow-hidden rounded-[1.4rem] border border-border-3 bg-background-1"
+            className="overflow-hidden rounded-xl border border-border-4 bg-background-2"
           >
             <div className="aspect-4/3 animate-pulse bg-background-3" />
-            <div className="space-y-3 p-4">
-              <div className="h-4 w-2/3 animate-pulse rounded bg-background-3" />
-              <div className="h-3 w-1/2 animate-pulse rounded bg-background-3" />
+            <div className="space-y-1 p-3">
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0 flex-1 space-y-1">
+                  <div className="h-[13px] w-2/3 animate-pulse rounded bg-background-3" />
+                  <div className="h-3 w-1/2 animate-pulse rounded bg-background-3" />
+                </div>
+                <div className="h-5 w-14 shrink-0 animate-pulse rounded-full bg-background-3" />
+              </div>
+              <div className="h-3 w-4/5 animate-pulse rounded bg-background-3" />
             </div>
           </div>
         ))}

--- a/src/features/asset-uploader/ui/asset-grid-skeleton.tsx
+++ b/src/features/asset-uploader/ui/asset-grid-skeleton.tsx
@@ -1,0 +1,20 @@
+export function AssetGridSkeleton() {
+  return (
+    <section className="rounded-[1.75rem] border border-border-3 bg-background-2 p-6">
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, index) => (
+          <div
+            key={index}
+            className="overflow-hidden rounded-[1.4rem] border border-border-3 bg-background-1"
+          >
+            <div className="aspect-[4/3] animate-pulse bg-background-3" />
+            <div className="space-y-3 p-4">
+              <div className="h-4 w-2/3 animate-pulse rounded bg-background-3" />
+              <div className="h-3 w-1/2 animate-pulse rounded bg-background-3" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/features/asset-uploader/ui/asset-grid.tsx
+++ b/src/features/asset-uploader/ui/asset-grid.tsx
@@ -233,7 +233,7 @@ function AssetGridCard({
                 <p className="truncate text-[13px] font-medium leading-none text-text-1">
                   {getAssetDisplayName(asset)}
                 </p>
-                <p className="mt-1 truncate text-[12px] leading-none text-text-4">
+                <p className="mt-1 truncate text-xs leading-none text-text-4">
                   {getAssetFilename(asset.url)}
                 </p>
               </div>
@@ -246,7 +246,7 @@ function AssetGridCard({
                 {asset.category.name}
               </span>
             </div>
-            <p className="truncate text-[12px] leading-none text-text-4">
+            <p className="truncate text-xs leading-none text-text-4">
               {formatAssetFileSize(asset.sizeBytes)} /{" "}
               {formatAssetResolution(asset.width, asset.height)} /{" "}
               {formatAssetDate(asset.createdAt)}
@@ -272,7 +272,7 @@ function AssetCardMedia({ asset }: { asset: Asset }) {
   const [hasError, setHasError] = useState(false);
 
   return (
-    <div className="relative aspect-[4/3] overflow-hidden bg-background-3">
+    <div className="relative aspect-4/3 overflow-hidden bg-background-3">
       {hasError ? (
         <div className="flex h-full items-center justify-center px-6 text-sm text-text-4">
           미리보기를 불러오지 못했습니다.

--- a/src/features/asset-uploader/ui/asset-pagination.tsx
+++ b/src/features/asset-uploader/ui/asset-pagination.tsx
@@ -1,0 +1,114 @@
+interface AssetPaginationProps {
+  page: number;
+  totalPages: number;
+  isFetching: boolean;
+  onPageChange: (page: number) => void;
+}
+
+function generatePageNumbers(
+  currentPage: number,
+  totalPages: number,
+  windowSize: number,
+): Array<number | "..."> {
+  if (totalPages <= 1) return [1];
+
+  const windowStart = Math.max(2, currentPage - windowSize);
+  const windowEnd = Math.min(totalPages - 1, currentPage + windowSize);
+  const pages: Array<number | "..."> = [1];
+
+  if (windowStart > 2) pages.push("...");
+  for (let index = windowStart; index <= windowEnd; index += 1) {
+    pages.push(index);
+  }
+  if (windowEnd < totalPages - 1) pages.push("...");
+  pages.push(totalPages);
+
+  return pages;
+}
+
+export function AssetPagination({
+  page,
+  totalPages,
+  isFetching,
+  onPageChange,
+}: AssetPaginationProps) {
+  const pageNumbers = generatePageNumbers(page, totalPages, 2);
+
+  return (
+    <>
+      <nav
+        aria-label="관리자 에셋 페이지네이션"
+        className="flex items-center justify-center gap-0.5"
+      >
+        <button
+          type="button"
+          onClick={() => onPageChange(Math.max(1, page - 5))}
+          disabled={page <= 5}
+          className="inline-flex items-center justify-center rounded px-2.5 py-1.5 text-sm text-text-1 transition-colors hover:bg-background-2 disabled:cursor-not-allowed disabled:text-text-4"
+          aria-label="5 pages back"
+        >
+          &laquo;
+        </button>
+        <button
+          type="button"
+          onClick={() => onPageChange(Math.max(1, page - 1))}
+          disabled={page === 1}
+          className="inline-flex items-center justify-center rounded px-2.5 py-1.5 text-sm text-text-1 transition-colors hover:bg-background-2 disabled:cursor-not-allowed disabled:text-text-4"
+          aria-label="Previous page"
+        >
+          &lsaquo;
+        </button>
+        {pageNumbers.map((pageNumber, index) =>
+          pageNumber === "..." ? (
+            <span
+              key={`ellipsis-${index}`}
+              className="inline-flex items-center justify-center rounded px-2.5 py-1.5 text-sm text-text-4"
+              aria-hidden="true"
+            >
+              &hellip;
+            </span>
+          ) : (
+            <button
+              key={pageNumber}
+              type="button"
+              onClick={() => onPageChange(pageNumber)}
+              disabled={pageNumber === page}
+              className={
+                pageNumber === page
+                  ? "pointer-events-none inline-flex min-w-[2rem] items-center justify-center rounded bg-primary-1 px-2.5 py-1.5 text-sm font-semibold text-white"
+                  : "inline-flex min-w-[2rem] items-center justify-center rounded px-2.5 py-1.5 text-sm text-text-1 transition-colors hover:bg-background-2"
+              }
+              aria-current={pageNumber === page ? "page" : undefined}
+              aria-label={`Page ${pageNumber}`}
+            >
+              {pageNumber}
+            </button>
+          ),
+        )}
+        <button
+          type="button"
+          onClick={() => onPageChange(Math.min(totalPages, page + 1))}
+          disabled={page === totalPages}
+          className="inline-flex items-center justify-center rounded px-2.5 py-1.5 text-sm text-text-1 transition-colors hover:bg-background-2 disabled:cursor-not-allowed disabled:text-text-4"
+          aria-label="Next page"
+        >
+          &rsaquo;
+        </button>
+        <button
+          type="button"
+          onClick={() => onPageChange(Math.min(totalPages, page + 5))}
+          disabled={page + 5 > totalPages}
+          className="inline-flex items-center justify-center rounded px-2.5 py-1.5 text-sm text-text-1 transition-colors hover:bg-background-2 disabled:cursor-not-allowed disabled:text-text-4"
+          aria-label="5 pages forward"
+        >
+          &raquo;
+        </button>
+      </nav>
+      {isFetching ? (
+        <p className="text-center text-sm text-text-3">
+          목록을 새로 불러오는 중...
+        </p>
+      ) : null}
+    </>
+  );
+}

--- a/src/features/asset-uploader/ui/asset-pagination.tsx
+++ b/src/features/asset-uploader/ui/asset-pagination.tsx
@@ -75,8 +75,8 @@ export function AssetPagination({
               disabled={pageNumber === page}
               className={
                 pageNumber === page
-                  ? "pointer-events-none inline-flex min-w-[2rem] items-center justify-center rounded bg-primary-1 px-2.5 py-1.5 text-sm font-semibold text-white"
-                  : "inline-flex min-w-[2rem] items-center justify-center rounded px-2.5 py-1.5 text-sm text-text-1 transition-colors hover:bg-background-2"
+                  ? "pointer-events-none inline-flex min-w-8 items-center justify-center rounded bg-primary-1 px-2.5 py-1.5 text-sm font-semibold text-white"
+                  : "inline-flex min-w-8 items-center justify-center rounded px-2.5 py-1.5 text-sm text-text-1 transition-colors hover:bg-background-2"
               }
               aria-current={pageNumber === page ? "page" : undefined}
               aria-label={`Page ${pageNumber}`}

--- a/src/features/asset-uploader/ui/asset-toolbar.tsx
+++ b/src/features/asset-uploader/ui/asset-toolbar.tsx
@@ -1,4 +1,5 @@
 import type { AssetCategory } from "@entities/asset";
+import { DropSelect } from "@shared/ui/libs";
 
 interface AssetToolbarProps {
   search: string;
@@ -18,36 +19,35 @@ export function AssetToolbar({
   onResetFilters,
 }: AssetToolbarProps) {
   return (
-    <section className="rounded-[1rem] border border-border-4 bg-background-2 p-4">
+    <section className="rounded-2xl border border-border-4 bg-background-2 p-4">
       <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_14rem_auto]">
         <input
           type="search"
           value={search}
           onChange={(event) => onSearchChange(event.target.value)}
           placeholder="별명 또는 파일명 검색"
-          className="h-10 rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1"
+          className="h-10 rounded-xl border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1"
         />
-        <select
-          value={categoryFilterId ?? ""}
-          onChange={(event) =>
-            onCategoryFilterChange(
-              event.target.value ? Number(event.target.value) : null,
-            )
+        <DropSelect
+          value={categoryFilterId === null ? "" : String(categoryFilterId)}
+          onChange={(value) =>
+            onCategoryFilterChange(value ? Number(value) : null)
           }
-          className="h-10 rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors focus:border-primary-1"
-          aria-label="카테고리 필터"
-        >
-          <option value="">전체 카테고리</option>
-          {categories.map((category) => (
-            <option key={category.id} value={category.id}>
-              {category.name}
-            </option>
-          ))}
-        </select>
+          ariaLabel="카테고리 필터"
+          className="w-full"
+          triggerClassName="h-10 rounded-[0.75rem] text-sm text-text-2"
+          options={[
+            { label: "전체 카테고리", value: "" },
+            ...categories.map((category) => ({
+              label: category.name,
+              value: String(category.id),
+            })),
+          ]}
+        />
         <button
           type="button"
           onClick={onResetFilters}
-          className="inline-flex h-10 items-center justify-center rounded-[0.75rem] border border-border-3 px-3 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
+          className="inline-flex h-10 items-center justify-center rounded-xl border border-border-3 px-3 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
         >
           필터 초기화
         </button>

--- a/src/features/asset-uploader/ui/asset-toolbar.tsx
+++ b/src/features/asset-uploader/ui/asset-toolbar.tsx
@@ -1,10 +1,15 @@
 import type { AssetCategory } from "@entities/asset";
+import { ChevronIcon } from "@shared/ui/icons";
 import { DropSelect } from "@shared/ui/libs";
 
 interface AssetToolbarProps {
   search: string;
   categoryFilterId: number | null;
   categories: AssetCategory[];
+  isUploadPanelOpen: boolean;
+  uploadQueueCount: number;
+  isUploadPanelPinned: boolean;
+  onToggleUploadPanel: () => void;
   onSearchChange: (value: string) => void;
   onCategoryFilterChange: (categoryId: number | null) => void;
   onResetFilters: () => void;
@@ -14,20 +19,45 @@ export function AssetToolbar({
   search,
   categoryFilterId,
   categories,
+  isUploadPanelOpen,
+  uploadQueueCount,
+  isUploadPanelPinned,
+  onToggleUploadPanel,
   onSearchChange,
   onCategoryFilterChange,
   onResetFilters,
 }: AssetToolbarProps) {
   return (
-    <section className="rounded-2xl border border-border-4 bg-background-2 p-4">
+    <section className="border-b border-border-4 pb-6">
       <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_14rem_auto]">
-        <input
-          type="search"
-          value={search}
-          onChange={(event) => onSearchChange(event.target.value)}
-          placeholder="별명 또는 파일명 검색"
-          className="h-10 rounded-xl border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1"
-        />
+        <div className="flex min-w-0 gap-2">
+          <button
+            type="button"
+            onClick={onToggleUploadPanel}
+            aria-pressed={isUploadPanelOpen}
+            aria-controls="asset-upload-panel"
+            disabled={isUploadPanelPinned}
+            className="inline-flex h-10 shrink-0 items-center justify-center gap-1.5 rounded-xl border border-border-3 px-3 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-60 data-[active=true]:border-primary-1 data-[active=true]:bg-primary-1 data-[active=true]:text-white"
+            data-active={isUploadPanelOpen ? "true" : "false"}
+          >
+            업로드
+            {uploadQueueCount > 0 ? (
+              <span className="ml-1 text-xs">({uploadQueueCount})</span>
+            ) : null}
+            <ChevronIcon
+              direction={isUploadPanelOpen ? "up" : "down"}
+              size="14"
+              className="shrink-0"
+            />
+          </button>
+          <input
+            type="search"
+            value={search}
+            onChange={(event) => onSearchChange(event.target.value)}
+            placeholder="별명 또는 파일명 검색"
+            className="h-10 min-w-0 flex-1 rounded-xl border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1"
+          />
+        </div>
         <DropSelect
           value={categoryFilterId === null ? "" : String(categoryFilterId)}
           onChange={(value) =>

--- a/src/features/asset-uploader/ui/asset-toolbar.tsx
+++ b/src/features/asset-uploader/ui/asset-toolbar.tsx
@@ -35,7 +35,7 @@ export function AssetToolbar({
           }
           ariaLabel="카테고리 필터"
           className="w-full"
-          triggerClassName="h-10 rounded-[0.75rem] text-sm text-text-2"
+          triggerClassName="h-10 rounded-xl text-sm text-text-2"
           options={[
             { label: "전체 카테고리", value: "" },
             ...categories.map((category) => ({

--- a/src/features/asset-uploader/ui/asset-toolbar.tsx
+++ b/src/features/asset-uploader/ui/asset-toolbar.tsx
@@ -1,0 +1,57 @@
+import type { AssetCategory } from "@entities/asset";
+
+interface AssetToolbarProps {
+  search: string;
+  categoryFilterId: number | null;
+  categories: AssetCategory[];
+  onSearchChange: (value: string) => void;
+  onCategoryFilterChange: (categoryId: number | null) => void;
+  onResetFilters: () => void;
+}
+
+export function AssetToolbar({
+  search,
+  categoryFilterId,
+  categories,
+  onSearchChange,
+  onCategoryFilterChange,
+  onResetFilters,
+}: AssetToolbarProps) {
+  return (
+    <section className="rounded-[1rem] border border-border-4 bg-background-2 p-4">
+      <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_14rem_auto]">
+        <input
+          type="search"
+          value={search}
+          onChange={(event) => onSearchChange(event.target.value)}
+          placeholder="별명 또는 파일명 검색"
+          className="h-10 rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1"
+        />
+        <select
+          value={categoryFilterId ?? ""}
+          onChange={(event) =>
+            onCategoryFilterChange(
+              event.target.value ? Number(event.target.value) : null,
+            )
+          }
+          className="h-10 rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors focus:border-primary-1"
+          aria-label="카테고리 필터"
+        >
+          <option value="">전체 카테고리</option>
+          {categories.map((category) => (
+            <option key={category.id} value={category.id}>
+              {category.name}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={onResetFilters}
+          className="inline-flex h-10 items-center justify-center rounded-[0.75rem] border border-border-3 px-3 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
+        >
+          필터 초기화
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/features/asset-uploader/ui/asset-uploader.tsx
+++ b/src/features/asset-uploader/ui/asset-uploader.tsx
@@ -58,6 +58,7 @@ export function AssetUploader() {
   const [pendingCategoryId, setPendingCategoryId] = useState<number | null>(
     null,
   );
+  const [isUploadPanelOpen, setIsUploadPanelOpen] = useState(false);
   const [pendingFiles, setPendingFiles] = useState<PendingUploadFile[]>([]);
   const [uploadProgress, setUploadProgress] = useState<number | null>(null);
   const [selectionMode, setSelectionMode] = useState(false);
@@ -132,6 +133,39 @@ export function AssetUploader() {
     findAssetCategoryByKey(categories, "default") ?? categories[0] ?? null;
   const selectedUploadCategoryId =
     defaultUploadCategoryId ?? fallbackDefaultCategory?.id ?? null;
+  const shouldShowUploadPanel =
+    isUploadPanelOpen || pendingFiles.length > 0 || uploadMutation.isPending;
+  const isUploadPanelPinned =
+    pendingFiles.length > 0 || uploadMutation.isPending;
+
+  const uploadZone = (
+    <UploadZone
+      files={pendingFiles}
+      isUploading={uploadMutation.isPending}
+      uploadProgress={uploadProgress}
+      errorMessage={null}
+      categories={categories}
+      defaultCategoryId={selectedUploadCategoryId}
+      isDefaultCategoryDisabled={
+        categoriesQuery.isPending || uploadMutation.isPending
+      }
+      onFilesAdded={addFiles}
+      onDefaultCategoryChange={setDefaultUploadCategoryId}
+      onOpenCategoryManager={() => setIsCategoryManagerOpen(true)}
+      onUpdateFileMetadata={updatePendingFileMetadata}
+      onRemoveFile={removePendingFile}
+      onClear={clearPendingFiles}
+      onUpload={() => {
+        if (pendingFiles.length === 0) {
+          toast.error("업로드할 파일을 먼저 선택하세요.");
+
+          return;
+        }
+
+        uploadMutation.mutate(pendingFiles);
+      }}
+    />
+  );
 
   const deleteMutation = useMutation({
     mutationFn: async (ids: number[]) => {
@@ -553,33 +587,6 @@ export function AssetUploader() {
 
   return (
     <div className="space-y-6">
-      <UploadZone
-        files={pendingFiles}
-        isUploading={uploadMutation.isPending}
-        uploadProgress={uploadProgress}
-        errorMessage={null}
-        categories={categories}
-        defaultCategoryId={selectedUploadCategoryId}
-        isDefaultCategoryDisabled={
-          categoriesQuery.isPending || uploadMutation.isPending
-        }
-        onFilesAdded={addFiles}
-        onDefaultCategoryChange={setDefaultUploadCategoryId}
-        onOpenCategoryManager={() => setIsCategoryManagerOpen(true)}
-        onUpdateFileMetadata={updatePendingFileMetadata}
-        onRemoveFile={removePendingFile}
-        onClear={clearPendingFiles}
-        onUpload={() => {
-          if (pendingFiles.length === 0) {
-            toast.error("업로드할 파일을 먼저 선택하세요.");
-
-            return;
-          }
-
-          uploadMutation.mutate(pendingFiles);
-        }}
-      />
-
       {assetsQuery.isPending ? <AssetGridSkeleton /> : null}
 
       {!assetsQuery.isPending && assetsQuery.isError ? (
@@ -606,6 +613,12 @@ export function AssetUploader() {
             search={search}
             categoryFilterId={categoryFilterId}
             categories={categories}
+            isUploadPanelOpen={shouldShowUploadPanel}
+            uploadQueueCount={pendingFiles.length}
+            isUploadPanelPinned={isUploadPanelPinned}
+            onToggleUploadPanel={() =>
+              setIsUploadPanelOpen((current) => !current)
+            }
             onSearchChange={setSearch}
             onCategoryFilterChange={setCategoryFilterId}
             onResetFilters={() => {
@@ -613,6 +626,10 @@ export function AssetUploader() {
               setCategoryFilterId(null);
             }}
           />
+
+          {shouldShowUploadPanel ? (
+            <div id="asset-upload-panel">{uploadZone}</div>
+          ) : null}
 
           <AssetGrid
             assets={assets}

--- a/src/features/asset-uploader/ui/asset-uploader.tsx
+++ b/src/features/asset-uploader/ui/asset-uploader.tsx
@@ -3,9 +3,14 @@
 import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { AssetBulkActionBar } from "./asset-bulk-action-bar";
 import { AssetCategoryManagerModal } from "./asset-category-manager-modal";
 import { AssetDetailModal } from "./asset-detail-modal";
 import { AssetGrid } from "./asset-grid";
+import { AssetGridSkeleton } from "./asset-grid-skeleton";
+import { AssetPagination } from "./asset-pagination";
+import { AssetToolbar } from "./asset-toolbar";
+import { DeleteAssetsModal } from "./delete-assets-modal";
 import { type PendingUploadFile, UploadZone } from "./upload-zone";
 import {
   adminAssetKeys,
@@ -27,7 +32,6 @@ import {
 } from "@entities/asset";
 import { toCanonicalAssetUrl } from "@shared/lib/asset-url";
 import { getErrorMessage } from "@shared/lib/get-error-message";
-import { Modal, Spinner } from "@shared/ui/libs";
 
 const PAGE_SIZE = 18;
 const MAX_FILES = 5;
@@ -40,27 +44,6 @@ const ACCEPTED_TYPES = new Set([
   "image/svg+xml",
 ]);
 const EMPTY_ASSETS: Asset[] = [];
-
-function generatePageNumbers(
-  currentPage: number,
-  totalPages: number,
-  windowSize: number,
-): Array<number | "..."> {
-  if (totalPages <= 1) return [1];
-
-  const windowStart = Math.max(2, currentPage - windowSize);
-  const windowEnd = Math.min(totalPages - 1, currentPage + windowSize);
-  const pages: Array<number | "..."> = [1];
-
-  if (windowStart > 2) pages.push("...");
-  for (let index = windowStart; index <= windowEnd; index += 1) {
-    pages.push(index);
-  }
-  if (windowEnd < totalPages - 1) pages.push("...");
-  pages.push(totalPages);
-
-  return pages;
-}
 
 export function AssetUploader() {
   const queryClient = useQueryClient();
@@ -367,8 +350,6 @@ export function AssetUploader() {
     return () => window.clearTimeout(timeout);
   }, [copiedState]);
 
-  const pageNumbers = meta ? generatePageNumbers(page, meta.totalPages, 2) : [];
-
   function clearPendingFiles() {
     setPendingFiles((current) => {
       current.forEach((item) => {
@@ -572,52 +553,19 @@ export function AssetUploader() {
 
   return (
     <div className="space-y-6">
-      <section className="rounded-[1rem] border border-border-4 bg-background-2 p-4">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-          <div>
-            <p className="text-sm font-semibold text-text-1">업로드 기본값</p>
-            <p className="mt-1 text-xs text-text-4">
-              에셋 관리에서 직접 추가하는 파일은 선택한 카테고리로 대기열에
-              들어갑니다.
-            </p>
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <select
-              value={selectedUploadCategoryId ?? ""}
-              onChange={(event) =>
-                setDefaultUploadCategoryId(
-                  event.target.value ? Number(event.target.value) : null,
-                )
-              }
-              disabled={categoriesQuery.isPending || uploadMutation.isPending}
-              className="h-10 min-w-[12rem] rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
-              aria-label="업로드 기본 카테고리"
-            >
-              {categories.length === 0 ? <option value="">기본</option> : null}
-              {categories.map((category) => (
-                <option key={category.id} value={category.id}>
-                  {category.name}
-                </option>
-              ))}
-            </select>
-            <button
-              type="button"
-              onClick={() => setIsCategoryManagerOpen(true)}
-              className="inline-flex h-10 items-center justify-center rounded-[0.75rem] border border-border-3 px-3 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
-            >
-              카테고리 관리
-            </button>
-          </div>
-        </div>
-      </section>
-
       <UploadZone
         files={pendingFiles}
         isUploading={uploadMutation.isPending}
         uploadProgress={uploadProgress}
         errorMessage={null}
         categories={categories}
+        defaultCategoryId={selectedUploadCategoryId}
+        isDefaultCategoryDisabled={
+          categoriesQuery.isPending || uploadMutation.isPending
+        }
         onFilesAdded={addFiles}
+        onDefaultCategoryChange={setDefaultUploadCategoryId}
+        onOpenCategoryManager={() => setIsCategoryManagerOpen(true)}
         onUpdateFileMetadata={updatePendingFileMetadata}
         onRemoveFile={removePendingFile}
         onClear={clearPendingFiles}
@@ -645,7 +593,7 @@ export function AssetUploader() {
           <button
             type="button"
             onClick={() => void assetsQuery.refetch()}
-            className="mt-4 inline-flex rounded-[0.75rem] border border-negative-1/20 px-4 py-2 text-sm font-medium text-negative-1 transition-colors hover:bg-negative-1/10"
+            className="mt-4 inline-flex rounded-xl border border-negative-1/20 px-4 py-2 text-sm font-medium text-negative-1 transition-colors hover:bg-negative-1/10"
           >
             다시 시도
           </button>
@@ -654,44 +602,17 @@ export function AssetUploader() {
 
       {!assetsQuery.isPending && !assetsQuery.isError ? (
         <>
-          <section className="rounded-[1rem] border border-border-4 bg-background-2 p-4">
-            <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_14rem_auto]">
-              <input
-                type="search"
-                value={search}
-                onChange={(event) => setSearch(event.target.value)}
-                placeholder="별명 또는 파일명 검색"
-                className="h-10 rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1"
-              />
-              <select
-                value={categoryFilterId ?? ""}
-                onChange={(event) =>
-                  setCategoryFilterId(
-                    event.target.value ? Number(event.target.value) : null,
-                  )
-                }
-                className="h-10 rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-sm text-text-2 outline-none transition-colors focus:border-primary-1"
-                aria-label="카테고리 필터"
-              >
-                <option value="">전체 카테고리</option>
-                {categories.map((category) => (
-                  <option key={category.id} value={category.id}>
-                    {category.name}
-                  </option>
-                ))}
-              </select>
-              <button
-                type="button"
-                onClick={() => {
-                  setSearch("");
-                  setCategoryFilterId(null);
-                }}
-                className="inline-flex h-10 items-center justify-center rounded-[0.75rem] border border-border-3 px-3 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
-              >
-                필터 초기화
-              </button>
-            </div>
-          </section>
+          <AssetToolbar
+            search={search}
+            categoryFilterId={categoryFilterId}
+            categories={categories}
+            onSearchChange={setSearch}
+            onCategoryFilterChange={setCategoryFilterId}
+            onResetFilters={() => {
+              setSearch("");
+              setCategoryFilterId(null);
+            }}
+          />
 
           <AssetGrid
             assets={assets}
@@ -710,175 +631,45 @@ export function AssetUploader() {
           />
           <div className="flex flex-col gap-4">
             {selectionMode ? (
-              <div className="fixed bottom-0 left-0 right-0 z-20 md:left-[var(--admin-sidebar-offset)]">
-                <div className="flex flex-wrap items-center gap-3 border-t border-border-3 bg-[rgba(241,242,243,0.95)] px-4 py-3 backdrop-blur-[12px] md:px-6 dark:bg-[rgba(19,20,21,0.94)]">
-                  <span className="text-sm font-medium text-text-1">
-                    선택됨 {selectedIds.length}개
-                  </span>
-                  <div className="ml-auto flex flex-wrap items-center gap-2">
-                    <select
-                      value={bulkCategoryId ?? ""}
-                      onChange={(event) =>
-                        setBulkCategoryId(
-                          event.target.value
-                            ? Number(event.target.value)
-                            : null,
-                        )
-                      }
-                      disabled={
-                        selectedIds.length === 0 ||
-                        bulkCategoryMutation.isPending
-                      }
-                      className="h-9 rounded-[0.7rem] border border-border-3 bg-background-1 px-2 text-sm text-text-2 outline-none disabled:cursor-not-allowed disabled:opacity-50"
-                      aria-label="선택 에셋 카테고리"
-                    >
-                      <option value="">카테고리 변경</option>
-                      {categories.map((category) => (
-                        <option key={category.id} value={category.id}>
-                          {category.name}
-                        </option>
-                      ))}
-                    </select>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        if (bulkCategoryId === null) {
-                          toast.error("변경할 카테고리를 선택하세요.");
+              <AssetBulkActionBar
+                selectedCount={selectedIds.length}
+                categories={categories}
+                bulkCategoryId={bulkCategoryId}
+                isApplyingCategory={bulkCategoryMutation.isPending}
+                isDeleting={deleteMutation.isPending}
+                isPageFullySelected={
+                  assets.length > 0 &&
+                  assets.every((asset) => selectedIds.includes(asset.id))
+                }
+                onBulkCategoryChange={setBulkCategoryId}
+                onApplyCategory={() => {
+                  if (bulkCategoryId === null) {
+                    toast.error("변경할 카테고리를 선택하세요.");
 
-                          return;
-                        }
+                    return;
+                  }
 
-                        bulkCategoryMutation.mutate({
-                          ids: selectedIds,
-                          categoryId: bulkCategoryId,
-                        });
-                      }}
-                      disabled={
-                        selectedIds.length === 0 ||
-                        bulkCategoryId === null ||
-                        bulkCategoryMutation.isPending
-                      }
-                      className="inline-flex h-9 cursor-pointer items-center rounded-[0.7rem] border border-border-3 px-3 text-sm text-text-2 transition-colors hover:bg-background-1 disabled:cursor-not-allowed disabled:opacity-40"
-                    >
-                      {bulkCategoryMutation.isPending
-                        ? "변경 중"
-                        : "카테고리 적용"}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() =>
-                        selectAll(
-                          !assets.every((asset) =>
-                            selectedIds.includes(asset.id),
-                          ),
-                        )
-                      }
-                      className="cursor-pointer px-2 py-1.5 text-sm text-primary-1 transition-colors hover:text-primary-1/80"
-                    >
-                      {assets.length > 0 &&
-                      assets.every((asset) => selectedIds.includes(asset.id))
-                        ? "전체 해제"
-                        : "전체 선택"}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => requestDelete(selectedIds)}
-                      disabled={
-                        selectedIds.length === 0 || deleteMutation.isPending
-                      }
-                      className="inline-flex h-9 cursor-pointer items-center rounded-[0.7rem] border border-negative-1/30 px-3 text-sm text-negative-1 transition-colors hover:bg-negative-1/10 disabled:cursor-not-allowed disabled:opacity-40"
-                    >
-                      삭제
-                    </button>
-                    <button
-                      type="button"
-                      onClick={exitSelectionMode}
-                      className="inline-flex h-9 cursor-pointer items-center rounded-[0.7rem] bg-primary-1 px-3 text-sm text-white transition-opacity hover:opacity-90"
-                    >
-                      완료
-                    </button>
-                  </div>
-                </div>
-              </div>
+                  bulkCategoryMutation.mutate({
+                    ids: selectedIds,
+                    categoryId: bulkCategoryId,
+                  });
+                }}
+                onToggleSelectAll={() =>
+                  selectAll(
+                    !assets.every((asset) => selectedIds.includes(asset.id)),
+                  )
+                }
+                onRequestDelete={() => requestDelete(selectedIds)}
+                onDone={exitSelectionMode}
+              />
             ) : null}
             {meta ? (
-              <nav
-                aria-label="관리자 에셋 페이지네이션"
-                className="flex items-center justify-center gap-0.5"
-              >
-                <button
-                  type="button"
-                  onClick={() => handlePageChange(Math.max(1, page - 5))}
-                  disabled={page <= 5}
-                  className="inline-flex items-center justify-center rounded px-2.5 py-1.5 text-sm text-text-1 transition-colors hover:bg-background-2 disabled:cursor-not-allowed disabled:text-text-4"
-                  aria-label="5 pages back"
-                >
-                  &laquo;
-                </button>
-                <button
-                  type="button"
-                  onClick={() => handlePageChange(Math.max(1, page - 1))}
-                  disabled={page === 1}
-                  className="inline-flex items-center justify-center rounded px-2.5 py-1.5 text-sm text-text-1 transition-colors hover:bg-background-2 disabled:cursor-not-allowed disabled:text-text-4"
-                  aria-label="Previous page"
-                >
-                  &lsaquo;
-                </button>
-                {pageNumbers.map((pageNumber, index) =>
-                  pageNumber === "..." ? (
-                    <span
-                      key={`ellipsis-${index}`}
-                      className="inline-flex items-center justify-center rounded px-2.5 py-1.5 text-sm text-text-4"
-                      aria-hidden="true"
-                    >
-                      &hellip;
-                    </span>
-                  ) : (
-                    <button
-                      key={pageNumber}
-                      type="button"
-                      onClick={() => handlePageChange(pageNumber)}
-                      disabled={pageNumber === page}
-                      className={
-                        pageNumber === page
-                          ? "pointer-events-none inline-flex min-w-[2rem] items-center justify-center rounded bg-primary-1 px-2.5 py-1.5 text-sm font-semibold text-white"
-                          : "inline-flex min-w-[2rem] items-center justify-center rounded px-2.5 py-1.5 text-sm text-text-1 transition-colors hover:bg-background-2"
-                      }
-                      aria-current={pageNumber === page ? "page" : undefined}
-                      aria-label={`Page ${pageNumber}`}
-                    >
-                      {pageNumber}
-                    </button>
-                  ),
-                )}
-                <button
-                  type="button"
-                  onClick={() =>
-                    handlePageChange(Math.min(meta.totalPages, page + 1))
-                  }
-                  disabled={page === meta.totalPages}
-                  className="inline-flex items-center justify-center rounded px-2.5 py-1.5 text-sm text-text-1 transition-colors hover:bg-background-2 disabled:cursor-not-allowed disabled:text-text-4"
-                  aria-label="Next page"
-                >
-                  &rsaquo;
-                </button>
-                <button
-                  type="button"
-                  onClick={() =>
-                    handlePageChange(Math.min(meta.totalPages, page + 5))
-                  }
-                  disabled={page + 5 > meta.totalPages}
-                  className="inline-flex items-center justify-center rounded px-2.5 py-1.5 text-sm text-text-1 transition-colors hover:bg-background-2 disabled:cursor-not-allowed disabled:text-text-4"
-                  aria-label="5 pages forward"
-                >
-                  &raquo;
-                </button>
-              </nav>
-            ) : null}
-            {assetsQuery.isFetching && !assetsQuery.isPending ? (
-              <p className="text-center text-sm text-text-3">
-                목록을 새로 불러오는 중...
-              </p>
+              <AssetPagination
+                page={page}
+                totalPages={meta.totalPages}
+                isFetching={assetsQuery.isFetching && !assetsQuery.isPending}
+                onPageChange={handlePageChange}
+              />
             ) : null}
           </div>
         </>
@@ -930,94 +721,5 @@ export function AssetUploader() {
         onDelete={handleDeleteCategory}
       />
     </div>
-  );
-}
-
-function DeleteAssetsModal({
-  ids,
-  isDeleting,
-  onCancel,
-  onConfirm,
-}: {
-  ids: number[];
-  isDeleting: boolean;
-  onCancel: () => void;
-  onConfirm: () => void;
-}) {
-  return (
-    <Modal
-      isOpen={ids.length > 0}
-      onClose={onCancel}
-      withBackground
-      aria-label={ids.length === 1 ? "에셋 삭제 확인" : "에셋 일괄 삭제 확인"}
-      className="w-[min(100%,30rem)] p-0 text-left"
-    >
-      <div className="border-b border-border-3 px-6 py-5">
-        <p className="text-body-xs uppercase tracking-[0.2em] text-text-4">
-          Delete assets
-        </p>
-        <h2 className="mt-2 text-xl font-semibold text-text-1">
-          {ids.length === 1
-            ? "이 에셋을 삭제할까요?"
-            : `${ids.length}개의 에셋을 삭제할까요?`}
-        </h2>
-      </div>
-
-      <div className="space-y-3 px-6 py-5 text-sm text-text-3">
-        <p>
-          삭제된 에셋은 복구되지 않으며, 에디터에서 이미 사용 중인 경우 깨진
-          이미지가 생길 수 있습니다.
-        </p>
-        <p className="rounded-[1rem] border border-negative-1/20 bg-negative-1/10 px-4 py-3 text-negative-1">
-          선택된 항목: {ids.join(", ")}
-        </p>
-      </div>
-
-      <div className="flex flex-wrap justify-end gap-3 border-t border-border-3 px-6 py-5">
-        <button
-          type="button"
-          onClick={onCancel}
-          disabled={isDeleting}
-          className="inline-flex items-center justify-center rounded-[0.75rem] border border-border-3 px-4 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          취소
-        </button>
-        <button
-          type="button"
-          onClick={onConfirm}
-          disabled={isDeleting}
-          className="inline-flex items-center justify-center rounded-[0.75rem] bg-negative-1 px-4 py-2 text-sm font-medium text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {isDeleting ? (
-            <>
-              <Spinner size="sm" /> 삭제 중
-            </>
-          ) : (
-            "삭제"
-          )}
-        </button>
-      </div>
-    </Modal>
-  );
-}
-
-function AssetGridSkeleton() {
-  return (
-    <section className="rounded-[1.75rem] border border-border-3 bg-background-2 p-6">
-      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-        {Array.from({ length: 6 }).map((_, index) => (
-          <div
-            key={index}
-            className="overflow-hidden rounded-[1.4rem] border border-border-3 bg-background-1"
-          >
-            <div className="aspect-[4/3] animate-pulse bg-background-3" />
-            <div className="space-y-3 p-4">
-              <div className="h-4 w-2/3 animate-pulse rounded bg-background-3" />
-              <div className="h-3 w-1/2 animate-pulse rounded bg-background-3" />
-            </div>
-          </div>
-        ))}
-      </div>
-    </section>
   );
 }

--- a/src/features/asset-uploader/ui/delete-assets-modal.tsx
+++ b/src/features/asset-uploader/ui/delete-assets-modal.tsx
@@ -37,7 +37,7 @@ export function DeleteAssetsModal({
           삭제된 에셋은 복구되지 않으며, 에디터에서 이미 사용 중인 경우 깨진
           이미지가 생길 수 있습니다.
         </p>
-        <p className="rounded-[1rem] border border-negative-1/20 bg-negative-1/10 px-4 py-3 text-negative-1">
+        <p className="rounded-2xl border border-negative-1/20 bg-negative-1/10 px-4 py-3 text-negative-1">
           선택된 항목: {ids.join(", ")}
         </p>
       </div>
@@ -47,7 +47,7 @@ export function DeleteAssetsModal({
           type="button"
           onClick={onCancel}
           disabled={isDeleting}
-          className="inline-flex items-center justify-center rounded-[0.75rem] border border-border-3 px-4 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
+          className="inline-flex items-center justify-center rounded-xl border border-border-3 px-4 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
         >
           취소
         </button>
@@ -55,7 +55,7 @@ export function DeleteAssetsModal({
           type="button"
           onClick={onConfirm}
           disabled={isDeleting}
-          className="inline-flex items-center justify-center rounded-[0.75rem] bg-negative-1 px-4 py-2 text-sm font-medium text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+          className="inline-flex items-center justify-center rounded-xl bg-negative-1 px-4 py-2 text-sm font-medium text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
         >
           {isDeleting ? (
             <>

--- a/src/features/asset-uploader/ui/delete-assets-modal.tsx
+++ b/src/features/asset-uploader/ui/delete-assets-modal.tsx
@@ -1,0 +1,71 @@
+import { Modal, Spinner } from "@shared/ui/libs";
+
+interface DeleteAssetsModalProps {
+  ids: number[];
+  isDeleting: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export function DeleteAssetsModal({
+  ids,
+  isDeleting,
+  onCancel,
+  onConfirm,
+}: DeleteAssetsModalProps) {
+  return (
+    <Modal
+      isOpen={ids.length > 0}
+      onClose={onCancel}
+      withBackground
+      aria-label={ids.length === 1 ? "에셋 삭제 확인" : "에셋 일괄 삭제 확인"}
+      className="w-[min(100%,30rem)] p-0 text-left"
+    >
+      <div className="border-b border-border-3 px-6 py-5">
+        <p className="text-body-xs uppercase tracking-[0.2em] text-text-4">
+          Delete assets
+        </p>
+        <h2 className="mt-2 text-xl font-semibold text-text-1">
+          {ids.length === 1
+            ? "이 에셋을 삭제할까요?"
+            : `${ids.length}개의 에셋을 삭제할까요?`}
+        </h2>
+      </div>
+
+      <div className="space-y-3 px-6 py-5 text-sm text-text-3">
+        <p>
+          삭제된 에셋은 복구되지 않으며, 에디터에서 이미 사용 중인 경우 깨진
+          이미지가 생길 수 있습니다.
+        </p>
+        <p className="rounded-[1rem] border border-negative-1/20 bg-negative-1/10 px-4 py-3 text-negative-1">
+          선택된 항목: {ids.join(", ")}
+        </p>
+      </div>
+
+      <div className="flex flex-wrap justify-end gap-3 border-t border-border-3 px-6 py-5">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isDeleting}
+          className="inline-flex items-center justify-center rounded-[0.75rem] border border-border-3 px-4 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          취소
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={isDeleting}
+          className="inline-flex items-center justify-center rounded-[0.75rem] bg-negative-1 px-4 py-2 text-sm font-medium text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isDeleting ? (
+            <>
+              <Spinner size="sm" /> 삭제 중
+            </>
+          ) : (
+            "삭제"
+          )}
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/features/asset-uploader/ui/upload-zone.tsx
+++ b/src/features/asset-uploader/ui/upload-zone.tsx
@@ -209,7 +209,7 @@ export function UploadZone({
                   <span className="max-w-48 truncate text-[13px] font-medium leading-none text-text-1">
                     {item.file.name}
                   </span>
-                  <span className="text-[12px] leading-none text-text-4">
+                  <span className="text-xs leading-none text-text-4">
                     {formatFileSize(item.file.size)}
                   </span>
                   {isUploading && uploadProgress !== null ? (
@@ -262,7 +262,7 @@ export function UploadZone({
                     type="button"
                     onClick={() => onRemoveFile(item.id)}
                     disabled={isUploading}
-                    className="inline-flex h-8 cursor-pointer items-center justify-center rounded-lg border border-border-3 px-3 text-[12px] font-normal leading-none text-text-2 transition-colors hover:bg-background-2 disabled:cursor-not-allowed disabled:opacity-50"
+                    className="inline-flex h-8 cursor-pointer items-center justify-center rounded-lg border border-border-3 px-3 text-xs font-normal leading-none text-text-2 transition-colors hover:bg-background-2 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     제거
                   </button>
@@ -343,15 +343,15 @@ function DropArea({
       <div className="flex flex-col items-center gap-2">
         <Icon icon={cloudUploadLinear} width="48" className="text-primary-1" />
         {isDragging ? (
-          <p className="text-[14px] font-medium leading-none text-primary-1">
+          <p className="text-sm font-medium leading-none text-primary-1">
             놓으면 대기열에 추가됩니다
           </p>
         ) : (
-          <p className="text-[14px] font-medium leading-none text-text-2">
+          <p className="text-sm font-medium leading-none text-text-2">
             이미지를 드래그하거나 클릭하여 업로드
           </p>
         )}
-        <p className="text-[12px] leading-none text-text-4">
+        <p className="text-xs leading-none text-text-4">
           JPEG, PNG, GIF, WebP, SVG / 최대 10MB / 5개까지 동시 업로드
         </p>
       </div>

--- a/src/features/asset-uploader/ui/upload-zone.tsx
+++ b/src/features/asset-uploader/ui/upload-zone.tsx
@@ -9,7 +9,7 @@ import trashBinMinimalisticLinear from "@iconify-icons/solar/trash-bin-minimalis
 import uploadMinimalisticLinear from "@iconify-icons/solar/upload-minimalistic-linear";
 import type { AssetCategory } from "@entities/asset";
 import { cn } from "@shared/lib/style-utils";
-import { Spinner } from "@shared/ui/libs";
+import { DropSelect, Spinner } from "@shared/ui/libs";
 
 export interface PendingUploadFile {
   id: string;
@@ -96,36 +96,33 @@ export function UploadZone({
                 </span>
               ) : null}
             </div>
-            <p className="mt-1 text-[12px] text-text-4">
-              기본 카테고리는 이후 추가되는 파일에 적용됩니다.
-            </p>
           </div>
           <div className="flex flex-wrap items-center gap-2">
-            <label className="flex min-w-52 items-center gap-2">
+            <div className="flex min-w-52 items-center gap-2">
               <span className="shrink-0 text-[12px] text-text-4">
-                새 파일 기본
+                기본 카테고리
               </span>
-              <select
-                value={defaultCategoryId ?? ""}
-                onChange={(event) =>
-                  onDefaultCategoryChange(
-                    event.target.value ? Number(event.target.value) : null,
-                  )
+              <DropSelect
+                value={
+                  defaultCategoryId === null ? "" : String(defaultCategoryId)
+                }
+                onChange={(value) =>
+                  onDefaultCategoryChange(value ? Number(value) : null)
                 }
                 disabled={isDefaultCategoryDisabled}
-                className="h-8 min-w-0 flex-1 rounded-lg border border-border-3 bg-background-1 px-2 text-[13px] text-text-2 outline-none transition-colors focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
-                aria-label="새 파일 기본 카테고리"
-              >
-                {categories.length === 0 ? (
-                  <option value="">기본</option>
-                ) : null}
-                {categories.map((category) => (
-                  <option key={category.id} value={category.id}>
-                    {category.name}
-                  </option>
-                ))}
-              </select>
-            </label>
+                ariaLabel="새 파일 기본 카테고리"
+                className="min-w-0 flex-1"
+                triggerClassName="h-8 rounded-lg px-2 pr-8 text-[13px] text-text-2"
+                options={
+                  categories.length === 0
+                    ? [{ label: "기본", value: "" }]
+                    : categories.map((category) => ({
+                        label: category.name,
+                        value: String(category.id),
+                      }))
+                }
+              />
+            </div>
             <button
               type="button"
               onClick={onOpenCategoryManager}
@@ -237,26 +234,27 @@ export function UploadZone({
                   placeholder="별명"
                   className="h-9 min-w-0 rounded-lg border border-border-3 bg-background-1 px-3 text-[13px] text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
                 />
-                <select
-                  value={item.categoryId ?? ""}
-                  onChange={(event) =>
+                <DropSelect
+                  value={
+                    item.categoryId === null ? "" : String(item.categoryId)
+                  }
+                  onChange={(value) =>
                     onUpdateFileMetadata(item.id, {
-                      categoryId: event.target.value
-                        ? Number(event.target.value)
-                        : null,
+                      categoryId: value ? Number(value) : null,
                     })
                   }
                   disabled={isUploading}
-                  aria-label={`${item.file.name} 카테고리`}
-                  className="h-9 min-w-0 rounded-lg border border-border-3 bg-background-1 px-3 text-[13px] text-text-2 outline-none transition-colors focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
-                >
-                  <option value="">기본</option>
-                  {categories.map((category) => (
-                    <option key={category.id} value={category.id}>
-                      {category.name}
-                    </option>
-                  ))}
-                </select>
+                  ariaLabel={`${item.file.name} 카테고리`}
+                  className="min-w-0"
+                  triggerClassName="h-9 rounded-lg text-[13px] text-text-2"
+                  options={[
+                    { label: "기본", value: "" },
+                    ...categories.map((category) => ({
+                      label: category.name,
+                      value: String(category.id),
+                    })),
+                  ]}
+                />
                 {isUploading ? (
                   <Spinner size="sm" className="shrink-0 text-primary-1" />
                 ) : (

--- a/src/features/asset-uploader/ui/upload-zone.tsx
+++ b/src/features/asset-uploader/ui/upload-zone.tsx
@@ -25,7 +25,11 @@ interface UploadZoneProps {
   uploadProgress: number | null;
   errorMessage: string | null;
   categories: AssetCategory[];
+  defaultCategoryId: number | null;
+  isDefaultCategoryDisabled: boolean;
   onFilesAdded: (files: FileList | File[]) => void;
+  onDefaultCategoryChange: (categoryId: number | null) => void;
+  onOpenCategoryManager: () => void;
   onUpdateFileMetadata: (
     id: string,
     metadata: { displayName?: string; categoryId?: number | null },
@@ -41,7 +45,11 @@ export function UploadZone({
   uploadProgress,
   errorMessage,
   categories,
+  defaultCategoryId,
+  isDefaultCategoryDisabled,
   onFilesAdded,
+  onDefaultCategoryChange,
+  onOpenCategoryManager,
   onUpdateFileMetadata,
   onRemoveFile,
   onClear,
@@ -76,18 +84,55 @@ export function UploadZone({
       />
 
       <div className="rounded-xl bg-background-2 p-4">
-        <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
-          <div className="flex items-center gap-2">
-            <span className="text-[13px] font-medium leading-none text-text-2">
-              업로드 큐 ({files.length}개)
-            </span>
-            {isUploading && uploadProgress !== null ? (
-              <span className="text-[11px] leading-none text-text-4">
-                {uploadProgress}%
+        <div className="mb-3 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <div className="flex items-center gap-2">
+              <span className="text-[13px] font-medium leading-none text-text-2">
+                업로드 큐 ({files.length}개)
               </span>
-            ) : null}
+              {isUploading && uploadProgress !== null ? (
+                <span className="text-[11px] leading-none text-text-4">
+                  {uploadProgress}%
+                </span>
+              ) : null}
+            </div>
+            <p className="mt-1 text-[12px] text-text-4">
+              기본 카테고리는 이후 추가되는 파일에 적용됩니다.
+            </p>
           </div>
           <div className="flex flex-wrap items-center gap-2">
+            <label className="flex min-w-52 items-center gap-2">
+              <span className="shrink-0 text-[12px] text-text-4">
+                새 파일 기본
+              </span>
+              <select
+                value={defaultCategoryId ?? ""}
+                onChange={(event) =>
+                  onDefaultCategoryChange(
+                    event.target.value ? Number(event.target.value) : null,
+                  )
+                }
+                disabled={isDefaultCategoryDisabled}
+                className="h-8 min-w-0 flex-1 rounded-lg border border-border-3 bg-background-1 px-2 text-[13px] text-text-2 outline-none transition-colors focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+                aria-label="새 파일 기본 카테고리"
+              >
+                {categories.length === 0 ? (
+                  <option value="">기본</option>
+                ) : null}
+                {categories.map((category) => (
+                  <option key={category.id} value={category.id}>
+                    {category.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button
+              type="button"
+              onClick={onOpenCategoryManager}
+              className="inline-flex h-8 cursor-pointer items-center justify-center rounded-lg border border-border-3 px-3 text-[13px] font-normal leading-none text-text-2 transition-colors hover:bg-background-1"
+            >
+              카테고리 관리
+            </button>
             <button
               type="button"
               onClick={() => inputRef.current?.click()}
@@ -126,7 +171,7 @@ export function UploadZone({
         </div>
 
         {errorMessage ? (
-          <div className="mt-4 rounded-[1rem] border border-negative-1/20 bg-negative-1/10 px-4 py-3 text-sm text-negative-1">
+          <div className="mt-4 rounded-2xl border border-negative-1/20 bg-negative-1/10 px-4 py-3 text-sm text-negative-1">
             {errorMessage}
           </div>
         ) : null}
@@ -147,7 +192,7 @@ export function UploadZone({
             files.map((item) => (
               <div
                 key={item.id}
-                className="grid gap-3 rounded-lg border border-border-4 bg-background-1 px-3 py-3 md:grid-cols-[auto_minmax(0,1fr)_9rem_auto] md:items-center"
+                className="grid gap-3 rounded-lg border border-border-4 bg-background-1 px-3 py-3 md:grid-cols-[auto_minmax(0,1fr)_minmax(10rem,14rem)_10rem_auto] md:items-center"
               >
                 <div className="flex h-12 w-16 shrink-0 items-center justify-center overflow-hidden rounded bg-background-3">
                   {item.previewUrl ? (
@@ -164,14 +209,14 @@ export function UploadZone({
                   )}
                 </div>
                 <div className="flex min-w-0 flex-col gap-0.5">
-                  <span className="max-w-[12rem] truncate text-[13px] font-medium leading-none text-text-1">
+                  <span className="max-w-48 truncate text-[13px] font-medium leading-none text-text-1">
                     {item.file.name}
                   </span>
                   <span className="text-[12px] leading-none text-text-4">
                     {formatFileSize(item.file.size)}
                   </span>
                   {isUploading && uploadProgress !== null ? (
-                    <div className="mt-1 h-1.5 w-full min-w-[8rem] overflow-hidden rounded-full bg-background-3">
+                    <div className="mt-1 h-1.5 w-full min-w-32 overflow-hidden rounded-full bg-background-3">
                       <div
                         className="h-full rounded-full bg-primary-1 transition-all duration-150"
                         style={{ width: `${uploadProgress}%` }}

--- a/src/features/category-manager/ui/category-bulk-delete-modal.tsx
+++ b/src/features/category-manager/ui/category-bulk-delete-modal.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { Category, DeleteCategoryOptions } from "@entities/category";
 import { cn } from "@shared/lib/style-utils";
-import { Modal, Spinner } from "@shared/ui/libs";
+import { DropSelect, Modal, Spinner } from "@shared/ui/libs";
 
 interface CategoryBulkDeleteModalProps {
   isOpen: boolean;
@@ -184,30 +184,31 @@ export function CategoryBulkDeleteModal({
                     </span>
                   </span>
 
-                  <select
-                    value={moveTo ?? ""}
-                    onChange={(event) =>
-                      setMoveTo(
-                        event.target.value ? Number(event.target.value) : null,
-                      )
+                  <DropSelect
+                    value={moveTo === null ? "" : String(moveTo)}
+                    onChange={(value) =>
+                      setMoveTo(value ? Number(value) : null)
                     }
                     disabled={
                       isDeleting || mode !== "move" || moveOptions.length === 0
                     }
-                    aria-label="이동 대상 카테고리"
-                    className="w-full rounded-[0.9rem] border border-border-3 bg-background-1 px-4 py-3 text-sm text-text-1 outline-none transition-colors focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    <option value="">
-                      {moveOptions.length > 0
-                        ? "이동할 카테고리를 선택하세요"
-                        : "이동 가능한 카테고리가 없습니다"}
-                    </option>
-                    {moveOptions.map((option) => (
-                      <option key={option.id} value={option.id}>
-                        {option.label}
-                      </option>
-                    ))}
-                  </select>
+                    ariaLabel="이동 대상 카테고리"
+                    className="w-full"
+                    triggerClassName="h-auto rounded-[0.9rem] px-4 py-3 text-sm text-text-1"
+                    options={[
+                      {
+                        label:
+                          moveOptions.length > 0
+                            ? "이동할 카테고리를 선택하세요"
+                            : "이동 가능한 카테고리가 없습니다",
+                        value: "",
+                      },
+                      ...moveOptions.map((option) => ({
+                        label: option.label,
+                        value: String(option.id),
+                      })),
+                    ]}
+                  />
                 </span>
               </label>
 

--- a/src/features/category-manager/ui/category-bulk-delete-modal.tsx
+++ b/src/features/category-manager/ui/category-bulk-delete-modal.tsx
@@ -158,7 +158,7 @@ export function CategoryBulkDeleteModal({
 
               <label
                 className={cn(
-                  "flex cursor-pointer gap-4 rounded-[1rem] border px-4 py-4 transition-colors",
+                  "flex cursor-pointer gap-4 rounded-2xl border px-4 py-4 transition-colors",
                   mode === "move"
                     ? "border-primary-1 bg-primary-1/5"
                     : "border-border-3 bg-background-1 hover:border-border-2",
@@ -214,7 +214,7 @@ export function CategoryBulkDeleteModal({
 
               <label
                 className={cn(
-                  "flex cursor-pointer gap-4 rounded-[1rem] border px-4 py-4 transition-colors",
+                  "flex cursor-pointer gap-4 rounded-2xl border px-4 py-4 transition-colors",
                   mode === "trash"
                     ? "border-negative-1/40 bg-negative-1/5"
                     : "border-border-3 bg-background-1 hover:border-border-2",
@@ -249,7 +249,7 @@ export function CategoryBulkDeleteModal({
           type="button"
           onClick={onCancel}
           disabled={isDeleting}
-          className="inline-flex items-center justify-center rounded-[0.75rem] border border-border-3 px-4 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
+          className="inline-flex items-center justify-center rounded-xl border border-border-3 px-4 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {hasChildren ? "확인" : "취소"}
         </button>
@@ -272,7 +272,7 @@ export function CategoryBulkDeleteModal({
               onConfirm({ action: "trash" });
             }}
             disabled={isConfirmDisabled}
-            className="inline-flex items-center justify-center gap-2 rounded-[0.75rem] bg-negative-1 px-4 py-2 text-sm font-medium text-text-1 transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+            className="inline-flex items-center justify-center gap-2 rounded-xl bg-negative-1 px-4 py-2 text-sm font-medium text-text-1 transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
           >
             {isDeleting ? (
               <>

--- a/src/features/category-manager/ui/category-delete-modal.tsx
+++ b/src/features/category-manager/ui/category-delete-modal.tsx
@@ -127,7 +127,7 @@ export function CategoryDeleteModal({
 
               <label
                 className={cn(
-                  "flex cursor-pointer gap-4 rounded-[1rem] border px-4 py-4 transition-colors",
+                  "flex cursor-pointer gap-4 rounded-2xl border px-4 py-4 transition-colors",
                   mode === "move"
                     ? "border-primary-1 bg-primary-1/5"
                     : "border-border-3 bg-background-1 hover:border-border-2",
@@ -174,7 +174,7 @@ export function CategoryDeleteModal({
 
               <label
                 className={cn(
-                  "flex cursor-pointer gap-4 rounded-[1rem] border px-4 py-4 transition-colors",
+                  "flex cursor-pointer gap-4 rounded-2xl border px-4 py-4 transition-colors",
                   mode === "trash"
                     ? "border-negative-1/40 bg-negative-1/5"
                     : "border-border-3 bg-background-1 hover:border-border-2",
@@ -209,7 +209,7 @@ export function CategoryDeleteModal({
           type="button"
           onClick={onCancel}
           disabled={isDeleting}
-          className="inline-flex items-center justify-center rounded-[0.75rem] border border-border-3 px-4 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
+          className="inline-flex items-center justify-center rounded-xl border border-border-3 px-4 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {hasChildren ? "확인" : "취소"}
         </button>
@@ -232,7 +232,7 @@ export function CategoryDeleteModal({
               onConfirm({ action: "trash" });
             }}
             disabled={isConfirmDisabled}
-            className="inline-flex items-center justify-center rounded-[0.75rem] bg-negative-1 px-4 py-2 text-sm font-medium text-text-1 transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+            className="inline-flex items-center justify-center rounded-xl bg-negative-1 px-4 py-2 text-sm font-medium text-text-1 transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
           >
             {isDeleting ? (
               <>

--- a/src/features/category-manager/ui/category-delete-modal.tsx
+++ b/src/features/category-manager/ui/category-delete-modal.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { Category, DeleteCategoryOptions } from "@entities/category";
 import { cn } from "@shared/lib/style-utils";
-import { Modal, Spinner } from "@shared/ui/libs";
+import { DropSelect, Modal, Spinner } from "@shared/ui/libs";
 
 interface CategoryDeleteModalProps {
   category: Category | null;
@@ -152,24 +152,23 @@ export function CategoryDeleteModal({
                     </span>
                   </span>
 
-                  <select
-                    value={moveTo ?? ""}
-                    onChange={(event) =>
-                      setMoveTo(
-                        event.target.value ? Number(event.target.value) : null,
-                      )
+                  <DropSelect
+                    value={moveTo === null ? "" : String(moveTo)}
+                    onChange={(value) =>
+                      setMoveTo(value ? Number(value) : null)
                     }
                     disabled={isDeleting || mode !== "move"}
-                    aria-label="이동 대상 카테고리"
-                    className="w-full rounded-[0.9rem] border border-border-3 bg-background-1 px-4 py-3 text-sm text-text-1 outline-none transition-colors focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    <option value="">이동할 카테고리를 선택하세요</option>
-                    {moveOptions.map((option) => (
-                      <option key={option.id} value={option.id}>
-                        {option.label}
-                      </option>
-                    ))}
-                  </select>
+                    ariaLabel="이동 대상 카테고리"
+                    className="w-full"
+                    triggerClassName="h-auto rounded-[0.9rem] px-4 py-3 text-sm text-text-1"
+                    options={[
+                      { label: "이동할 카테고리를 선택하세요", value: "" },
+                      ...moveOptions.map((option) => ({
+                        label: option.label,
+                        value: String(option.id),
+                      })),
+                    ]}
+                  />
                 </span>
               </label>
 

--- a/src/features/category-manager/ui/category-form-modal.tsx
+++ b/src/features/category-manager/ui/category-form-modal.tsx
@@ -153,7 +153,7 @@ export function CategoryFormModal({
             disabled={isSubmitting}
             ariaLabel="부모 카테고리"
             className="w-full"
-            triggerClassName="h-10 rounded-[0.75rem] text-[13px] text-text-2"
+            triggerClassName="h-10 rounded-xl text-[13px] text-text-2"
           />
         </label>
 
@@ -193,7 +193,7 @@ export function CategoryFormModal({
         </div>
 
         {validationError ? (
-          <div className="rounded-[1rem] border border-negative-1/20 bg-negative-1/10 px-4 py-3 text-sm text-negative-1">
+          <div className="rounded-2xl border border-negative-1/20 bg-negative-1/10 px-4 py-3 text-sm text-negative-1">
             {validationError}
           </div>
         ) : null}
@@ -204,7 +204,7 @@ export function CategoryFormModal({
           type="button"
           onClick={onClose}
           disabled={isSubmitting}
-          className="inline-flex items-center justify-center rounded-[0.75rem] border border-border-3 px-4 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
+          className="inline-flex items-center justify-center rounded-xl border border-border-3 px-4 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
         >
           취소
         </button>
@@ -212,7 +212,7 @@ export function CategoryFormModal({
           type="button"
           onClick={handleSubmit}
           disabled={isSubmitting || !trimmedName}
-          className="inline-flex items-center justify-center rounded-[0.75rem] bg-primary-1 px-4 py-2 text-sm font-medium text-text-1 transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+          className="inline-flex items-center justify-center rounded-xl bg-primary-1 px-4 py-2 text-sm font-medium text-text-1 transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
         >
           {isSubmitting ? (
             <>

--- a/src/features/category-manager/ui/category-form-modal.tsx
+++ b/src/features/category-manager/ui/category-form-modal.tsx
@@ -1,15 +1,13 @@
 "use client";
 
-import type { KeyboardEvent as ReactKeyboardEvent } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type {
   Category,
   CreateCategoryBody,
   UpdateCategoryBody,
 } from "@entities/category";
 import { useImeSafeText } from "@shared/hooks/use-ime-safe-text";
-import { cn } from "@shared/lib/style-utils";
-import { Modal, Spinner } from "@shared/ui/libs";
+import { DropSelect, Modal, Spinner } from "@shared/ui/libs";
 import { ToggleSwitch } from "@shared/ui/toggle-switch";
 
 interface CategoryFormModalProps {
@@ -41,212 +39,6 @@ function getInitialValues(category: Category | null): CategoryFormValues {
     parentId: category?.parentId ?? null,
     isVisible: category?.isVisible ?? true,
   };
-}
-
-function InlineCustomSelect({
-  value,
-  options,
-  onChange,
-  placeholder,
-  disabled,
-}: {
-  value: number | null;
-  options: CategoryOption[];
-  onChange: (value: number | null) => void;
-  placeholder?: string;
-  disabled?: boolean;
-}) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [activeIndex, setActiveIndex] = useState(-1);
-  const rootRef = useRef<HTMLDivElement | null>(null);
-  const listboxIdRef = useRef(
-    `inline-select-${Math.random().toString(36).slice(2)}`,
-  );
-  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
-  const normalizedOptions = [{ id: -1, label: placeholder ?? "" }, ...options];
-  const selectedIndex = normalizedOptions.findIndex((option) =>
-    option.id === -1 ? value === null : option.id === value,
-  );
-  const selected = selectedIndex >= 0 ? normalizedOptions[selectedIndex] : null;
-
-  useEffect(() => {
-    optionRefs.current = [];
-  }, [options]);
-
-  useEffect(() => {
-    if (!isOpen) {
-      setActiveIndex(-1);
-
-      return;
-    }
-
-    setActiveIndex(selectedIndex >= 0 ? selectedIndex : 0);
-  }, [isOpen, selectedIndex]);
-
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    const handlePointerDown = (event: MouseEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-
-    document.addEventListener("mousedown", handlePointerDown);
-
-    return () => document.removeEventListener("mousedown", handlePointerDown);
-  }, [isOpen]);
-
-  useEffect(() => {
-    if (!isOpen || activeIndex < 0) {
-      return;
-    }
-
-    optionRefs.current[activeIndex]?.focus();
-  }, [activeIndex, isOpen]);
-
-  const commitSelection = (index: number) => {
-    const option = normalizedOptions[index];
-    if (!option) {
-      return;
-    }
-
-    onChange(option.id === -1 ? null : option.id);
-    setIsOpen(false);
-  };
-
-  const handleTriggerKeyDown = (
-    event: ReactKeyboardEvent<HTMLButtonElement>,
-  ) => {
-    if (disabled) {
-      return;
-    }
-
-    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
-      event.preventDefault();
-      setIsOpen(true);
-      setActiveIndex(selectedIndex >= 0 ? selectedIndex : 0);
-
-      return;
-    }
-
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      setIsOpen((current) => !current);
-    }
-  };
-
-  const handleOptionKeyDown = (
-    event: ReactKeyboardEvent<HTMLButtonElement>,
-    index: number,
-  ) => {
-    if (event.key === "ArrowDown") {
-      event.preventDefault();
-      setActiveIndex((index + 1) % normalizedOptions.length);
-
-      return;
-    }
-
-    if (event.key === "ArrowUp") {
-      event.preventDefault();
-      setActiveIndex(
-        (index - 1 + normalizedOptions.length) % normalizedOptions.length,
-      );
-
-      return;
-    }
-
-    if (event.key === "Home") {
-      event.preventDefault();
-      setActiveIndex(0);
-
-      return;
-    }
-
-    if (event.key === "End") {
-      event.preventDefault();
-      setActiveIndex(normalizedOptions.length - 1);
-
-      return;
-    }
-
-    if (event.key === "Escape") {
-      event.preventDefault();
-      setIsOpen(false);
-
-      return;
-    }
-
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      commitSelection(index);
-    }
-  };
-
-  return (
-    <div ref={rootRef} className="relative w-full">
-      <button
-        type="button"
-        disabled={disabled}
-        onClick={() => setIsOpen((current) => !current)}
-        onKeyDown={handleTriggerKeyDown}
-        role="combobox"
-        aria-autocomplete="none"
-        aria-expanded={isOpen}
-        aria-controls={listboxIdRef.current}
-        aria-haspopup="listbox"
-        className="flex h-10 w-full items-center rounded-[0.75rem] border border-border-3 bg-background-1 px-3 pr-8 text-left text-[13px] text-text-2 outline-none transition-colors focus-visible:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
-      >
-        <span className="truncate">{selected?.label ?? placeholder ?? ""}</span>
-        <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[11px] text-text-4">
-          ▾
-        </span>
-      </button>
-
-      {isOpen ? (
-        <div
-          id={listboxIdRef.current}
-          role="listbox"
-          aria-activedescendant={
-            activeIndex >= 0
-              ? `${listboxIdRef.current}-option-${activeIndex}`
-              : undefined
-          }
-          className="absolute left-0 top-[calc(100%+0.25rem)] z-30 min-w-full overflow-hidden rounded-[0.5rem] border border-border-3 bg-background-1 shadow-[0px_8px_24px_rgba(15,23,42,0.08)]"
-        >
-          {normalizedOptions.map((option, index) => {
-            const isSelected =
-              option.id === -1 ? value === null : option.id === value;
-
-            return (
-              <button
-                key={`${option.id}-${option.label}`}
-                id={`${listboxIdRef.current}-option-${index}`}
-                ref={(element) => {
-                  optionRefs.current[index] = element;
-                }}
-                type="button"
-                role="option"
-                aria-selected={isSelected}
-                tabIndex={activeIndex === index ? 0 : -1}
-                onKeyDown={(event) => handleOptionKeyDown(event, index)}
-                onFocus={() => setActiveIndex(index)}
-                onClick={() => commitSelection(index)}
-                className={cn(
-                  "flex w-full items-center px-3 py-2 text-left text-[13px] transition-colors hover:bg-background-2",
-                  isSelected ? "font-medium text-primary-1" : "text-text-2",
-                )}
-              >
-                <span className="truncate">{option.label}</span>
-              </button>
-            );
-          })}
-        </div>
-      ) : null}
-    </div>
-  );
 }
 
 export function CategoryFormModal({
@@ -343,17 +135,25 @@ export function CategoryFormModal({
 
         <label className="flex flex-col gap-2 text-sm text-text-2">
           <span className="font-medium text-text-1">부모 카테고리</span>
-          <InlineCustomSelect
-            value={values.parentId}
-            options={parentOptions}
+          <DropSelect
+            value={values.parentId === null ? "" : String(values.parentId)}
+            options={[
+              { label: "최상위 카테고리", value: "" },
+              ...parentOptions.map((option) => ({
+                label: option.label,
+                value: String(option.id),
+              })),
+            ]}
             onChange={(nextValue) =>
               setValues((current) => ({
                 ...current,
-                parentId: nextValue,
+                parentId: nextValue ? Number(nextValue) : null,
               }))
             }
-            placeholder="최상위 카테고리"
             disabled={isSubmitting}
+            ariaLabel="부모 카테고리"
+            className="w-full"
+            triggerClassName="h-10 rounded-[0.75rem] text-[13px] text-text-2"
           />
         </label>
 

--- a/src/features/category-manager/ui/category-manager.tsx
+++ b/src/features/category-manager/ui/category-manager.tsx
@@ -211,14 +211,61 @@ export function CategoryManager() {
         <div>
           {categoriesQuery.isPending ? (
             <div className="space-y-4">
-              {Array.from({ length: 4 }).map((_, index) => (
-                <Skeleton
-                  key={index}
-                  variant="rect"
-                  height="6rem"
-                  className="rounded-[1.25rem]"
-                />
-              ))}
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Skeleton
+                    height="2.5rem"
+                    width="7rem"
+                    className="rounded-lg"
+                  />
+                  <Skeleton
+                    height="2.5rem"
+                    width="7rem"
+                    className="rounded-lg"
+                  />
+                  <Skeleton
+                    height="2.5rem"
+                    width="6rem"
+                    className="rounded-lg"
+                  />
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Skeleton
+                    height="2.5rem"
+                    width="6rem"
+                    className="rounded-lg"
+                  />
+                  <Skeleton
+                    height="2.5rem"
+                    width="6rem"
+                    className="rounded-lg"
+                  />
+                </div>
+              </div>
+              <div className="overflow-hidden rounded-xl border border-border-4 bg-background-2">
+                {Array.from({ length: 8 }).map((_, index) => (
+                  <div
+                    key={index}
+                    className="border-b border-border-4 px-4 py-3 last:border-b-0"
+                  >
+                    <div
+                      className="flex h-7 items-center gap-2"
+                      style={{ paddingLeft: `${(index % 3) * 24}px` }}
+                    >
+                      <Skeleton height="1.5rem" width="1.5rem" />
+                      <Skeleton
+                        height="0.875rem"
+                        width={index % 3 === 0 ? "10rem" : "8rem"}
+                      />
+                      <Skeleton
+                        height="1rem"
+                        width="5rem"
+                        className="ml-auto rounded"
+                      />
+                    </div>
+                  </div>
+                ))}
+              </div>
             </div>
           ) : null}
 

--- a/src/features/category-manager/ui/category-manager.tsx
+++ b/src/features/category-manager/ui/category-manager.tsx
@@ -223,7 +223,7 @@ export function CategoryManager() {
           ) : null}
 
           {!categoriesQuery.isPending && categoriesQuery.isError ? (
-            <div className="rounded-[1.5rem] border border-negative-1/20 bg-negative-1/10 px-6 py-8 text-center">
+            <div className="rounded-3xl border border-negative-1/20 bg-negative-1/10 px-6 py-8 text-center">
               <p className="text-sm text-negative-1">
                 {getErrorMessage(
                   categoriesQuery.error,
@@ -233,7 +233,7 @@ export function CategoryManager() {
               <button
                 type="button"
                 onClick={() => void categoriesQuery.refetch()}
-                className="mt-4 inline-flex rounded-[0.75rem] border border-negative-1/20 px-4 py-2 text-sm font-medium text-negative-1 transition-colors hover:bg-negative-1/10"
+                className="mt-4 inline-flex rounded-xl border border-negative-1/20 px-4 py-2 text-sm font-medium text-negative-1 transition-colors hover:bg-negative-1/10"
               >
                 다시 시도
               </button>

--- a/src/features/category-manager/ui/category-tree-row.tsx
+++ b/src/features/category-manager/ui/category-tree-row.tsx
@@ -170,12 +170,12 @@ export function CategoryTreeRow({
               {category.name}
             </span>
             {!category.isVisible ? (
-              <span className="shrink-0 whitespace-nowrap text-[12px] leading-none text-text-4">
+              <span className="shrink-0 whitespace-nowrap text-xs leading-none text-text-4">
                 (숨김)
               </span>
             ) : null}
             {showSlug ? (
-              <span className="shrink-0 whitespace-nowrap rounded-[4px] bg-background-3 px-1.5 py-px text-[11px] leading-none text-text-4">
+              <span className="shrink-0 whitespace-nowrap rounded bg-background-3 px-1.5 py-px text-[11px] leading-none text-text-4">
                 {category.slug}
               </span>
             ) : null}
@@ -190,7 +190,7 @@ export function CategoryTreeRow({
             className="flex shrink-0 items-center gap-3"
             style={{ opacity: rowOpacity }}
           >
-            <span className="whitespace-nowrap rounded-[4px] bg-[rgba(219,221,224,0.30)] px-1.5 py-px text-[12px] leading-4 text-text-3">
+            <span className="whitespace-nowrap rounded bg-[rgba(219,221,224,0.30)] px-1.5 py-px text-xs leading-4 text-text-3">
               발행 {category.publishedPostCount ?? 0} / 전체{" "}
               {category.totalPostCount ?? 0}
             </span>
@@ -214,7 +214,7 @@ export function CategoryTreeRow({
                   >
                     <span
                       className={cn(
-                        "inline-block h-4 w-4 rounded-[8px] bg-white shadow-sm transition-transform duration-200",
+                        "inline-block h-4 w-4 rounded-lg bg-white shadow-sm transition-transform duration-200",
                         category.isVisible ? "translate-x-4" : "translate-x-0",
                       )}
                     />
@@ -280,7 +280,7 @@ export function CategoryTreeRowPreview({
   invalidDrop: boolean;
 }) {
   return (
-    <div className="flex min-w-[18rem] items-center justify-between gap-2 rounded-xl border border-border-3 bg-background-2 px-4 py-3 shadow-[0px_18px_40px_0px_rgba(0,0,0,0.14)]">
+    <div className="flex min-w-72 items-center justify-between gap-2 rounded-xl border border-border-3 bg-background-2 px-4 py-3 shadow-[0px_18px_40px_0px_rgba(0,0,0,0.14)]">
       <div
         className="flex min-w-0 flex-1 items-center gap-2"
         style={{ paddingLeft: `${depth * 24}px` }}
@@ -292,7 +292,7 @@ export function CategoryTreeRowPreview({
         <span className="truncate whitespace-nowrap text-sm font-medium leading-none text-text-1">
           {category.name}
         </span>
-        <span className="shrink-0 whitespace-nowrap rounded-[4px] bg-background-3 px-1.5 py-px text-[11px] leading-none text-text-4">
+        <span className="shrink-0 whitespace-nowrap rounded bg-background-3 px-1.5 py-px text-[11px] leading-none text-text-4">
           {category.slug}
         </span>
         {changeMarker ? (
@@ -301,7 +301,7 @@ export function CategoryTreeRowPreview({
           </span>
         ) : null}
       </div>
-      <span className="whitespace-nowrap rounded-[4px] bg-[rgba(219,221,224,0.30)] px-1.5 py-px text-[12px] leading-4 text-text-3">
+      <span className="whitespace-nowrap rounded bg-[rgba(219,221,224,0.30)] px-1.5 py-px text-xs leading-4 text-text-3">
         발행 {category.publishedPostCount ?? 0} / 전체{" "}
         {category.totalPostCount ?? 0}
       </span>

--- a/src/features/category-manager/ui/category-tree-row.tsx
+++ b/src/features/category-manager/ui/category-tree-row.tsx
@@ -2,7 +2,6 @@
 
 import { useDraggable, useDroppable } from "@dnd-kit/core";
 import { Icon } from "@iconify/react/offline";
-import altArrowRightLinear from "@iconify-icons/solar/alt-arrow-right-linear";
 import menuDotsLinear from "@iconify-icons/solar/menu-dots-linear";
 import penNewRoundLinear from "@iconify-icons/solar/pen-new-round-linear";
 import trashBinMinimalisticLinear from "@iconify-icons/solar/trash-bin-minimalistic-linear";
@@ -15,6 +14,7 @@ import type {
 } from "../lib/tree-utils";
 import type { Category } from "@entities/category";
 import { cn } from "@shared/lib/style-utils";
+import { ChevronIcon } from "@shared/ui/icons";
 
 interface CategoryTreeRowProps {
   category: Category;
@@ -152,10 +152,9 @@ export function CategoryTreeRow({
                   isExpanded && "text-text-2",
                 )}
               >
-                <Icon
-                  icon={altArrowRightLinear}
-                  width="16"
-                  aria-hidden="true"
+                <ChevronIcon
+                  direction="right"
+                  size="16"
                   className={cn(
                     "transition-transform duration-200",
                     isExpanded && "rotate-90",

--- a/src/features/category-manager/ui/category-tree.tsx
+++ b/src/features/category-manager/ui/category-tree.tsx
@@ -600,7 +600,7 @@ export function CategoryTree({
 
         {mode === "select" ? (
           <div className="fixed bottom-0 left-0 right-0 z-20 md:left-[var(--admin-sidebar-offset)]">
-            <div className="flex flex-wrap items-center gap-3 border-t border-border-3 bg-[rgba(241,242,243,0.95)] px-4 py-3 backdrop-blur-[12px] md:px-6 dark:bg-[rgba(19,20,21,0.94)]">
+            <div className="flex flex-wrap items-center gap-3 border-t border-border-3 bg-[rgba(241,242,243,0.95)] px-4 py-3 backdrop-blur-md md:px-6 dark:bg-[rgba(19,20,21,0.94)]">
               <span className="text-sm font-medium text-text-1">
                 선택됨 {selectedCount}개
               </span>
@@ -660,7 +660,7 @@ export function CategoryTree({
 
         {mode === "edit" ? (
           <div className="fixed bottom-0 left-0 right-0 z-20 md:left-[var(--admin-sidebar-offset)]">
-            <div className="flex flex-wrap items-center gap-3 border-t border-border-3 bg-[rgba(241,242,243,0.95)] px-4 py-3 backdrop-blur-[12px] md:px-6 dark:bg-[rgba(19,20,21,0.94)]">
+            <div className="flex flex-wrap items-center gap-3 border-t border-border-3 bg-[rgba(241,242,243,0.95)] px-4 py-3 backdrop-blur-md md:px-6 dark:bg-[rgba(19,20,21,0.94)]">
               <span className="text-sm font-medium text-text-1">
                 변경사항 {pendingChanges.length}건
               </span>

--- a/src/features/category-tree/ui/overview-category-tree.tsx
+++ b/src/features/category-tree/ui/overview-category-tree.tsx
@@ -43,7 +43,7 @@ function OverviewCategoryItem({
     depth > 0 ? { marginLeft: `${depth * 1.25}rem` } : undefined;
   const titleClassName = cn(
     "flex h-full min-w-0 items-center truncate leading-none",
-    isRoot ? "text-[1.125rem] font-bold" : "text-[0.875rem] font-medium",
+    isRoot ? "text-[1.125rem] font-bold" : "text-sm font-medium",
   );
   const countContent =
     postCount !== undefined ? (

--- a/src/features/category-tree/ui/overview-category-tree.tsx
+++ b/src/features/category-tree/ui/overview-category-tree.tsx
@@ -13,6 +13,7 @@ import { useExpandedCategorySlugs } from "../lib/use-expanded-category-slugs";
 import type { Category } from "@entities/category";
 import { formatNumber } from "@shared/lib/format-number";
 import { cn } from "@shared/lib/style-utils";
+import { ChevronIcon } from "@shared/ui/icons";
 
 interface OverviewCategoryTreeProps {
   categories: Category[];
@@ -71,8 +72,11 @@ function OverviewCategoryItem({
             style={indentStyle}
           >
             <ChevronIcon
+              direction="right"
+              size="16"
+              strokeWidth="2"
               className={cn(
-                "h-4 w-4 shrink-0 transition-transform duration-200",
+                "shrink-0 transition-transform duration-200",
                 isOpen && "rotate-90",
               )}
             />
@@ -193,23 +197,5 @@ export function OverviewCategoryTree({
         </ul>
       </section>
     </div>
-  );
-}
-
-function ChevronIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="m9 18 6-6-6-6" />
-    </svg>
   );
 }

--- a/src/features/category-tree/ui/sidebar-category-tree.tsx
+++ b/src/features/category-tree/ui/sidebar-category-tree.tsx
@@ -11,6 +11,7 @@ import { useExpandedCategorySlugs } from "../lib/use-expanded-category-slugs";
 import type { Category } from "@entities/category";
 import { formatNumber } from "@shared/lib/format-number";
 import { cn } from "@shared/lib/style-utils";
+import { ChevronIcon } from "@shared/ui/icons";
 
 interface SidebarCategoryTreeProps {
   categories: Category[];
@@ -68,8 +69,11 @@ function SidebarCategoryItem({
             style={indentStyle}
           >
             <ChevronIcon
+              direction="right"
+              size="16"
+              strokeWidth="2"
               className={cn(
-                "h-4 w-4 transition-transform duration-200 shrink-0",
+                "shrink-0 transition-transform duration-200",
                 isOpen && "rotate-90",
               )}
             />
@@ -148,23 +152,5 @@ export function SidebarCategoryTree({
         ))}
       </ul>
     </div>
-  );
-}
-
-function ChevronIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="m9 18 6-6-6-6" />
-    </svg>
   );
 }

--- a/src/features/comment-section/ui/comment-form.tsx
+++ b/src/features/comment-section/ui/comment-form.tsx
@@ -245,7 +245,7 @@ export function CommentForm<TPayload extends CommentFormPayload>({
       <form
         onSubmit={handleSubmit}
         className={cn(
-          "rounded-[1.5rem] border border-border-3 bg-background-2 p-5 sm:p-6",
+          "rounded-3xl border border-border-3 bg-background-2 p-5 sm:p-6",
           className,
         )}
       >
@@ -257,7 +257,7 @@ export function CommentForm<TPayload extends CommentFormPayload>({
             )}
           >
             <label className="block">
-              <span className="text-[0.75rem] font-semibold leading-4 tracking-[0.02em] text-text-3">
+              <span className="text-xs font-semibold leading-4 tracking-[0.02em] text-text-3">
                 이름 <span className="text-negative-1">*</span>
               </span>
               <input
@@ -267,7 +267,7 @@ export function CommentForm<TPayload extends CommentFormPayload>({
                   onProfileChange("guestName", event.target.value)
                 }
                 disabled={isSubmitting}
-                className="mt-1.5 w-full rounded-[0.875rem] border border-border-3 bg-background-1 px-3 py-[0.5625rem] text-[0.875rem] leading-[1.1875rem] text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+                className="mt-1.5 w-full rounded-[0.875rem] border border-border-3 bg-background-1 px-3 py-[0.5625rem] text-sm leading-[1.1875rem] text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
                 placeholder="이름을 입력하세요"
                 autoComplete="name"
                 required
@@ -276,7 +276,7 @@ export function CommentForm<TPayload extends CommentFormPayload>({
 
             {showGuestEmailField ? (
               <label className="block">
-                <span className="text-[0.75rem] font-semibold leading-4 tracking-[0.02em] text-text-3">
+                <span className="text-xs font-semibold leading-4 tracking-[0.02em] text-text-3">
                   이메일
                 </span>
                 <input
@@ -286,7 +286,7 @@ export function CommentForm<TPayload extends CommentFormPayload>({
                     onProfileChange("guestEmail", event.target.value)
                   }
                   disabled={isSubmitting}
-                  className="mt-1.5 w-full rounded-[0.875rem] border border-border-3 bg-background-1 px-3 py-[0.5625rem] text-[0.875rem] leading-[1.1875rem] text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+                  className="mt-1.5 w-full rounded-[0.875rem] border border-border-3 bg-background-1 px-3 py-[0.5625rem] text-sm leading-[1.1875rem] text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
                   placeholder="이메일 (선택)"
                   autoComplete="email"
                 />
@@ -294,7 +294,7 @@ export function CommentForm<TPayload extends CommentFormPayload>({
             ) : null}
 
             <label className="block">
-              <span className="text-[0.75rem] font-semibold leading-4 tracking-[0.02em] text-text-3">
+              <span className="text-xs font-semibold leading-4 tracking-[0.02em] text-text-3">
                 비밀번호 <span className="text-negative-1">*</span>
               </span>
               <input
@@ -304,7 +304,7 @@ export function CommentForm<TPayload extends CommentFormPayload>({
                   onProfileChange("guestPassword", event.target.value)
                 }
                 disabled={isSubmitting}
-                className="mt-1.5 w-full rounded-[0.875rem] border border-border-3 bg-background-1 px-3 py-[0.5625rem] text-[0.875rem] leading-[1.1875rem] text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+                className="mt-1.5 w-full rounded-[0.875rem] border border-border-3 bg-background-1 px-3 py-[0.5625rem] text-sm leading-[1.1875rem] text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
                 placeholder="삭제 시 필요합니다"
                 minLength={4}
                 required
@@ -317,25 +317,23 @@ export function CommentForm<TPayload extends CommentFormPayload>({
               <UserIcon />
             </div>
             <div>
-              <p className="text-[0.875rem] font-semibold leading-[1.1875rem] text-text-1">
+              <p className="text-sm font-semibold leading-[1.1875rem] text-text-1">
                 로그인 사용자
               </p>
-              <p className="text-[0.75rem] leading-4 text-text-4">
-                로그인 중 · OAuth
-              </p>
+              <p className="text-xs leading-4 text-text-4">로그인 중 · OAuth</p>
             </div>
           </div>
         )}
 
         <label className="mt-3 block">
-          <span className="text-[0.75rem] font-semibold leading-4 tracking-[0.02em] text-text-3">
+          <span className="text-xs font-semibold leading-4 tracking-[0.02em] text-text-3">
             내용 <span className="text-negative-1">*</span>
           </span>
           <textarea
             value={body}
             onChange={(event) => setBody(event.target.value)}
             disabled={isSubmitting}
-            className="mt-1.5 min-h-24 w-full rounded-[0.875rem] border border-border-3 bg-background-1 px-3 py-[0.5625rem] text-[0.875rem] leading-[1.6] text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+            className="mt-1.5 min-h-24 w-full rounded-[0.875rem] border border-border-3 bg-background-1 px-3 py-[0.5625rem] text-sm leading-[1.6] text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
             placeholder="방명록을 남겨주세요 (최대 2,000자)"
             maxLength={2000}
             required
@@ -345,7 +343,7 @@ export function CommentForm<TPayload extends CommentFormPayload>({
         <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
           <label
             className={cn(
-              "inline-flex cursor-pointer items-center gap-2 text-[0.8125rem] leading-[1.125rem] transition-colors",
+              "inline-flex cursor-pointer items-center gap-2 text-[0.8125rem] leading-4.5 transition-colors",
               isSecret ? "text-primary-1" : "text-text-3",
             )}
           >
@@ -366,7 +364,7 @@ export function CommentForm<TPayload extends CommentFormPayload>({
           <div className="flex items-center gap-3">
             <span
               className={cn(
-                "text-[0.75rem] leading-4 text-text-4",
+                "text-xs leading-4 text-text-4",
                 bodyLength >= 2000
                   ? "text-negative-1"
                   : bodyLength >= 1500
@@ -380,7 +378,7 @@ export function CommentForm<TPayload extends CommentFormPayload>({
             <button
               type="submit"
               disabled={isSubmitting}
-              className="inline-flex items-center justify-center gap-2 rounded-[0.625rem] bg-primary-1 px-5 py-[0.5625rem] text-[0.875rem] font-semibold leading-[1.1875rem] text-white transition-all hover:-translate-y-0.5 hover:bg-secondary-1 disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center justify-center gap-2 rounded-[0.625rem] bg-primary-1 px-5 py-[0.5625rem] text-sm font-semibold leading-[1.1875rem] text-white transition-all hover:-translate-y-0.5 hover:bg-secondary-1 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {isSubmitting ? (
                 <>
@@ -399,7 +397,7 @@ export function CommentForm<TPayload extends CommentFormPayload>({
         {errorMessage ? (
           <div
             role="alert"
-            className="mt-4 rounded-[1rem] border border-negative-1/30 bg-negative-1/5 px-4 py-3 text-body-sm text-negative-1"
+            className="mt-4 rounded-2xl border border-negative-1/30 bg-negative-1/5 px-4 py-3 text-body-sm text-negative-1"
           >
             {errorMessage}
           </div>
@@ -412,7 +410,7 @@ export function CommentForm<TPayload extends CommentFormPayload>({
     <form
       onSubmit={handleSubmit}
       className={cn(
-        "rounded-[1rem] border border-border-3 bg-background-2 p-5",
+        "rounded-2xl border border-border-3 bg-background-2 p-5",
         className,
       )}
     >
@@ -440,7 +438,7 @@ export function CommentForm<TPayload extends CommentFormPayload>({
                 onProfileChange("guestName", event.target.value)
               }
               disabled={isSubmitting}
-              className="w-full rounded-[0.75rem] border border-border-3 bg-background-1 px-3.5 py-2.5 text-body-sm text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+              className="w-full rounded-xl border border-border-3 bg-background-1 px-3.5 py-2.5 text-body-sm text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
               placeholder="이름"
               required
             />
@@ -456,7 +454,7 @@ export function CommentForm<TPayload extends CommentFormPayload>({
                   onProfileChange("guestEmail", event.target.value)
                 }
                 disabled={isSubmitting}
-                className="w-full rounded-[0.75rem] border border-border-3 bg-background-1 px-3.5 py-2.5 text-body-sm text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+                className="w-full rounded-xl border border-border-3 bg-background-1 px-3.5 py-2.5 text-body-sm text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
                 placeholder="이메일"
               />
             </label>
@@ -471,7 +469,7 @@ export function CommentForm<TPayload extends CommentFormPayload>({
                 onProfileChange("guestPassword", event.target.value)
               }
               disabled={isSubmitting}
-              className="w-full rounded-[0.75rem] border border-border-3 bg-background-1 px-3.5 py-2.5 text-body-sm text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+              className="w-full rounded-xl border border-border-3 bg-background-1 px-3.5 py-2.5 text-body-sm text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
               placeholder="삭제 시 필요합니다"
               minLength={4}
               required
@@ -491,7 +489,7 @@ export function CommentForm<TPayload extends CommentFormPayload>({
           onChange={(event) => setBody(event.target.value)}
           disabled={isSubmitting}
           className={cn(
-            "w-full rounded-[0.75rem] border border-border-3 bg-background-1 px-3.5 py-2.5 text-body-sm leading-[1.6] text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60",
+            "w-full rounded-xl border border-border-3 bg-background-1 px-3.5 py-2.5 text-body-sm leading-[1.6] text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60",
             replyToName ? "min-h-24" : "min-h-[6.25rem]",
           )}
           placeholder={getBodyPlaceholder(variant, replyToName)}
@@ -515,7 +513,7 @@ export function CommentForm<TPayload extends CommentFormPayload>({
       {errorMessage ? (
         <div
           role="alert"
-          className="mt-3 rounded-[0.75rem] border border-negative-1/30 bg-negative-1/5 px-4 py-3 text-body-sm text-negative-1"
+          className="mt-3 rounded-xl border border-negative-1/30 bg-negative-1/5 px-4 py-3 text-body-sm text-negative-1"
         >
           {errorMessage}
         </div>

--- a/src/features/comment-section/ui/comment-form.tsx
+++ b/src/features/comment-section/ui/comment-form.tsx
@@ -245,7 +245,7 @@ export function CommentForm<TPayload extends CommentFormPayload>({
       <form
         onSubmit={handleSubmit}
         className={cn(
-          "rounded-3xl border border-border-3 bg-background-2 p-5 sm:p-6",
+          "rounded-3xl border border-border-3 bg-background-2 p-3 sm:p-6",
           className,
         )}
       >
@@ -340,7 +340,7 @@ export function CommentForm<TPayload extends CommentFormPayload>({
           />
         </label>
 
-        <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
+        <div className="mt-1 flex flex-wrap items-end justify-between gap-3">
           <label
             className={cn(
               "inline-flex cursor-pointer items-center gap-2 text-[0.8125rem] leading-4.5 transition-colors",
@@ -361,7 +361,7 @@ export function CommentForm<TPayload extends CommentFormPayload>({
             비밀글
           </label>
 
-          <div className="flex items-center gap-3">
+          <div className="flex items-end gap-4">
             <span
               className={cn(
                 "text-xs leading-4 text-text-4",

--- a/src/features/comment-section/ui/comment-item.tsx
+++ b/src/features/comment-section/ui/comment-item.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { Comment } from "@entities/comment";
+import { ChevronIcon } from "@shared/ui/icons";
 
 interface CommentItemProps {
   comment: Comment;
@@ -42,23 +43,6 @@ function LockIcon() {
   );
 }
 
-function ChevronIcon({ expanded }: { expanded: boolean }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      className="h-3.5 w-3.5"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.8"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      {expanded ? <path d="m6 15 6-6 6 6" /> : <path d="m6 9 6 6 6-6" />}
-    </svg>
-  );
-}
-
 export function CommentItem({
   comment,
   body,
@@ -87,7 +71,10 @@ export function CommentItem({
               className="inline-flex items-center gap-1 text-ui-sm text-text-3 transition-colors hover:text-text-1"
             >
               답글 {replyCount}개
-              <ChevronIcon expanded={repliesExpanded} />
+              <ChevronIcon
+                direction={repliesExpanded ? "up" : "down"}
+                size="14"
+              />
             </button>
           </div>
         ) : null}
@@ -149,7 +136,10 @@ export function CommentItem({
             className="inline-flex items-center gap-1 text-ui-sm text-text-3 transition-colors hover:text-text-1"
           >
             답글 {replyCount}개
-            <ChevronIcon expanded={repliesExpanded} />
+            <ChevronIcon
+              direction={repliesExpanded ? "up" : "down"}
+              size="14"
+            />
           </button>
         </div>
       ) : null}

--- a/src/features/comment-section/ui/comment-list.tsx
+++ b/src/features/comment-section/ui/comment-list.tsx
@@ -732,7 +732,7 @@ export function CommentList({
           </span>
         </h2>
         {isLocked ? (
-          <p className="mt-3 rounded-[0.75rem] border border-border-3 bg-background-2 px-4 py-3 text-body-sm text-text-3">
+          <p className="mt-3 rounded-xl border border-border-3 bg-background-2 px-4 py-3 text-body-sm text-text-3">
             댓글이 잠겼습니다. 기존 댓글만 확인할 수 있습니다.
           </p>
         ) : null}
@@ -754,14 +754,14 @@ export function CommentList({
         {loadError ? (
           <div
             role="status"
-            className="mb-5 rounded-[0.75rem] border border-border-3 bg-background-2 px-4 py-3 text-body-sm text-text-3"
+            className="mb-5 rounded-xl border border-border-3 bg-background-2 px-4 py-3 text-body-sm text-text-3"
           >
             {loadError}
           </div>
         ) : null}
 
         {isLoadingPage ? (
-          <div className="flex min-h-48 items-center justify-center rounded-[1rem] border border-dashed border-border-3 bg-background-2 px-5 py-8 text-body-md text-text-3">
+          <div className="flex min-h-48 items-center justify-center rounded-2xl border border-dashed border-border-3 bg-background-2 px-5 py-8 text-body-md text-text-3">
             <Spinner size="sm" />
             <span className="ml-3">댓글을 불러오는 중입니다.</span>
           </div>
@@ -865,7 +865,7 @@ export function CommentList({
             })}
           </ul>
         ) : (
-          <div className="rounded-[1rem] border border-dashed border-border-3 bg-background-2 px-5 py-8 text-body-md text-text-3">
+          <div className="rounded-2xl border border-dashed border-border-3 bg-background-2 px-5 py-8 text-body-md text-text-3">
             첫 댓글을 남겨 보세요.
           </div>
         )}
@@ -880,7 +880,7 @@ export function CommentList({
             type="button"
             onClick={() => loadPage(Math.max(1, currentPage - 1))}
             disabled={isLoadingPage || currentPage <= 1}
-            className="inline-flex h-8 w-8 items-center justify-center rounded-[0.5rem] text-sm text-text-3 transition-colors hover:bg-background-3 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-40"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-sm text-text-3 transition-colors hover:bg-background-3 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-40"
           >
             &lsaquo;
           </button>
@@ -903,8 +903,8 @@ export function CommentList({
                   aria-current={page === currentPage ? "page" : undefined}
                   className={
                     page === currentPage
-                      ? "inline-flex h-8 min-w-8 items-center justify-center rounded-[0.5rem] bg-primary-1 px-2 text-sm font-semibold text-white"
-                      : "inline-flex h-8 min-w-8 items-center justify-center rounded-[0.5rem] px-2 text-sm text-text-3 transition-colors hover:bg-background-3 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-40"
+                      ? "inline-flex h-8 min-w-8 items-center justify-center rounded-lg bg-primary-1 px-2 text-sm font-semibold text-white"
+                      : "inline-flex h-8 min-w-8 items-center justify-center rounded-lg px-2 text-sm text-text-3 transition-colors hover:bg-background-3 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-40"
                   }
                 >
                   {page}
@@ -917,7 +917,7 @@ export function CommentList({
               loadPage(Math.min(safeMeta.totalPages, currentPage + 1))
             }
             disabled={isLoadingPage || currentPage >= safeMeta.totalPages}
-            className="inline-flex h-8 w-8 items-center justify-center rounded-[0.5rem] text-sm text-text-3 transition-colors hover:bg-background-3 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-40"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-sm text-text-3 transition-colors hover:bg-background-3 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-40"
           >
             &rsaquo;
           </button>
@@ -954,7 +954,7 @@ export function CommentList({
           </p>
 
           {deleteTarget && deleteTarget.replies.length > 0 ? (
-            <div className="mt-4 rounded-[1rem] border border-warning-1/30 bg-warning-1/5 px-4 py-3 text-body-sm text-warning-1">
+            <div className="mt-4 rounded-2xl border border-warning-1/30 bg-warning-1/5 px-4 py-3 text-body-sm text-warning-1">
               <p className="font-medium">대댓글이 있는 댓글입니다.</p>
               <p className="mt-1">
                 삭제 후에도 대댓글 {deleteTarget.replies.length}개는 유지됩니다.
@@ -974,7 +974,7 @@ export function CommentList({
                 value={deletePassword}
                 onChange={(event) => setDeletePassword(event.target.value)}
                 disabled={deleteBusy}
-                className="mt-2 w-full rounded-[1rem] border border-border-3 bg-background-1 px-4 py-3 text-body-sm text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
+                className="mt-2 w-full rounded-2xl border border-border-3 bg-background-1 px-4 py-3 text-body-sm text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
                 minLength={4}
                 required
               />
@@ -984,7 +984,7 @@ export function CommentList({
           {deleteError ? (
             <div
               role="alert"
-              className="mt-4 rounded-[1rem] border border-negative-1/30 bg-negative-1/5 px-4 py-3 text-body-sm text-negative-1"
+              className="mt-4 rounded-2xl border border-negative-1/30 bg-negative-1/5 px-4 py-3 text-body-sm text-negative-1"
             >
               {deleteError}
             </div>
@@ -999,7 +999,7 @@ export function CommentList({
                 (deleteTarget?.author.type !== "oauth" &&
                   deletePassword.trim().length < 4)
               }
-              className="inline-flex items-center justify-center rounded-[1rem] bg-negative-1 px-5 py-3 text-body-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center justify-center rounded-2xl bg-negative-1 px-5 py-3 text-body-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {deleteBusy ? (
                 <>
@@ -1021,7 +1021,7 @@ export function CommentList({
                 setDeleteError(null);
               }}
               disabled={deleteBusy}
-              className="inline-flex items-center justify-center rounded-[1rem] border border-border-3 px-5 py-3 text-body-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center justify-center rounded-2xl border border-border-3 px-5 py-3 text-body-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-60"
             >
               취소
             </button>

--- a/src/features/guestbook-form/ui/guestbook-page-content.tsx
+++ b/src/features/guestbook-form/ui/guestbook-page-content.tsx
@@ -251,7 +251,7 @@ function GuestbookEntryItem({
             <div className="flex flex-wrap items-center gap-2">
               <span
                 className={cn(
-                  "text-[0.875rem] font-semibold leading-[1.1875rem]",
+                  "text-sm font-semibold leading-[1.1875rem]",
                   isDeleted ? "text-text-4" : "text-text-1",
                 )}
               >
@@ -274,7 +274,7 @@ function GuestbookEntryItem({
 
               <time
                 dateTime={entry.createdAt}
-                className="text-[0.75rem] leading-4 text-text-4"
+                className="text-xs leading-4 text-text-4"
               >
                 {formatRelativeTime(entry.createdAt)}
               </time>
@@ -284,7 +284,7 @@ function GuestbookEntryItem({
               <button
                 type="button"
                 onClick={() => onDelete(entry)}
-                className="inline-flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-[0.75rem] font-medium leading-4 text-text-4 transition-colors hover:bg-negative-1/8 hover:text-negative-1"
+                className="inline-flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-xs font-medium leading-4 text-text-4 transition-colors hover:bg-negative-1/8 hover:text-negative-1"
               >
                 <TrashIcon className="h-[0.8125rem] w-[0.8125rem]" />
                 삭제
@@ -295,20 +295,18 @@ function GuestbookEntryItem({
           {body.masked ? (
             <div
               className={cn(
-                "inline-flex max-w-full items-center gap-2 rounded-xl bg-background-2 px-4 py-3 text-[0.875rem] italic leading-[0.875rem] text-text-4",
+                "inline-flex max-w-full items-center gap-2 rounded-xl bg-background-2 px-4 py-3 text-sm italic leading-3.5 text-text-4",
               )}
             >
               {entry.isSecret && !isDeleted ? (
-                <LockIcon className="h-[0.875rem] w-[0.875rem] shrink-0" />
+                <LockIcon className="h-3.5 w-3.5 shrink-0" />
               ) : (
-                <TrashIcon className="h-[0.875rem] w-[0.875rem] shrink-0" />
+                <TrashIcon className="h-3.5 w-3.5 shrink-0" />
               )}
-              <span className="break-words leading-[0.875rem]">
-                {body.text}
-              </span>
+              <span className="break-words leading-3.5">{body.text}</span>
             </div>
           ) : (
-            <p className="whitespace-pre-wrap break-words text-[0.875rem] leading-relaxed text-text-2">
+            <p className="whitespace-pre-wrap break-words text-sm leading-relaxed text-text-2">
               {body.text}
             </p>
           )}
@@ -447,10 +445,10 @@ export function GuestbookPageContent({
     <main className="mx-auto flex min-h-screen w-full max-w-[67.5rem] flex-col px-4 py-12 md:px-6">
       <header className="motion-reveal">
         <div className="flex flex-wrap items-baseline justify-between gap-4">
-          <h1 className="text-[1.5rem] font-bold leading-[1.9375rem] tracking-tight text-text-1 sm:text-[1.875rem] sm:leading-[2.375rem]">
+          <h1 className="text-2xl font-bold leading-[1.9375rem] tracking-tight text-text-1 sm:text-3xl sm:leading-9.5">
             방명록
           </h1>
-          <span className="text-[0.875rem] leading-[1.1875rem] text-text-4">
+          <span className="text-sm leading-[1.1875rem] text-text-4">
             총 {meta.total.toLocaleString("ko-KR")}개 방명록
           </span>
         </div>
@@ -460,7 +458,7 @@ export function GuestbookPageContent({
       {viewer.authErrorMessage ? (
         <div
           role="status"
-          className="mt-6 flex items-start gap-3 rounded-2xl border border-warning-1/25 bg-warning-2 px-4 py-4 text-[0.875rem] leading-[1.1875rem] text-text-3 motion-reveal"
+          className="mt-6 flex items-start gap-3 rounded-2xl border border-warning-1/25 bg-warning-2 px-4 py-4 text-sm leading-[1.1875rem] text-text-3 motion-reveal"
         >
           <span className="mt-0.5 shrink-0 text-warning-1">
             <AlertIcon />
@@ -574,7 +572,7 @@ export function GuestbookPageContent({
           {deleteError ? (
             <div
               role="alert"
-              className="mt-4 rounded-[1rem] border border-negative-1/25 bg-negative-1/5 px-4 py-3 text-body-sm text-negative-1"
+              className="mt-4 rounded-2xl border border-negative-1/25 bg-negative-1/5 px-4 py-3 text-body-sm text-negative-1"
             >
               {deleteError}
             </div>

--- a/src/features/guestbook-form/ui/guestbook-page-content.tsx
+++ b/src/features/guestbook-form/ui/guestbook-page-content.tsx
@@ -442,7 +442,7 @@ export function GuestbookPageContent({
   );
 
   return (
-    <main className="mx-auto flex min-h-screen w-full max-w-[67.5rem] flex-col px-4 py-12 md:px-6">
+    <div className="flex w-full flex-col">
       <header className="motion-reveal">
         <div className="flex flex-wrap items-baseline justify-between gap-4">
           <h1 className="text-2xl font-bold leading-[1.9375rem] tracking-tight text-text-1 sm:text-3xl sm:leading-9.5">
@@ -615,6 +615,6 @@ export function GuestbookPageContent({
           </div>
         </div>
       </Modal>
-    </main>
+    </div>
   );
 }

--- a/src/features/guestbook-manager/ui/guestbook-action-modal.tsx
+++ b/src/features/guestbook-manager/ui/guestbook-action-modal.tsx
@@ -90,7 +90,7 @@ export function GuestbookActionModal({
             <label
               key={option.value}
               className={cn(
-                "flex cursor-pointer gap-4 rounded-[1rem] border px-4 py-4 transition-colors",
+                "flex cursor-pointer gap-4 rounded-2xl border px-4 py-4 transition-colors",
                 selectedAction === option.value
                   ? "border-primary-1 bg-primary-1/5"
                   : "border-border-3 bg-background-1 hover:border-border-2",
@@ -120,7 +120,7 @@ export function GuestbookActionModal({
             type="button"
             onClick={handleClose}
             disabled={isPending}
-            className="inline-flex items-center justify-center rounded-[0.75rem] border border-border-3 px-4 py-2.5 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex items-center justify-center rounded-xl border border-border-3 px-4 py-2.5 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
           >
             취소
           </button>
@@ -133,7 +133,7 @@ export function GuestbookActionModal({
             }}
             disabled={!selectedOption || isPending}
             className={cn(
-              "inline-flex items-center justify-center rounded-[0.75rem] px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50",
+              "inline-flex items-center justify-center rounded-xl px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50",
               selectedOption?.tone === "danger"
                 ? "bg-negative-1"
                 : "bg-primary-1",

--- a/src/features/guestbook-manager/ui/guestbook-detail-modal.tsx
+++ b/src/features/guestbook-manager/ui/guestbook-detail-modal.tsx
@@ -174,7 +174,7 @@ export function GuestbookDetailModal({
                 onClick={() => onSelectAction(action.value)}
                 disabled={isPending}
                 className={cn(
-                  "inline-flex items-center justify-center gap-1 whitespace-nowrap rounded-[0.75rem] px-4 py-2.5 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+                  "inline-flex items-center justify-center gap-1 whitespace-nowrap rounded-xl px-4 py-2.5 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
                   action.tone === "danger"
                     ? "bg-negative-1 text-white hover:opacity-90"
                     : "border border-border-3 text-text-2 hover:border-border-2 hover:text-text-1",

--- a/src/features/guestbook-manager/ui/guestbook-manager.tsx
+++ b/src/features/guestbook-manager/ui/guestbook-manager.tsx
@@ -431,7 +431,7 @@ export function GuestbookManager() {
             <button
               type="button"
               onClick={() => void settingsQuery.refetch()}
-              className="rounded-[0.75rem] border border-border-3 px-3 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
+              className="rounded-xl border border-border-3 px-3 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
             >
               다시 시도
             </button>
@@ -448,7 +448,7 @@ export function GuestbookManager() {
       </div>
 
       {settingsQuery.isError ? (
-        <div className="rounded-[1rem] border border-negative-1/20 bg-negative-1/10 px-4 py-3 text-sm text-negative-1">
+        <div className="rounded-2xl border border-negative-1/20 bg-negative-1/10 px-4 py-3 text-sm text-negative-1">
           {getErrorMessage(
             settingsQuery.error,
             "방명록 설정을 불러오지 못했습니다. 상태를 확인한 뒤 다시 시도해 주세요.",
@@ -471,7 +471,7 @@ export function GuestbookManager() {
                   key={index}
                   variant="rect"
                   height="2.5rem"
-                  className="w-[8rem] rounded-[0.8rem]"
+                  className="w-32 rounded-[0.8rem]"
                 />
               ))}
             </div>
@@ -489,7 +489,7 @@ export function GuestbookManager() {
         ) : null}
 
         {!guestbookQuery.isLoading && guestbookQuery.isError ? (
-          <div className="rounded-[1.5rem] border border-negative-1/20 bg-negative-1/10 px-6 py-8 text-center">
+          <div className="rounded-3xl border border-negative-1/20 bg-negative-1/10 px-6 py-8 text-center">
             <p className="text-sm text-negative-1">
               {getErrorMessage(
                 guestbookQuery.error,
@@ -499,7 +499,7 @@ export function GuestbookManager() {
             <button
               type="button"
               onClick={() => void guestbookQuery.refetch()}
-              className="mt-4 inline-flex rounded-[0.75rem] border border-negative-1/20 px-4 py-2 text-sm font-medium text-negative-1 transition-colors hover:bg-negative-1/10"
+              className="mt-4 inline-flex rounded-xl border border-negative-1/20 px-4 py-2 text-sm font-medium text-negative-1 transition-colors hover:bg-negative-1/10"
             >
               다시 시도
             </button>
@@ -627,8 +627,8 @@ export function GuestbookManager() {
                         disabled={pageNumber === page}
                         className={
                           pageNumber === page
-                            ? "pointer-events-none inline-flex min-w-[2rem] items-center justify-center rounded bg-primary-1 px-2.5 py-1.5 text-sm font-semibold text-white"
-                            : "inline-flex min-w-[2rem] items-center justify-center rounded px-2.5 py-1.5 text-sm text-text-1 transition-colors hover:bg-background-2"
+                            ? "pointer-events-none inline-flex min-w-8 items-center justify-center rounded bg-primary-1 px-2.5 py-1.5 text-sm font-semibold text-white"
+                            : "inline-flex min-w-8 items-center justify-center rounded px-2.5 py-1.5 text-sm text-text-1 transition-colors hover:bg-background-2"
                         }
                         aria-current={pageNumber === page ? "page" : undefined}
                         aria-label={`Page ${pageNumber}`}
@@ -668,7 +668,7 @@ export function GuestbookManager() {
 
       {selectedIds.length > 0 ? (
         <div className="fixed bottom-0 left-0 right-0 z-20 md:left-[var(--admin-sidebar-offset)]">
-          <div className="flex flex-wrap items-center gap-3 border-t border-border-3 bg-[rgba(241,242,243,0.95)] px-4 py-3 backdrop-blur-[12px] md:px-6 dark:bg-[rgba(19,20,21,0.94)]">
+          <div className="flex flex-wrap items-center gap-3 border-t border-border-3 bg-[rgba(241,242,243,0.95)] px-4 py-3 backdrop-blur-md md:px-6 dark:bg-[rgba(19,20,21,0.94)]">
             <span className="text-sm font-medium text-text-1">
               선택됨 {selectedIds.length}개
               {offPageCount > 0 ? (

--- a/src/features/guestbook-manager/ui/guestbook-manager.tsx
+++ b/src/features/guestbook-manager/ui/guestbook-manager.tsx
@@ -30,7 +30,7 @@ import {
   updateGuestbookSettings,
 } from "@entities/guestbook";
 import { getErrorMessage } from "@shared/lib/get-error-message";
-import { Skeleton, Spinner } from "@shared/ui/libs";
+import { Skeleton, Spinner, TableSkeleton } from "@shared/ui/libs";
 import { ToggleSwitch } from "@shared/ui/toggle-switch";
 
 const PAGE_SIZE = 10;
@@ -465,7 +465,7 @@ export function GuestbookManager() {
       >
         {guestbookQuery.isLoading && !guestbookQuery.data ? (
           <div className="space-y-4">
-            <div className="flex gap-3">
+            <div className="flex flex-wrap items-end justify-start gap-3">
               {Array.from({ length: 4 }).map((_, index) => (
                 <Skeleton
                   key={index}
@@ -474,17 +474,25 @@ export function GuestbookManager() {
                   className="w-32 rounded-[0.8rem]"
                 />
               ))}
+              <Skeleton
+                variant="rect"
+                height="2.5rem"
+                className="min-w-72 flex-1 rounded-[0.8rem]"
+              />
             </div>
-            <div className="space-y-3">
-              {Array.from({ length: 6 }).map((_, index) => (
-                <Skeleton
-                  key={index}
-                  variant="rect"
-                  height="3.25rem"
-                  className="rounded-[0.9rem]"
-                />
-              ))}
-            </div>
+            <TableSkeleton
+              rows={6}
+              rowHeight="3.25rem"
+              columns={[
+                { width: "2.5rem" },
+                { width: "12rem" },
+                { width: "28rem" },
+                { width: "4rem", className: "text-center" },
+                { width: "6rem" },
+                { width: "7rem" },
+                { width: "4rem", className: "text-center" },
+              ]}
+            />
           </div>
         ) : null}
 

--- a/src/features/guestbook-manager/ui/guestbook-table.tsx
+++ b/src/features/guestbook-manager/ui/guestbook-table.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  useEffect,
-  useRef,
-  useState,
-  type FormEvent,
-  type KeyboardEvent,
-} from "react";
+import { useEffect, useRef, type FormEvent } from "react";
 import { Icon } from "@iconify/react/offline";
 import chatRoundDotsLinear from "@iconify-icons/solar/chat-round-dots-linear";
 import closeCircleLinear from "@iconify-icons/solar/close-circle-linear";
@@ -18,7 +12,7 @@ import type {
   AdminGuestbookItem,
 } from "@entities/guestbook";
 import { cn } from "@shared/lib/style-utils";
-import { EmptyState } from "@shared/ui/libs";
+import { DropSelect, EmptyState } from "@shared/ui/libs";
 
 interface GuestbookTableProps {
   items: AdminGuestbookItem[];
@@ -57,22 +51,22 @@ export type GuestbookPeriodFilter = "all" | "7d" | "30d" | "90d";
 
 const STATUS_OPTIONS: Array<SelectOption<AdminGuestbookFilterStatus>> = [
   { label: "전체", value: "all", triggerLabel: "상태" },
-  { label: "정상", value: "active", triggerLabel: "상태" },
-  { label: "숨김", value: "hidden", triggerLabel: "상태" },
-  { label: "삭제됨", value: "deleted", triggerLabel: "상태" },
+  { label: "정상", value: "active" },
+  { label: "숨김", value: "hidden" },
+  { label: "삭제됨", value: "deleted" },
 ];
 
 const AUTHOR_OPTIONS: Array<SelectOption<AdminGuestbookAuthorType | "all">> = [
   { label: "전체", value: "all", triggerLabel: "작성자 타입" },
-  { label: "OAuth", value: "oauth", triggerLabel: "작성자 타입" },
-  { label: "게스트", value: "guest", triggerLabel: "작성자 타입" },
+  { label: "OAuth", value: "oauth" },
+  { label: "게스트", value: "guest" },
 ];
 
 const PERIOD_OPTIONS: Array<SelectOption<GuestbookPeriodFilter>> = [
   { label: "전체 기간", value: "all", triggerLabel: "전체 기간" },
-  { label: "최근 7일", value: "7d", triggerLabel: "전체 기간" },
-  { label: "최근 30일", value: "30d", triggerLabel: "전체 기간" },
-  { label: "최근 90일", value: "90d", triggerLabel: "전체 기간" },
+  { label: "최근 7일", value: "7d" },
+  { label: "최근 30일", value: "30d" },
+  { label: "최근 90일", value: "90d" },
 ];
 
 const dateFormatter = new Intl.DateTimeFormat("ko-KR", {
@@ -97,195 +91,6 @@ function getStatusTone(status: AdminGuestbookItem["status"]) {
 
 function getBodyPreview(item: AdminGuestbookItem) {
   return item.body || "삭제된 방명록입니다.";
-}
-
-function FilterCustomSelect<T extends string>({
-  label,
-  value,
-  options,
-  onChange,
-  triggerClassName,
-}: {
-  label: string;
-  value: T;
-  options: Array<SelectOption<T>>;
-  onChange: (value: T) => void;
-  triggerClassName?: string;
-}) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [activeIndex, setActiveIndex] = useState(-1);
-  const rootRef = useRef<HTMLDivElement | null>(null);
-  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
-  const listboxIdRef = useRef(
-    `guestbook-filter-select-${Math.random().toString(36).slice(2)}`,
-  );
-  const selected = options.find((option) => option.value === value);
-  const selectedIndex = options.findIndex((option) => option.value === value);
-
-  useEffect(() => {
-    optionRefs.current = [];
-  }, [options]);
-
-  useEffect(() => {
-    if (!isOpen) {
-      setActiveIndex(-1);
-
-      return;
-    }
-
-    setActiveIndex(selectedIndex >= 0 ? selectedIndex : 0);
-  }, [isOpen, selectedIndex]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handlePointerDown = (event: MouseEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-
-    document.addEventListener("mousedown", handlePointerDown);
-
-    return () => document.removeEventListener("mousedown", handlePointerDown);
-  }, [isOpen]);
-
-  useEffect(() => {
-    if (!isOpen || activeIndex < 0) return;
-    optionRefs.current[activeIndex]?.focus();
-  }, [activeIndex, isOpen]);
-
-  function commitSelection(index: number) {
-    const option = options[index];
-    if (!option) return;
-    onChange(option.value);
-    setIsOpen(false);
-  }
-
-  function handleTriggerKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
-    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
-      event.preventDefault();
-      setIsOpen(true);
-      setActiveIndex(selectedIndex >= 0 ? selectedIndex : 0);
-
-      return;
-    }
-
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      setIsOpen((current) => !current);
-    }
-  }
-
-  function handleOptionKeyDown(
-    event: KeyboardEvent<HTMLButtonElement>,
-    index: number,
-  ) {
-    if (event.key === "ArrowDown") {
-      event.preventDefault();
-      setActiveIndex((index + 1) % options.length);
-
-      return;
-    }
-
-    if (event.key === "ArrowUp") {
-      event.preventDefault();
-      setActiveIndex((index - 1 + options.length) % options.length);
-
-      return;
-    }
-
-    if (event.key === "Home") {
-      event.preventDefault();
-      setActiveIndex(0);
-
-      return;
-    }
-
-    if (event.key === "End") {
-      event.preventDefault();
-      setActiveIndex(options.length - 1);
-
-      return;
-    }
-
-    if (event.key === "Escape") {
-      event.preventDefault();
-      setIsOpen(false);
-
-      return;
-    }
-
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      commitSelection(index);
-    }
-  }
-
-  return (
-    <div ref={rootRef} className="relative">
-      <button
-        type="button"
-        onClick={() => setIsOpen((current) => !current)}
-        onKeyDown={handleTriggerKeyDown}
-        role="combobox"
-        aria-autocomplete="none"
-        aria-expanded={isOpen}
-        aria-controls={listboxIdRef.current}
-        aria-haspopup="listbox"
-        className={cn(
-          "relative flex h-10 items-center whitespace-nowrap rounded-[0.8rem] border border-border-3 bg-background-1 px-3 pr-8 text-left text-sm leading-none text-text-2 outline-none transition-colors hover:border-border-2 focus-visible:border-primary-1",
-          triggerClassName,
-        )}
-      >
-        <span className="truncate">
-          {selected?.value === "all"
-            ? (selected?.triggerLabel ?? label)
-            : (selected?.label ?? "")}
-        </span>
-        <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[11px] text-text-4">
-          ▾
-        </span>
-      </button>
-
-      {isOpen ? (
-        <div
-          id={listboxIdRef.current}
-          role="listbox"
-          className="absolute left-0 top-full z-20 mt-2 min-w-full overflow-hidden rounded-[1rem] border border-border-3 bg-background-1 shadow-[0px_16px_40px_0px_rgba(0,0,0,0.12)]"
-        >
-          <div className="max-h-60 overflow-y-auto py-1">
-            {options.map((option, index) => {
-              const isSelected = option.value === value;
-
-              return (
-                <button
-                  key={option.value}
-                  ref={(node) => {
-                    optionRefs.current[index] = node;
-                  }}
-                  type="button"
-                  role="option"
-                  aria-selected={isSelected}
-                  onClick={() => commitSelection(index)}
-                  onKeyDown={(event) => handleOptionKeyDown(event, index)}
-                  className={cn(
-                    "flex w-full items-center justify-between px-4 py-3 text-left text-sm leading-none outline-none transition-colors hover:bg-background-2 focus:bg-background-2",
-                    isSelected ? "text-primary-1" : "text-text-1",
-                  )}
-                >
-                  <span>{option.label}</span>
-                  {isSelected ? (
-                    <span className="text-[11px] text-primary-1">선택됨</span>
-                  ) : null}
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      ) : null}
-    </div>
-  );
 }
 
 export function GuestbookTable({
@@ -330,28 +135,31 @@ export function GuestbookTable({
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-end justify-start gap-3">
-        <FilterCustomSelect
-          label="상태"
+        <DropSelect
+          ariaLabel="상태"
           value={status}
           options={STATUS_OPTIONS}
           onChange={onStatusChange}
           triggerClassName="w-[8em]"
+          showSelectedIndicator
         />
 
-        <FilterCustomSelect
-          label="작성자 타입"
+        <DropSelect
+          ariaLabel="작성자 타입"
           value={authorType}
           options={AUTHOR_OPTIONS}
           onChange={onAuthorTypeChange}
           triggerClassName="w-[9em]"
+          showSelectedIndicator
         />
 
-        <FilterCustomSelect
-          label="전체 기간"
+        <DropSelect
+          ariaLabel="전체 기간"
           value={period}
           options={PERIOD_OPTIONS}
           onChange={onPeriodChange}
           triggerClassName="w-[9em]"
+          showSelectedIndicator
         />
 
         <div className="flex items-center gap-2">

--- a/src/features/guestbook-manager/ui/guestbook-table.tsx
+++ b/src/features/guestbook-manager/ui/guestbook-table.tsx
@@ -181,7 +181,7 @@ export function GuestbookTable({
           />
         </div>
 
-        <form onSubmit={handleSubmit} className="flex min-w-[18rem] flex-1">
+        <form onSubmit={handleSubmit} className="flex min-w-72 flex-1">
           <div className="relative w-full">
             <Icon
               icon={magniferLinear}
@@ -219,7 +219,7 @@ export function GuestbookTable({
       ) : null}
 
       {items.length > 0 ? (
-        <div className="overflow-hidden rounded-[1rem] border border-border-4 bg-background-1">
+        <div className="overflow-hidden rounded-2xl border border-border-4 bg-background-1">
           <div className="overflow-x-auto">
             <table className="min-w-full">
               <thead className="bg-background-2 text-left text-[11px] font-semibold uppercase tracking-[0.16em] text-text-4">
@@ -295,7 +295,7 @@ export function GuestbookTable({
                       </td>
                       <td className="whitespace-nowrap px-3 py-3.5 align-middle leading-none">
                         <span
-                          className="block max-w-[28rem] truncate text-sm leading-none text-text-2"
+                          className="block max-w-md truncate text-sm leading-none text-text-2"
                           title={getBodyPreview(item)}
                         >
                           {getBodyPreview(item)}

--- a/src/features/popular-posts/ui/popular-post-list.tsx
+++ b/src/features/popular-posts/ui/popular-post-list.tsx
@@ -150,7 +150,7 @@ export function PopularPostList({
               <Link
                 href={buildPostHref(post.slug)}
                 onClick={onItemClick}
-                className="group block min-h-[3rem] rounded-md px-0.5 py-1 transition-colors hover:text-primary-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-1"
+                className="group block min-h-12 rounded-md px-0.5 py-1 transition-colors hover:text-primary-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-1"
               >
                 <span className="line-clamp-2 block text-ui-sm font-medium leading-[1.4] text-text-2 transition-colors group-hover:text-primary-1">
                   {post.title}

--- a/src/features/post-detail/ui/related-posts.tsx
+++ b/src/features/post-detail/ui/related-posts.tsx
@@ -27,9 +27,9 @@ export function RelatedPosts({ posts }: RelatedPostsProps) {
           <Link
             key={post.id}
             href={buildPostHref(post.slug)}
-            className="group block w-[11.75rem] shrink-0 overflow-hidden rounded-[0.75rem] border border-border-3 bg-background-2 text-decoration-none transition-all duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] [scroll-snap-align:start] hover:-translate-y-[3px] hover:border-primary-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.06)]"
+            className="group block w-[11.75rem] shrink-0 overflow-hidden rounded-xl border border-border-3 bg-background-2 text-decoration-none transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] [scroll-snap-align:start] hover:-translate-y-[3px] hover:border-primary-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.06)]"
           >
-            <div className="aspect-[16/10] overflow-hidden bg-background-3">
+            <div className="aspect-16/10 overflow-hidden bg-background-3">
               {post.thumbnailUrl ? (
                 <Image
                   src={post.thumbnailUrl}
@@ -37,7 +37,7 @@ export function RelatedPosts({ posts }: RelatedPostsProps) {
                   width={180}
                   height={113}
                   sizes="180px"
-                  className="h-full w-full object-cover transition-transform duration-[500ms] ease-[cubic-bezier(0.16,1,0.3,1)] group-hover:scale-105"
+                  className="h-full w-full object-cover transition-transform duration-500 ease-[cubic-bezier(0.16,1,0.3,1)] group-hover:scale-105"
                 />
               ) : (
                 <div className="h-full w-full bg-background-3" />

--- a/src/features/post-editor/ui/category-tree-select.tsx
+++ b/src/features/post-editor/ui/category-tree-select.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { Category } from "@entities/category";
+import { DropSelect } from "@shared/ui/libs";
 
 interface CategoryTreeSelectProps {
   categories: Category[];
@@ -46,25 +47,25 @@ export function CategoryTreeSelect({
   const options = flattenCategoryTree(categories);
 
   return (
-    <select
+    <DropSelect
       id="categoryId"
       name="categoryId"
-      value={value ?? ""}
-      onChange={(event) =>
-        onChange(event.target.value ? Number(event.target.value) : null)
-      }
+      value={value === null ? "" : String(value)}
+      onChange={(nextValue) => onChange(nextValue ? Number(nextValue) : null)}
       disabled={disabled}
-      aria-label="카테고리"
-      className="h-10 rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-[13px] text-text-2 outline-none transition-colors focus:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
-    >
-      <option value="">
-        {disabled ? "카테고리 불러오는 중..." : "카테고리 선택"}
-      </option>
-      {options.map((option) => (
-        <option key={option.id} value={option.id}>
-          {formatCategoryLabel(option)}
-        </option>
-      ))}
-    </select>
+      ariaLabel="카테고리"
+      className="w-full"
+      triggerClassName="h-10 rounded-[0.75rem] text-[13px] text-text-2"
+      options={[
+        {
+          label: disabled ? "카테고리 불러오는 중..." : "카테고리 선택",
+          value: "",
+        },
+        ...options.map((option) => ({
+          label: formatCategoryLabel(option),
+          value: String(option.id),
+        })),
+      ]}
+    />
   );
 }

--- a/src/features/post-editor/ui/category-tree-select.tsx
+++ b/src/features/post-editor/ui/category-tree-select.tsx
@@ -55,7 +55,7 @@ export function CategoryTreeSelect({
       disabled={disabled}
       ariaLabel="카테고리"
       className="w-full"
-      triggerClassName="h-10 rounded-[0.75rem] text-[13px] text-text-2"
+      triggerClassName="h-10 rounded-xl text-[13px] text-text-2"
       options={[
         {
           label: disabled ? "카테고리 불러오는 중..." : "카테고리 선택",

--- a/src/features/post-editor/ui/image-gallery-modal.tsx
+++ b/src/features/post-editor/ui/image-gallery-modal.tsx
@@ -39,7 +39,7 @@ export function ImageGalleryModal({
       withBackground
       aria-label="이미지 삽입"
     >
-      <div className="flex h-[min(88vh,52rem)] w-[min(92vw,64rem)] flex-col overflow-hidden rounded-[1.5rem] bg-background-1 text-left">
+      <div className="flex h-[min(88vh,52rem)] w-[min(92vw,64rem)] flex-col overflow-hidden rounded-3xl bg-background-1 text-left">
         <div className="border-b border-border-3 px-6 py-5">
           <p className="text-xs uppercase tracking-[0.24em] text-text-4">
             Images
@@ -84,7 +84,7 @@ export function ImageGalleryModal({
           ) : null}
 
           {assetsQuery.isError ? (
-            <div className="rounded-[1rem] border border-negative-1/20 bg-negative-1/5 px-4 py-3 text-sm text-negative-1">
+            <div className="rounded-2xl border border-negative-1/20 bg-negative-1/5 px-4 py-3 text-sm text-negative-1">
               {getErrorMessage(
                 assetsQuery.error,
                 "에셋 목록을 불러오지 못했습니다.",
@@ -95,7 +95,7 @@ export function ImageGalleryModal({
           {!assetsQuery.isPending &&
           !assetsQuery.isError &&
           (assetsQuery.data?.data.length ?? 0) === 0 ? (
-            <div className="rounded-[1rem] border border-border-3 bg-background-2 px-4 py-6 text-sm text-text-3">
+            <div className="rounded-2xl border border-border-3 bg-background-2 px-4 py-6 text-sm text-text-3">
               표시할 에셋이 없습니다. 위 버튼으로 이미지를 선택해 주세요.
             </div>
           ) : null}
@@ -111,7 +111,7 @@ export function ImageGalleryModal({
                   onClick={() => onSelectAsset(asset)}
                   className="overflow-hidden rounded-[1.25rem] border border-border-3 bg-background-2 text-left transition-colors hover:border-primary-1"
                 >
-                  <div className="aspect-[4/3] bg-background-3">
+                  <div className="aspect-4/3 bg-background-3">
                     {/* eslint-disable-next-line @next/next/no-img-element -- arbitrary admin asset hosts are allowed */}
                     <img
                       src={asset.url}

--- a/src/features/post-editor/ui/post-card-preview.tsx
+++ b/src/features/post-editor/ui/post-card-preview.tsx
@@ -42,17 +42,17 @@ export function PostCardPreview({
   return (
     <>
       {compact ? (
-        <div className="overflow-hidden rounded-[1rem] border border-border-3 bg-background-1">
+        <div className="overflow-hidden rounded-2xl border border-border-3 bg-background-1">
           <div className="overflow-hidden bg-background-3">
             {displayThumbnailUrl ? (
               // eslint-disable-next-line @next/next/no-img-element -- arbitrary admin preview URLs are allowed
               <img
                 src={displayThumbnailUrl}
                 alt={title || "썸네일 미리보기"}
-                className="aspect-[8/5] w-full object-cover"
+                className="aspect-8/5 w-full object-cover"
               />
             ) : (
-              <div className="flex aspect-[8/5] w-full items-center justify-center text-sm text-text-4">
+              <div className="flex aspect-8/5 w-full items-center justify-center text-sm text-text-4">
                 썸네일 미리보기
               </div>
             )}
@@ -72,18 +72,18 @@ export function PostCardPreview({
           </div>
         </div>
       ) : (
-        <div className="rounded-[1rem] border border-border-3 bg-background-1 p-4">
+        <div className="rounded-2xl border border-border-3 bg-background-1 p-4">
           <div className="flex gap-4">
-            <div className="w-[11rem] shrink-0 overflow-hidden rounded-[0.9rem] bg-background-3">
+            <div className="w-44 shrink-0 overflow-hidden rounded-[0.9rem] bg-background-3">
               {displayThumbnailUrl ? (
                 // eslint-disable-next-line @next/next/no-img-element -- arbitrary admin preview URLs are allowed
                 <img
                   src={displayThumbnailUrl}
                   alt={title || "썸네일 미리보기"}
-                  className="aspect-[4/3] w-full object-cover"
+                  className="aspect-4/3 w-full object-cover"
                 />
               ) : (
-                <div className="flex aspect-[4/3] w-full items-center justify-center text-sm text-text-4">
+                <div className="flex aspect-4/3 w-full items-center justify-center text-sm text-text-4">
                   썸네일
                 </div>
               )}

--- a/src/features/post-editor/ui/post-form.tsx
+++ b/src/features/post-editor/ui/post-form.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import type {
-  FormEvent,
-  KeyboardEvent as ReactKeyboardEvent,
-  ReactNode,
-} from "react";
+import type { FormEvent, ReactNode } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@iconify/react/offline";
 import archiveLinear from "@iconify-icons/solar/archive-linear";
@@ -60,7 +56,11 @@ import {
 import { normalizeAssetUrl, toCanonicalAssetUrl } from "@shared/lib/asset-url";
 import { getErrorMessage } from "@shared/lib/get-error-message";
 import { cn } from "@shared/lib/style-utils";
-import { Spinner } from "@shared/ui/libs";
+import {
+  CustomSelect,
+  Spinner,
+  type CustomSelectOption,
+} from "@shared/ui/libs";
 
 type EditorTab = "all" | "info" | "editor-split" | "editor-only";
 type SubmitIntent =
@@ -77,12 +77,6 @@ interface PostFormProps {
   cancelLabel?: string;
   onCancel?: () => void;
   onSuccess?: (post: PostDetail) => void;
-}
-
-interface InlineSelectOption<T extends string | number> {
-  label: string;
-  triggerLabel?: string;
-  value: T;
 }
 
 const DEFAULT_VALUES: PostFormValues = {
@@ -183,7 +177,7 @@ function sortCategories(categories: Category[]): Category[] {
 function flattenCategoryOptions(
   categories: Category[],
   depth = 0,
-): Array<{ label: string; triggerLabel?: string; value: number }> {
+): Array<CustomSelectOption<number>> {
   return categories.flatMap((category) => {
     const prefix = depth === 0 ? "" : `\u3000`.repeat(depth);
 
@@ -286,211 +280,6 @@ function SearchIndexableToggle({
         )}
       />
     </button>
-  );
-}
-
-function InlineCustomSelect<T extends string | number>({
-  value,
-  options,
-  onChange,
-  placeholder,
-  disabled,
-  className,
-}: {
-  value: T | null;
-  options: Array<InlineSelectOption<T>>;
-  onChange: (value: T) => void;
-  placeholder?: string;
-  disabled?: boolean;
-  className?: string;
-}) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [activeIndex, setActiveIndex] = useState(-1);
-  const rootRef = useRef<HTMLDivElement | null>(null);
-  const listboxIdRef = useRef(
-    `inline-select-${Math.random().toString(36).slice(2)}`,
-  );
-  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
-  const selected = options.find((option) => option.value === value);
-  const selectedIndex = options.findIndex((option) => option.value === value);
-
-  useEffect(() => {
-    optionRefs.current = [];
-  }, [options]);
-
-  useEffect(() => {
-    if (!isOpen) {
-      setActiveIndex(-1);
-
-      return;
-    }
-
-    setActiveIndex(selectedIndex >= 0 ? selectedIndex : 0);
-  }, [isOpen, selectedIndex]);
-
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    const handlePointerDown = (event: MouseEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-
-    document.addEventListener("mousedown", handlePointerDown);
-
-    return () => {
-      document.removeEventListener("mousedown", handlePointerDown);
-    };
-  }, [isOpen]);
-
-  useEffect(() => {
-    if (!isOpen || activeIndex < 0) {
-      return;
-    }
-
-    optionRefs.current[activeIndex]?.focus();
-  }, [activeIndex, isOpen]);
-
-  const commitSelection = (index: number) => {
-    const option = options[index];
-
-    if (!option) {
-      return;
-    }
-
-    onChange(option.value);
-    setIsOpen(false);
-  };
-
-  const handleTriggerKeyDown = (
-    event: ReactKeyboardEvent<HTMLButtonElement>,
-  ) => {
-    if (disabled) {
-      return;
-    }
-
-    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
-      event.preventDefault();
-      setIsOpen(true);
-      setActiveIndex(selectedIndex >= 0 ? selectedIndex : 0);
-
-      return;
-    }
-
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      setIsOpen((current) => !current);
-    }
-  };
-
-  const handleOptionKeyDown = (
-    event: ReactKeyboardEvent<HTMLButtonElement>,
-    index: number,
-  ) => {
-    if (event.key === "ArrowDown") {
-      event.preventDefault();
-      setActiveIndex((index + 1) % options.length);
-
-      return;
-    }
-
-    if (event.key === "ArrowUp") {
-      event.preventDefault();
-      setActiveIndex((index - 1 + options.length) % options.length);
-
-      return;
-    }
-
-    if (event.key === "Home") {
-      event.preventDefault();
-      setActiveIndex(0);
-
-      return;
-    }
-
-    if (event.key === "End") {
-      event.preventDefault();
-      setActiveIndex(options.length - 1);
-
-      return;
-    }
-
-    if (event.key === "Escape") {
-      event.preventDefault();
-      setIsOpen(false);
-
-      return;
-    }
-
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      commitSelection(index);
-    }
-  };
-
-  return (
-    <div ref={rootRef} className={cn("relative w-full", className)}>
-      <button
-        type="button"
-        disabled={disabled}
-        onClick={() => setIsOpen((current) => !current)}
-        onKeyDown={handleTriggerKeyDown}
-        role="combobox"
-        aria-autocomplete="none"
-        aria-expanded={isOpen}
-        aria-controls={listboxIdRef.current}
-        aria-haspopup="listbox"
-        className="flex h-10 w-full items-center rounded-[0.5rem] border border-border-3 bg-background-1 px-3 pr-8 text-left text-[13px] text-text-2 outline-none transition-colors focus-visible:border-primary-1 disabled:cursor-not-allowed disabled:opacity-60"
-      >
-        <span className="truncate">
-          {selected?.triggerLabel ?? selected?.label ?? placeholder ?? ""}
-        </span>
-        <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[11px] text-text-4">
-          ▾
-        </span>
-      </button>
-
-      {isOpen ? (
-        <div
-          id={listboxIdRef.current}
-          role="listbox"
-          aria-activedescendant={
-            activeIndex >= 0
-              ? `${listboxIdRef.current}-option-${activeIndex}`
-              : undefined
-          }
-          className="absolute left-0 top-[calc(100%+0.25rem)] z-30 min-w-full overflow-hidden rounded-[0.5rem] border border-border-3 bg-background-1 shadow-[0px_8px_24px_rgba(15,23,42,0.08)]"
-        >
-          {options.map((option, index) => (
-            <button
-              key={String(option.value)}
-              id={`${listboxIdRef.current}-option-${index}`}
-              ref={(element) => {
-                optionRefs.current[index] = element;
-              }}
-              type="button"
-              role="option"
-              aria-selected={option.value === value}
-              tabIndex={activeIndex === index ? 0 : -1}
-              onKeyDown={(event) => handleOptionKeyDown(event, index)}
-              onFocus={() => setActiveIndex(index)}
-              onClick={() => commitSelection(index)}
-              className={cn(
-                "flex w-full items-center px-3 py-2 text-left text-[13px] transition-colors hover:bg-background-2",
-                option.value === value
-                  ? "font-medium text-primary-1"
-                  : "text-text-2",
-              )}
-            >
-              <span className="truncate">{option.label}</span>
-            </button>
-          ))}
-        </div>
-      ) : null}
-    </div>
   );
 }
 
@@ -1040,15 +829,19 @@ export function PostForm({
               <div className="flex flex-wrap items-center gap-4">
                 <CompactMetaLabel label="카테고리">
                   <div className="min-w-[10rem]">
-                    <InlineCustomSelect
+                    <CustomSelect
                       value={values.categoryId}
                       options={categoryOptions}
                       disabled={categoriesQuery.isPending}
+                      ariaLabel="카테고리"
                       placeholder={
                         categoriesQuery.isPending
                           ? "카테고리 불러오는 중..."
                           : "카테고리 선택"
                       }
+                      className="w-full"
+                      triggerClassName="rounded-[0.5rem] text-[13px] text-text-2 focus-visible:border-primary-1"
+                      optionClassName="text-[13px] text-text-2"
                       onChange={(value) =>
                         handleFieldChange("categoryId", value)
                       }
@@ -1161,9 +954,13 @@ export function PostForm({
 
                 <CompactMetaLabel label="댓글 상태">
                   <div className="min-w-[7rem]">
-                    <InlineCustomSelect
+                    <CustomSelect
                       value={values.commentStatus}
                       options={commentStatusOptions}
+                      ariaLabel="댓글 상태"
+                      className="w-full"
+                      triggerClassName="rounded-[0.5rem] text-[13px] text-text-2 focus-visible:border-primary-1"
+                      optionClassName="text-[13px] text-text-2"
                       onChange={(value) =>
                         handleFieldChange(
                           "commentStatus",
@@ -1182,15 +979,19 @@ export function PostForm({
               <div className="grid gap-6 lg:grid-cols-[minmax(0,1.15fr)_20rem]">
                 <div className="space-y-5">
                   <MetaFormRow label="카테고리">
-                    <InlineCustomSelect
+                    <CustomSelect
                       value={values.categoryId}
                       options={categoryOptions}
                       disabled={categoriesQuery.isPending}
+                      ariaLabel="카테고리"
                       placeholder={
                         categoriesQuery.isPending
                           ? "카테고리 불러오는 중..."
                           : "카테고리 선택"
                       }
+                      className="w-full"
+                      triggerClassName="rounded-[0.5rem] text-[13px] text-text-2 focus-visible:border-primary-1"
+                      optionClassName="text-[13px] text-text-2"
                       onChange={(value) =>
                         handleFieldChange("categoryId", value)
                       }
@@ -1255,9 +1056,13 @@ export function PostForm({
                     }: ${getCommentStatusDescription(values.commentStatus)}`}
                   >
                     <div className="max-w-[14rem]">
-                      <InlineCustomSelect
+                      <CustomSelect
                         value={values.commentStatus}
                         options={commentStatusOptions}
+                        ariaLabel="댓글 상태"
+                        className="w-full"
+                        triggerClassName="rounded-[0.5rem] text-[13px] text-text-2 focus-visible:border-primary-1"
+                        optionClassName="text-[13px] text-text-2"
                         onChange={(value) =>
                           handleFieldChange(
                             "commentStatus",

--- a/src/features/post-editor/ui/post-form.tsx
+++ b/src/features/post-editor/ui/post-form.tsx
@@ -108,11 +108,11 @@ const TABS: Array<{ id: EditorTab; label: string }> = [
 const REMOVED_PENDING_IMAGE_TTL_MS = 30_000;
 const EDITOR_INLINE_PREVIEW_MEDIA_QUERY = "(min-width: 67.5rem)";
 const PAGE_TAB_CLASS =
-  "inline-flex h-8 items-center justify-center rounded-[0.375rem] px-[0.875rem] border-none bg-transparent text-[13px] font-medium leading-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-1/20";
+  "inline-flex h-8 items-center justify-center rounded-md px-3.5 border-none bg-transparent text-[13px] font-medium leading-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-1/20";
 const SECONDARY_BUTTON_CLASS =
-  "inline-flex h-9 shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-[0.5rem] border border-border-3 bg-transparent px-4 text-sm font-medium text-text-2 transition-[background-color,transform] hover:bg-background-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-1/20 disabled:opacity-60";
+  "inline-flex h-9 shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-lg border border-border-3 bg-transparent px-4 text-sm font-medium text-text-2 transition-[background-color,transform] hover:bg-background-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-1/20 disabled:opacity-60";
 const PRIMARY_BUTTON_CLASS =
-  "inline-flex h-9 shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-[0.5rem] bg-primary-1 px-4 text-sm font-medium text-white transition-[opacity,transform] hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-1/20 disabled:opacity-60";
+  "inline-flex h-9 shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-lg bg-primary-1 px-4 text-sm font-medium text-white transition-[opacity,transform] hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-1/20 disabled:opacity-60";
 
 function createInitialValues(
   initialValues?: Partial<PostFormValues>,
@@ -793,13 +793,13 @@ export function PostForm({
         ) : null}
 
         {submitError ? (
-          <div className="mx-5 mt-5 rounded-[1rem] border border-negative-1/20 bg-negative-1/5 px-4 py-3 text-sm text-negative-1 md:mx-6">
+          <div className="mx-5 mt-5 rounded-2xl border border-negative-1/20 bg-negative-1/5 px-4 py-3 text-sm text-negative-1 md:mx-6">
             {submitError}
           </div>
         ) : null}
 
         {categoriesQuery.isError ? (
-          <div className="mx-5 mt-5 rounded-[1rem] border border-negative-1/20 bg-negative-1/5 px-4 py-3 text-sm text-negative-1 md:mx-6">
+          <div className="mx-5 mt-5 rounded-2xl border border-negative-1/20 bg-negative-1/5 px-4 py-3 text-sm text-negative-1 md:mx-6">
             {getErrorMessage(
               categoriesQuery.error,
               "카테고리 목록을 불러오지 못했습니다.",
@@ -808,7 +808,7 @@ export function PostForm({
         ) : null}
 
         {!categoriesQuery.isPending && categories.length === 0 ? (
-          <div className="mx-5 mt-5 rounded-[1rem] border border-warning-1/20 bg-warning-2 px-4 py-3 text-sm text-warning-1 md:mx-6">
+          <div className="mx-5 mt-5 rounded-2xl border border-warning-1/20 bg-warning-2 px-4 py-3 text-sm text-warning-1 md:mx-6">
             카테고리를 먼저 생성하세요.
           </div>
         ) : null}
@@ -825,7 +825,7 @@ export function PostForm({
             <section className="border-b border-border-4 px-6 py-3">
               <div className="flex flex-wrap items-center gap-4">
                 <CompactMetaLabel label="카테고리">
-                  <div className="min-w-[10rem]">
+                  <div className="min-w-40">
                     <DropSelect
                       value={values.categoryId}
                       options={categoryOptions}
@@ -837,7 +837,7 @@ export function PostForm({
                           : "카테고리 선택"
                       }
                       className="w-full"
-                      triggerClassName="rounded-[0.5rem] text-[13px] text-text-2 focus-visible:border-primary-1"
+                      triggerClassName="rounded-lg text-[13px] text-text-2 focus-visible:border-primary-1"
                       optionClassName="text-[13px] text-text-2"
                       onChange={(value) =>
                         handleFieldChange("categoryId", value)
@@ -847,7 +847,7 @@ export function PostForm({
                 </CompactMetaLabel>
 
                 <CompactMetaLabel label="태그">
-                  <div className="min-w-[16rem] flex-1">
+                  <div className="min-w-64 flex-1">
                     <TagChipInput
                       value={values.tags}
                       showHelperText={false}
@@ -950,13 +950,13 @@ export function PostForm({
                 </CompactMetaLabel>
 
                 <CompactMetaLabel label="댓글 상태">
-                  <div className="min-w-[7rem]">
+                  <div className="min-w-28">
                     <DropSelect
                       value={values.commentStatus}
                       options={commentStatusOptions}
                       ariaLabel="댓글 상태"
                       className="w-full"
-                      triggerClassName="rounded-[0.5rem] text-[13px] text-text-2 focus-visible:border-primary-1"
+                      triggerClassName="rounded-lg text-[13px] text-text-2 focus-visible:border-primary-1"
                       optionClassName="text-[13px] text-text-2"
                       onChange={(value) =>
                         handleFieldChange(
@@ -987,7 +987,7 @@ export function PostForm({
                           : "카테고리 선택"
                       }
                       className="w-full"
-                      triggerClassName="rounded-[0.5rem] text-[13px] text-text-2 focus-visible:border-primary-1"
+                      triggerClassName="rounded-lg text-[13px] text-text-2 focus-visible:border-primary-1"
                       optionClassName="text-[13px] text-text-2"
                       onChange={(value) =>
                         handleFieldChange("categoryId", value)
@@ -1058,7 +1058,7 @@ export function PostForm({
                         options={commentStatusOptions}
                         ariaLabel="댓글 상태"
                         className="w-full"
-                        triggerClassName="rounded-[0.5rem] text-[13px] text-text-2 focus-visible:border-primary-1"
+                        triggerClassName="rounded-lg text-[13px] text-text-2 focus-visible:border-primary-1"
                         optionClassName="text-[13px] text-text-2"
                         onChange={(value) =>
                           handleFieldChange(
@@ -1091,7 +1091,7 @@ export function PostForm({
                       }
                       placeholder="글 목록에 표시될 요약문을 입력하세요"
                       aria-label="Summary"
-                      className="w-full rounded-[0.75rem] border border-border-3 bg-background-1 px-3 py-2.5 text-[13px] text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1"
+                      className="w-full rounded-xl border border-border-3 bg-background-1 px-3 py-2.5 text-[13px] text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1"
                     />
                     <div className="mt-1.5 text-right text-[11px] text-text-4">
                       {values.summary.length} / 200자
@@ -1110,7 +1110,7 @@ export function PostForm({
                       }
                       placeholder="검색엔진에 표시될 설명을 입력하세요"
                       aria-label="Description"
-                      className="w-full rounded-[0.75rem] border border-border-3 bg-background-1 px-3 py-2.5 text-[13px] text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1"
+                      className="w-full rounded-xl border border-border-3 bg-background-1 px-3 py-2.5 text-[13px] text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1"
                     />
                     <div className="mt-1.5 text-right text-[11px] text-text-4">
                       {values.description.length} / 300자

--- a/src/features/post-editor/ui/post-form.tsx
+++ b/src/features/post-editor/ui/post-form.tsx
@@ -106,6 +106,7 @@ const TABS: Array<{ id: EditorTab; label: string }> = [
 ];
 
 const REMOVED_PENDING_IMAGE_TTL_MS = 30_000;
+const EDITOR_INLINE_PREVIEW_MEDIA_QUERY = "(min-width: 67.5rem)";
 const PAGE_TAB_CLASS =
   "inline-flex h-8 items-center justify-center rounded-[0.375rem] px-[0.875rem] border-none bg-transparent text-[13px] font-medium leading-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-1/20";
 const SECONDARY_BUTTON_CLASS =
@@ -394,7 +395,7 @@ export function PostForm({
       return;
     }
 
-    const mediaQuery = window.matchMedia("(min-width: 1024px)");
+    const mediaQuery = window.matchMedia(EDITOR_INLINE_PREVIEW_MEDIA_QUERY);
     const updateViewport = () => {
       setIsDesktopPreview(mediaQuery.matches);
     };

--- a/src/features/post-editor/ui/post-form.tsx
+++ b/src/features/post-editor/ui/post-form.tsx
@@ -56,11 +56,7 @@ import {
 import { normalizeAssetUrl, toCanonicalAssetUrl } from "@shared/lib/asset-url";
 import { getErrorMessage } from "@shared/lib/get-error-message";
 import { cn } from "@shared/lib/style-utils";
-import {
-  CustomSelect,
-  Spinner,
-  type CustomSelectOption,
-} from "@shared/ui/libs";
+import { DropSelect, Spinner, type DropSelectOption } from "@shared/ui/libs";
 
 type EditorTab = "all" | "info" | "editor-split" | "editor-only";
 type SubmitIntent =
@@ -177,7 +173,7 @@ function sortCategories(categories: Category[]): Category[] {
 function flattenCategoryOptions(
   categories: Category[],
   depth = 0,
-): Array<CustomSelectOption<number>> {
+): Array<DropSelectOption<number>> {
   return categories.flatMap((category) => {
     const prefix = depth === 0 ? "" : `\u3000`.repeat(depth);
 
@@ -829,7 +825,7 @@ export function PostForm({
               <div className="flex flex-wrap items-center gap-4">
                 <CompactMetaLabel label="카테고리">
                   <div className="min-w-[10rem]">
-                    <CustomSelect
+                    <DropSelect
                       value={values.categoryId}
                       options={categoryOptions}
                       disabled={categoriesQuery.isPending}
@@ -954,7 +950,7 @@ export function PostForm({
 
                 <CompactMetaLabel label="댓글 상태">
                   <div className="min-w-[7rem]">
-                    <CustomSelect
+                    <DropSelect
                       value={values.commentStatus}
                       options={commentStatusOptions}
                       ariaLabel="댓글 상태"
@@ -979,7 +975,7 @@ export function PostForm({
               <div className="grid gap-6 lg:grid-cols-[minmax(0,1.15fr)_20rem]">
                 <div className="space-y-5">
                   <MetaFormRow label="카테고리">
-                    <CustomSelect
+                    <DropSelect
                       value={values.categoryId}
                       options={categoryOptions}
                       disabled={categoriesQuery.isPending}
@@ -1056,7 +1052,7 @@ export function PostForm({
                     }: ${getCommentStatusDescription(values.commentStatus)}`}
                   >
                     <div className="max-w-[14rem]">
-                      <CustomSelect
+                      <DropSelect
                         value={values.commentStatus}
                         options={commentStatusOptions}
                         ariaLabel="댓글 상태"

--- a/src/features/post-editor/ui/preview-modal.tsx
+++ b/src/features/post-editor/ui/preview-modal.tsx
@@ -23,7 +23,7 @@ export function PreviewModal({
       withBackground
       aria-label="마크다운 미리보기"
     >
-      <div className="flex h-[min(88vh,60rem)] w-[min(94vw,76rem)] flex-col overflow-hidden rounded-[1.5rem] border border-border-3 bg-background-1 text-left shadow-[0px_28px_90px_0px_rgba(15,23,42,0.18)]">
+      <div className="flex h-[min(88vh,60rem)] w-[min(94vw,76rem)] flex-col overflow-hidden rounded-3xl border border-border-3 bg-background-1 text-left shadow-[0px_28px_90px_0px_rgba(15,23,42,0.18)]">
         <div className="flex items-center justify-between border-b border-border-3 bg-background-2 px-6 py-4">
           <div className="min-w-0">
             <p className="text-xs font-medium text-text-4">실제 글 미리보기</p>

--- a/src/features/post-editor/ui/publish-confirm-modal.tsx
+++ b/src/features/post-editor/ui/publish-confirm-modal.tsx
@@ -22,7 +22,7 @@ export function PublishConfirmModal({
       withBackground
       aria-label="게시글 발행 확인"
     >
-      <div className="w-full max-w-xl rounded-[1.5rem] bg-background-1 p-6">
+      <div className="w-full max-w-xl rounded-3xl bg-background-1 p-6">
         <div className="space-y-2">
           <p className="text-xs uppercase tracking-[0.24em] text-text-4">
             Publish

--- a/src/features/post-editor/ui/tag-chip-input.tsx
+++ b/src/features/post-editor/ui/tag-chip-input.tsx
@@ -148,7 +148,7 @@ export function TagChipInput({
   return (
     <div className="space-y-1.5" ref={containerRef}>
       <div
-        className="relative rounded-[0.75rem] border border-border-3 bg-background-1 px-[10px] py-[6px] transition-colors focus-within:border-primary-1"
+        className="relative rounded-xl border border-border-3 bg-background-1 px-2.5 py-1.5 transition-colors focus-within:border-primary-1"
         onClick={() => inputRef.current?.focus()}
       >
         <div className="flex flex-wrap items-center gap-1.5">
@@ -156,7 +156,7 @@ export function TagChipInput({
             return (
               <span
                 key={tag}
-                className="inline-flex items-center gap-1 leading-none rounded-full bg-primary-1/10 px-2 py-[2px] text-[12px] text-primary-1"
+                className="inline-flex items-center gap-1 leading-none rounded-full bg-primary-1/10 px-2 py-0.5 text-xs text-primary-1"
               >
                 {tag}
                 <button
@@ -196,7 +196,7 @@ export function TagChipInput({
             aria-label="태그"
             aria-expanded={suggestions.length > 0}
             aria-controls={suggestions.length > 0 ? listboxId : undefined}
-            className="min-w-[80px] h-[26px] flex-1 bg-transparent px-0 py-0 text-[12px] leading-none text-text-2 outline-none placeholder:text-text-4"
+            className="min-w-20 h-[26px] flex-1 bg-transparent px-0 py-0 text-xs leading-none text-text-2 outline-none placeholder:text-text-4"
           />
         </div>
 

--- a/src/features/post-editor/ui/thumbnail-uploader.tsx
+++ b/src/features/post-editor/ui/thumbnail-uploader.tsx
@@ -166,7 +166,7 @@ export function ThumbnailUploader({ value, onChange }: ThumbnailUploaderProps) {
             setIsPickerOpen(true);
           }}
           disabled={isUploading}
-          className="inline-flex h-9 shrink-0 items-center gap-1.5 whitespace-nowrap leading-none rounded-[0.75rem] border border-border-3 px-3 text-[11px] font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-60"
+          className="inline-flex h-9 shrink-0 items-center gap-1.5 whitespace-nowrap leading-none rounded-xl border border-border-3 px-3 text-[11px] font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-60"
         >
           <Icon icon={galleryWideLinear} width="14" aria-hidden="true" />
           에셋 갤러리
@@ -174,7 +174,7 @@ export function ThumbnailUploader({ value, onChange }: ThumbnailUploaderProps) {
         <button
           type="button"
           onClick={() => setShowUrlInput((current) => !current)}
-          className="inline-flex h-9 shrink-0 items-center gap-1.5 whitespace-nowrap leading-none rounded-[0.75rem] border border-border-3 px-3 text-[11px] font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
+          className="inline-flex h-9 shrink-0 items-center gap-1.5 whitespace-nowrap leading-none rounded-xl border border-border-3 px-3 text-[11px] font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
         >
           <Icon icon={linkMinimalistic2Linear} width="14" aria-hidden="true" />
           URL
@@ -183,7 +183,7 @@ export function ThumbnailUploader({ value, onChange }: ThumbnailUploaderProps) {
           type="button"
           onClick={() => setIsAwaitingPaste((current) => !current)}
           className={cn(
-            "inline-flex h-9 items-center gap-1.5 whitespace-nowrap leading-none rounded-[0.75rem] border px-3 text-[11px] font-medium transition-colors",
+            "inline-flex h-9 items-center gap-1.5 whitespace-nowrap leading-none rounded-xl border px-3 text-[11px] font-medium transition-colors",
             isAwaitingPaste
               ? "border-primary-1 bg-primary-1/10 text-primary-1"
               : "border-border-3 text-text-2 hover:border-border-2 hover:text-text-1",
@@ -198,7 +198,7 @@ export function ThumbnailUploader({ value, onChange }: ThumbnailUploaderProps) {
             onChange("");
             setPendingFile(null);
           }}
-          className="inline-flex h-9 shrink-0 items-center whitespace-nowrap leading-none rounded-[0.75rem] border border-negative-1/20 px-3 text-[11px] font-medium text-negative-1 transition-colors hover:bg-negative-1/10"
+          className="inline-flex h-9 shrink-0 items-center whitespace-nowrap leading-none rounded-xl border border-negative-1/20 px-3 text-[11px] font-medium text-negative-1 transition-colors hover:bg-negative-1/10"
         >
           삭제
         </button>
@@ -217,7 +217,7 @@ export function ThumbnailUploader({ value, onChange }: ThumbnailUploaderProps) {
             }}
             placeholder="https://example.com/thumbnail.jpg"
             aria-label="썸네일 URL"
-            className="h-10 flex-1 rounded-[0.75rem] border border-border-3 bg-background-1 px-3 text-[13px] text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1"
+            className="h-10 flex-1 rounded-xl border border-border-3 bg-background-1 px-3 text-[13px] text-text-2 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1"
           />
           <p className="text-[11px] text-text-4">
             URL 입력은 실시간으로 반영됩니다.
@@ -227,7 +227,7 @@ export function ThumbnailUploader({ value, onChange }: ThumbnailUploaderProps) {
 
       <div
         className={cn(
-          "flex min-h-[13rem] flex-col items-center justify-center rounded-[1rem] border border-dashed bg-background-1 p-4 text-center transition-colors",
+          "flex min-h-52 flex-col items-center justify-center rounded-2xl border border-dashed bg-background-1 p-4 text-center transition-colors",
           isDragging ? "border-primary-1 bg-primary-1/5" : "border-border-3",
         )}
         onDragOver={(event) => {
@@ -266,7 +266,7 @@ export function ThumbnailUploader({ value, onChange }: ThumbnailUploaderProps) {
           <button
             type="button"
             onClick={() => inputRef.current?.click()}
-            className="h-9 rounded-[0.75rem] border border-border-3 px-3 text-[11px] font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
+            className="h-9 rounded-xl border border-border-3 px-3 text-[11px] font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
           >
             파일 선택
           </button>
@@ -275,7 +275,7 @@ export function ThumbnailUploader({ value, onChange }: ThumbnailUploaderProps) {
               type="button"
               onClick={() => void uploadFile(pendingFile)}
               disabled={isUploading}
-              className="inline-flex h-9 items-center gap-2 rounded-[0.75rem] bg-primary-1 px-3 text-[11px] font-semibold text-white transition-opacity disabled:opacity-60"
+              className="inline-flex h-9 items-center gap-2 rounded-xl bg-primary-1 px-3 text-[11px] font-semibold text-white transition-opacity disabled:opacity-60"
             >
               {isUploading ? <Spinner size="sm" /> : null}
               업로드

--- a/src/features/post-list/index.ts
+++ b/src/features/post-list/index.ts
@@ -1,3 +1,4 @@
 export { PostCard } from "./ui/post-card";
 export { PostList } from "./ui/post-list";
 export { PostListItem } from "./ui/post-list-item";
+export { PostListSkeleton } from "./ui/post-list-skeleton";

--- a/src/features/post-list/ui/post-card.tsx
+++ b/src/features/post-list/ui/post-card.tsx
@@ -25,7 +25,7 @@ export function PostCard({ post, className }: PostCardProps) {
     <Link
       href={buildPostHref(post.slug)}
       className={cn(
-        "group flex overflow-hidden rounded-[1.5rem] border border-border-3 bg-background-1 transition-colors hover:border-border-2",
+        "group flex overflow-hidden rounded-3xl border border-border-3 bg-background-1 transition-colors hover:border-border-2",
         className,
       )}
     >

--- a/src/features/post-list/ui/post-list-skeleton.tsx
+++ b/src/features/post-list/ui/post-list-skeleton.tsx
@@ -1,0 +1,13 @@
+import { PostListItemSkeleton } from "./post-list-item-skeleton";
+
+const SKELETON_COUNT = 10;
+
+export function PostListSkeleton() {
+  return (
+    <div className="grid gap-3" aria-busy="true">
+      {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
+        <PostListItemSkeleton key={i} />
+      ))}
+    </div>
+  );
+}

--- a/src/features/post-list/ui/post-list.tsx
+++ b/src/features/post-list/ui/post-list.tsx
@@ -36,7 +36,7 @@ function PostListSkeleton() {
 function PostListEmptyState() {
   return (
     <section
-      className="motion-reveal rounded-[2rem] border-2 border-dashed border-border-3 bg-background-2 px-8 py-16 text-center"
+      className="motion-reveal rounded-4xl border-2 border-dashed border-border-3 bg-background-2 px-8 py-16 text-center"
       style={{ animationDelay: "160ms" }}
     >
       <div className="mb-4 flex justify-center">
@@ -55,7 +55,7 @@ function PostListEmptyState() {
 function PostListErrorState() {
   return (
     <section
-      className="motion-reveal rounded-[2rem] border-2 border-dashed border-border-3 bg-background-2 px-8 py-16 text-center"
+      className="motion-reveal rounded-4xl border-2 border-dashed border-border-3 bg-background-2 px-8 py-16 text-center"
       style={{ animationDelay: "160ms" }}
     >
       <div className="mb-4 flex justify-center">

--- a/src/features/post-list/ui/post-list.tsx
+++ b/src/features/post-list/ui/post-list.tsx
@@ -6,7 +6,7 @@ import documentTextLinear from "@iconify-icons/solar/document-text-linear";
 import { useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";
 import { PostListItem } from "./post-list-item";
-import { PostListItemSkeleton } from "./post-list-item-skeleton";
+import { PostListSkeleton } from "./post-list-skeleton";
 import type { PaginatedResponse } from "@shared/api";
 import {
   fetchPosts,
@@ -19,18 +19,6 @@ interface PostListProps {
   initialData: PaginatedResponse<PostListEntry>;
   initialPage: number;
   basePath?: string;
-}
-
-const SKELETON_COUNT = 10;
-
-function PostListSkeleton() {
-  return (
-    <div className="grid gap-3">
-      {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
-        <PostListItemSkeleton key={i} />
-      ))}
-    </div>
-  );
 }
 
 function PostListEmptyState() {

--- a/src/features/recent-popular-posts/ui/recent-popular-posts.tsx
+++ b/src/features/recent-popular-posts/ui/recent-popular-posts.tsx
@@ -88,7 +88,7 @@ export function RecentPopularPosts({
                     setSelectedPopularDays(option.days);
                   }}
                   className={cn(
-                    "inline-flex min-h-5 rounded-full border px-2 py-[2px] text-[0.688rem] leading-3.5 font-normal transition-colors",
+                    "inline-flex min-h-5 rounded-full border px-2 py-0.5 text-[0.688rem] leading-3.5 font-normal transition-colors",
                     isActive
                       ? "border-primary-1 bg-primary-1/6 text-primary-1"
                       : "border-border-3 text-text-3 hover:border-primary-1 hover:bg-primary-1/6 hover:text-primary-1",
@@ -114,7 +114,7 @@ export function RecentPopularPosts({
                 <Link
                   href={buildPostHref(post.slug)}
                   onClick={onItemClick}
-                  className="group block min-h-[3rem] rounded-md px-0.5 py-1 transition-colors hover:text-primary-1"
+                  className="group block min-h-12 rounded-md px-0.5 py-1 transition-colors hover:text-primary-1"
                 >
                   <span className="line-clamp-2 block text-ui-sm font-medium leading-[1.4] text-text-2 transition-colors group-hover:text-primary-1">
                     {post.title}

--- a/src/features/search/lib/highlight.tsx
+++ b/src/features/search/lib/highlight.tsx
@@ -11,7 +11,7 @@ export function highlightText(text: string, query: string): React.ReactNode {
     i % 2 !== 0 ? (
       <mark
         key={i}
-        className="inline-block rounded-[0.1875rem] bg-primary-1/20 px-[0.125rem] py-[0.0625rem] leading-[1.1] text-text-1"
+        className="inline-block rounded-[0.1875rem] bg-primary-1/20 px-0.5 py-[0.0625rem] leading-[1.1] text-text-1"
       >
         {part}
       </mark>

--- a/src/features/search/ui/search-filter.tsx
+++ b/src/features/search/ui/search-filter.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter, useSearchParams } from "next/navigation";
 import type { SearchFilter } from "@entities/post";
+import { DropSelect } from "@shared/ui/libs";
 
 const FILTER_OPTIONS: Array<{ value: SearchFilter; label: string }> = [
   { value: "title_content", label: "제목 + 내용" },
@@ -24,9 +25,9 @@ export function SearchFilterDropdown({
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleChange = (value: SearchFilter) => {
     const params = new URLSearchParams(searchParams.toString());
-    params.set("filter", event.target.value);
+    params.set("filter", value);
     params.set("page", "1");
     if (query) {
       params.set("q", query);
@@ -35,40 +36,13 @@ export function SearchFilterDropdown({
   };
 
   return (
-    <div className="relative">
-      <select
-        value={currentFilter}
-        onChange={handleChange}
-        aria-label="검색 필터"
-        className="h-[2.625rem] appearance-none rounded-[0.625rem] border border-border-3 bg-background-2 py-0 pl-[0.875rem] pr-9 text-ui-sm text-text-1 outline-none transition-[border-color,box-shadow] focus:border-primary-1"
-      >
-        {FILTER_OPTIONS.map((opt) => (
-          <option key={opt.value} value={opt.value}>
-            {opt.label}
-          </option>
-        ))}
-      </select>
-      <ChevronDownIcon className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-text-3" />
-    </div>
-  );
-}
-
-function ChevronDownIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      width="16"
-      height="16"
-      aria-hidden="true"
-      className={className}
-    >
-      <polyline points="6 9 12 15 18 9" />
-    </svg>
+    <DropSelect
+      value={currentFilter}
+      onChange={handleChange}
+      ariaLabel="검색 필터"
+      triggerClassName="h-[2.625rem] rounded-[0.625rem] border-border-3 bg-background-2 py-0 pl-[0.875rem] pr-9 text-ui-sm text-text-1"
+      iconClassName="text-text-3"
+      options={FILTER_OPTIONS}
+    />
   );
 }

--- a/src/features/search/ui/search-filter.tsx
+++ b/src/features/search/ui/search-filter.tsx
@@ -40,7 +40,7 @@ export function SearchFilterDropdown({
       value={currentFilter}
       onChange={handleChange}
       ariaLabel="검색 필터"
-      triggerClassName="h-[2.625rem] rounded-[0.625rem] border-border-3 bg-background-2 py-0 pl-[0.875rem] pr-9 text-ui-sm text-text-1"
+      triggerClassName="h-[2.625rem] rounded-[0.625rem] border-border-3 bg-background-2 py-0 pl-3.5 pr-9 text-ui-sm text-text-1"
       iconClassName="text-text-3"
       options={FILTER_OPTIONS}
     />

--- a/src/features/search/ui/search-form.tsx
+++ b/src/features/search/ui/search-form.tsx
@@ -64,13 +64,13 @@ export function SearchForm({ currentFilter, initialQuery }: SearchFormProps) {
         onChange={setFilter}
         ariaLabel="검색 필터"
         className="w-full shrink-0 sm:w-auto"
-        triggerClassName="h-[2.625rem] rounded-[0.625rem] border-border-3 bg-background-2 py-0 pl-[0.875rem] pr-9 text-ui-sm text-text-1 sm:min-w-[7.5rem]"
+        triggerClassName="h-[2.625rem] rounded-[0.625rem] border-border-3 bg-background-2 py-0 pl-3.5 pr-9 text-ui-sm text-text-1 sm:min-w-[7.5rem]"
         iconClassName="text-text-3"
         iconWidth="12"
         options={FILTER_OPTIONS}
       />
 
-      <label className="flex h-[2.625rem] flex-1 items-center gap-2 rounded-[0.625rem] border border-border-3 bg-background-2 px-[0.875rem] transition-[border-color,box-shadow] focus-within:border-primary-1 focus-within:shadow-[0_0_0_3px_rgba(138,111,224,0.12)]">
+      <label className="flex h-[2.625rem] flex-1 items-center gap-2 rounded-[0.625rem] border border-border-3 bg-background-2 px-3.5 transition-[border-color,box-shadow] focus-within:border-primary-1 focus-within:shadow-[0_0_0_3px_rgba(138,111,224,0.12)]">
         <Icon
           icon={magniferLinear}
           width="16"
@@ -84,7 +84,7 @@ export function SearchForm({ currentFilter, initialQuery }: SearchFormProps) {
           onChange={(event) => setQuery(event.target.value)}
           placeholder="검색어를 입력해 주세요"
           aria-label="검색어 입력"
-          className="h-full w-full min-w-0 bg-transparent text-[0.875rem] leading-normal text-text-1 outline-none placeholder:text-text-4"
+          className="h-full w-full min-w-0 bg-transparent text-sm leading-normal text-text-1 outline-none placeholder:text-text-4"
         />
       </label>
 

--- a/src/features/search/ui/search-form.tsx
+++ b/src/features/search/ui/search-form.tsx
@@ -5,6 +5,7 @@ import { Icon } from "@iconify/react/offline";
 import magniferLinear from "@iconify-icons/solar/magnifer-linear";
 import { useRouter } from "next/navigation";
 import type { SearchFilter } from "@entities/post";
+import { DropSelect } from "@shared/ui/libs";
 
 const FILTER_OPTIONS: Array<{ value: SearchFilter; label: string }> = [
   { value: "title_content", label: "제목 + 내용" },
@@ -58,21 +59,16 @@ export function SearchForm({ currentFilter, initialQuery }: SearchFormProps) {
       className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center"
       onSubmit={handleSubmit}
     >
-      <div className="relative shrink-0">
-        <select
-          value={filter}
-          onChange={(event) => setFilter(event.target.value as SearchFilter)}
-          aria-label="검색 필터"
-          className="h-[2.625rem] w-full appearance-none rounded-[0.625rem] border border-border-3 bg-background-2 py-0 pl-[0.875rem] pr-9 text-ui-sm text-text-1 outline-none transition-[border-color,box-shadow] focus:border-primary-1 sm:w-auto sm:min-w-[7.5rem]"
-        >
-          {FILTER_OPTIONS.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </select>
-        <ChevronDownIcon className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-text-3" />
-      </div>
+      <DropSelect
+        value={filter}
+        onChange={setFilter}
+        ariaLabel="검색 필터"
+        className="w-full shrink-0 sm:w-auto"
+        triggerClassName="h-[2.625rem] rounded-[0.625rem] border-border-3 bg-background-2 py-0 pl-[0.875rem] pr-9 text-ui-sm text-text-1 sm:min-w-[7.5rem]"
+        iconClassName="text-text-3"
+        iconWidth="12"
+        options={FILTER_OPTIONS}
+      />
 
       <label className="flex h-[2.625rem] flex-1 items-center gap-2 rounded-[0.625rem] border border-border-3 bg-background-2 px-[0.875rem] transition-[border-color,box-shadow] focus-within:border-primary-1 focus-within:shadow-[0_0_0_3px_rgba(138,111,224,0.12)]">
         <Icon
@@ -100,25 +96,5 @@ export function SearchForm({ currentFilter, initialQuery }: SearchFormProps) {
         <Icon icon={magniferLinear} width="18" aria-hidden="true" />
       </button>
     </form>
-  );
-}
-
-function ChevronDownIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      width="12"
-      height="12"
-      aria-hidden="true"
-      className={className}
-    >
-      <polyline points="6 9 12 15 18 9" />
-    </svg>
   );
 }

--- a/src/features/toc/ui/toc-section.tsx
+++ b/src/features/toc/ui/toc-section.tsx
@@ -78,7 +78,7 @@ export function TocSection({ headings, onItemClick }: TocSectionProps) {
                 href={`#${item.id}`}
                 onClick={(event) => handleHeadingClick(event, item.id)}
                 className={cn(
-                  "block truncate py-[2px] text-[0.688rem] font-medium leading-4 transition-colors hover:text-primary-1",
+                  "block truncate py-0.5 text-[0.688rem] font-medium leading-4 transition-colors hover:text-primary-1",
                   item.level === 1 && "pl-0 text-text-3",
                   item.level === 2 && "pl-2.5 text-text-3",
                   item.level === 3 && "pl-5 text-text-4",

--- a/src/features/toc/ui/toc-section.tsx
+++ b/src/features/toc/ui/toc-section.tsx
@@ -5,6 +5,7 @@ import { Icon } from "@iconify/react/offline";
 import listLinear from "@iconify-icons/solar/list-linear";
 import type { TocItem } from "@shared/lib/markdown";
 import { cn } from "@shared/lib/style-utils";
+import { ChevronIcon } from "@shared/ui/icons";
 
 const DESKTOP_BREAKPOINT = 1080;
 const DESKTOP_MEDIA_QUERY = `(min-width: ${DESKTOP_BREAKPOINT}px)`;
@@ -66,7 +67,11 @@ export function TocSection({ headings, onItemClick }: TocSectionProps) {
           aria-label={isOpen ? "목차 접기" : "목차 펼치기"}
           className="rounded-md p-1 text-text-4 transition-colors hover:text-primary-1"
         >
-          <ChevronIcon isOpen={isOpen} />
+          <ChevronIcon
+            direction="down"
+            size="18"
+            className={cn("transition-transform", isOpen && "rotate-180")}
+          />
         </button>
       </div>
 
@@ -92,25 +97,5 @@ export function TocSection({ headings, onItemClick }: TocSectionProps) {
         </ol>
       )}
     </nav>
-  );
-}
-
-function ChevronIcon({ isOpen }: { isOpen: boolean }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="18"
-      height="18"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.8"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={cn("transition-transform", isOpen && "rotate-180")}
-      aria-hidden="true"
-    >
-      <path d="m6 9 6 6 6-6" />
-    </svg>
   );
 }

--- a/src/shared/ui/confirm-dialog.tsx
+++ b/src/shared/ui/confirm-dialog.tsx
@@ -39,7 +39,7 @@ export function ConfirmDialog({
             type="button"
             onClick={onClose}
             disabled={isPending}
-            className="inline-flex items-center justify-center rounded-[0.75rem] border border-border-3 px-4 py-2.5 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex items-center justify-center rounded-xl border border-border-3 px-4 py-2.5 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
           >
             취소
           </button>
@@ -48,7 +48,7 @@ export function ConfirmDialog({
             onClick={onConfirm}
             disabled={isPending}
             className={cn(
-              "inline-flex items-center justify-center rounded-[0.75rem] px-4 py-2.5 text-sm font-semibold transition-colors",
+              "inline-flex items-center justify-center rounded-xl px-4 py-2.5 text-sm font-semibold transition-colors",
               "disabled:cursor-not-allowed disabled:opacity-50",
               confirmTone === "danger"
                 ? "bg-negative-1 text-white hover:opacity-90"

--- a/src/shared/ui/icons/chevron-icon.tsx
+++ b/src/shared/ui/icons/chevron-icon.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import type { IIconProps } from ".";
+import { cn } from "@shared/lib/style-utils";
+
+type ChevronDirection = "up" | "down" | "left" | "right";
+
+interface ChevronIconProps extends IIconProps {
+  direction?: ChevronDirection;
+  size?: number | string;
+  strokeWidth?: number | string;
+}
+
+const pathByDirection: Record<ChevronDirection, string> = {
+  up: "m6 15 6-6 6 6",
+  down: "m6 9 6 6 6-6",
+  left: "m15 18-6-6 6-6",
+  right: "m9 18 6-6-6-6",
+};
+
+const ChevronIcon: React.FC<ChevronIconProps> = ({
+  className,
+  size,
+  width,
+  height,
+  direction = "down",
+  strokeWidth = 1.8,
+}) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn("[&_path]:stroke-current", className)}
+      width={width ?? size ?? 16}
+      height={height ?? size ?? 16}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d={pathByDirection[direction]}
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};
+
+export { ChevronIcon };

--- a/src/shared/ui/icons/index.tsx
+++ b/src/shared/ui/icons/index.tsx
@@ -6,6 +6,7 @@ export interface IIconProps {
 
 export { ArrowUpIcon } from "./arrow-up-icon";
 export { BrushIcon } from "./brush-icon";
+export { ChevronIcon } from "./chevron-icon";
 export { GithubIcon } from "./github-icon";
 export { HomeIcon } from "./home-icon";
 export { MailIcon } from "./mail-icon";

--- a/src/shared/ui/libs/archive-header.tsx
+++ b/src/shared/ui/libs/archive-header.tsx
@@ -47,7 +47,7 @@ export function ArchiveHeader({
             <>
               <span
                 aria-hidden="true"
-                className="text-[0.75rem] leading-none text-border-3"
+                className="text-xs leading-none text-border-3"
               >
                 ·
               </span>
@@ -91,7 +91,7 @@ export function ArchiveHeader({
       )}
 
       <div className="flex flex-wrap items-baseline justify-between gap-4">
-        <h1 className="min-w-0 flex-1 break-keep text-[2.25rem] leading-[1.1] font-bold tracking-[-0.025em] text-text-1 sm:text-[2.875rem]">
+        <h1 className="min-w-0 flex-1 break-keep text-4xl leading-[1.1] font-bold tracking-tight text-text-1 sm:text-[2.875rem]">
           {variant === "tag" ? <span className="text-primary-1">#</span> : null}
           {title}
         </h1>

--- a/src/shared/ui/libs/archive-header.tsx
+++ b/src/shared/ui/libs/archive-header.tsx
@@ -1,9 +1,8 @@
 import type { ReactNode } from "react";
-import { Icon } from "@iconify/react/offline";
-import altArrowRightLinear from "@iconify-icons/solar/alt-arrow-right-linear";
 import Link from "next/link";
 import { formatNumber } from "@shared/lib/format-number";
 import { cn } from "@shared/lib/style-utils";
+import { ChevronIcon } from "@shared/ui/icons";
 
 interface ArchiveBreadcrumbItem {
   label: string;
@@ -113,7 +112,7 @@ function BreadcrumbChevron() {
       aria-hidden="true"
       className="mx-px inline-flex h-2.5 w-2.5 shrink-0 items-center justify-center text-text-4"
     >
-      <Icon icon={altArrowRightLinear} width="10" aria-hidden="true" />
+      <ChevronIcon direction="right" size="10" />
     </span>
   );
 }

--- a/src/shared/ui/libs/custom-select.tsx
+++ b/src/shared/ui/libs/custom-select.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
+import { Icon } from "@iconify/react/offline";
+import altArrowDownLinear from "@iconify-icons/solar/alt-arrow-down-linear";
+import { cn } from "@shared/lib/style-utils";
+
+export interface CustomSelectOption<T extends string | number> {
+  label: string;
+  triggerLabel?: string;
+  value: T;
+  depth?: number;
+}
+
+interface CustomSelectProps<T extends string | number> {
+  value: T | null;
+  options: Array<CustomSelectOption<T>>;
+  onChange: (value: T) => void;
+  ariaLabel: string;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+  triggerClassName?: string;
+  optionClassName?: string;
+  listboxClassName?: string;
+  iconClassName?: string;
+  iconWidth?: string;
+}
+
+export function CustomSelect<T extends string | number>({
+  value,
+  options,
+  onChange,
+  ariaLabel,
+  placeholder,
+  disabled,
+  className,
+  triggerClassName,
+  optionClassName,
+  listboxClassName,
+  iconClassName,
+  iconWidth = "14",
+}: CustomSelectProps<T>) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const listboxId = useId();
+  const selected = options.find((option) => option.value === value);
+  const selectedIndex = options.findIndex((option) => option.value === value);
+  const visibleLabel =
+    selected?.triggerLabel ?? selected?.label ?? placeholder ?? "";
+
+  useEffect(() => {
+    optionRefs.current = [];
+  }, [options]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    function handlePointerDown(event: MouseEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handlePointerDown);
+
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const next = optionRefs.current[activeIndex];
+    if (!next) {
+      return;
+    }
+
+    const frame = requestAnimationFrame(() => next.focus());
+
+    return () => cancelAnimationFrame(frame);
+  }, [activeIndex, isOpen]);
+
+  function openList(index = selectedIndex >= 0 ? selectedIndex : 0) {
+    setActiveIndex(
+      Math.min(Math.max(index, 0), Math.max(options.length - 1, 0)),
+    );
+    setIsOpen(true);
+  }
+
+  function closeList(options: { focusTrigger?: boolean } = {}) {
+    setIsOpen(false);
+    if (options.focusTrigger) {
+      triggerRef.current?.focus();
+    }
+  }
+
+  function commitSelection(index: number) {
+    const option = options[index];
+    if (!option) {
+      return;
+    }
+
+    onChange(option.value);
+    closeList({ focusTrigger: true });
+  }
+
+  function moveActive(nextIndex: number) {
+    const maxIndex = options.length - 1;
+    if (maxIndex < 0) {
+      return;
+    }
+
+    setActiveIndex(Math.min(Math.max(nextIndex, 0), maxIndex));
+  }
+
+  function handleTriggerKeyDown(event: ReactKeyboardEvent<HTMLButtonElement>) {
+    if (disabled) {
+      return;
+    }
+
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      openList(selectedIndex >= 0 ? selectedIndex : 0);
+
+      return;
+    }
+
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      if (isOpen) {
+        closeList();
+      } else {
+        openList(selectedIndex >= 0 ? selectedIndex : 0);
+      }
+    }
+  }
+
+  function handleOptionKeyDown(
+    event: ReactKeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      moveActive(index + 1);
+
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      moveActive(index - 1);
+
+      return;
+    }
+
+    if (event.key === "Home") {
+      event.preventDefault();
+      moveActive(0);
+
+      return;
+    }
+
+    if (event.key === "End") {
+      event.preventDefault();
+      moveActive(options.length - 1);
+
+      return;
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeList({ focusTrigger: true });
+
+      return;
+    }
+
+    if (event.key === "Tab") {
+      closeList();
+
+      return;
+    }
+
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      commitSelection(index);
+    }
+  }
+
+  return (
+    <div ref={rootRef} className={cn("relative inline-flex", className)}>
+      <button
+        ref={triggerRef}
+        type="button"
+        disabled={disabled}
+        aria-label={ariaLabel}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-controls={listboxId}
+        onClick={() =>
+          isOpen
+            ? closeList()
+            : openList(selectedIndex >= 0 ? selectedIndex : 0)
+        }
+        onKeyDown={handleTriggerKeyDown}
+        className={cn(
+          "flex h-10 w-full items-center rounded-lg border border-border-3 bg-background-1 px-3 py-2 pr-8 text-left text-[14px] leading-5 text-text-1 outline-none transition-colors disabled:cursor-not-allowed disabled:opacity-60",
+          isOpen && "border-primary-1 ring-3 ring-primary-1/10",
+          triggerClassName,
+        )}
+      >
+        <span className="truncate whitespace-nowrap">{visibleLabel}</span>
+        <Icon
+          icon={altArrowDownLinear}
+          width={iconWidth}
+          aria-hidden="true"
+          className={cn(
+            "pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-text-4 transition-transform",
+            isOpen && "rotate-180",
+            iconClassName,
+          )}
+        />
+      </button>
+
+      {isOpen ? (
+        <div
+          className={cn(
+            "absolute left-0 top-[calc(100%+4px)] z-[200] min-w-full overflow-hidden rounded-lg border border-border-3 bg-background-1 shadow-[0_4px_16px_rgba(0,0,0,0.1)]",
+            listboxClassName,
+          )}
+        >
+          <div
+            id={listboxId}
+            role="listbox"
+            aria-label={ariaLabel}
+            className="py-0.5"
+          >
+            {options.map((option, index) => {
+              const isSelected = option.value === value;
+
+              return (
+                <button
+                  key={String(option.value)}
+                  ref={(node) => {
+                    optionRefs.current[index] = node;
+                  }}
+                  type="button"
+                  role="option"
+                  aria-selected={isSelected}
+                  tabIndex={index === activeIndex ? 0 : -1}
+                  onClick={() => commitSelection(index)}
+                  onFocus={() => setActiveIndex(index)}
+                  onKeyDown={(event) => handleOptionKeyDown(event, index)}
+                  className={cn(
+                    "flex w-full items-center whitespace-nowrap px-3 py-2 text-left text-[14px] leading-5 text-text-1 transition-colors hover:bg-background-2",
+                    isSelected && "font-medium text-primary-1",
+                    optionClassName,
+                  )}
+                  style={{
+                    paddingLeft: option.depth
+                      ? `${12 + option.depth * 16}px`
+                      : undefined,
+                  }}
+                >
+                  <span className="truncate">{option.label}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/shared/ui/libs/drop-select.tsx
+++ b/src/shared/ui/libs/drop-select.tsx
@@ -260,6 +260,7 @@ export function DropSelect<T extends string | number>({
 
     if (event.key === "Escape") {
       event.preventDefault();
+      event.stopPropagation();
       closeList({ focusTrigger: true });
 
       return;

--- a/src/shared/ui/libs/drop-select.tsx
+++ b/src/shared/ui/libs/drop-select.tsx
@@ -10,9 +10,8 @@ import {
   useRef,
   useState,
 } from "react";
-import { Icon } from "@iconify/react/offline";
-import altArrowDownLinear from "@iconify-icons/solar/alt-arrow-down-linear";
 import { cn } from "@shared/lib/style-utils";
+import { ChevronIcon } from "@shared/ui/icons";
 
 export interface DropSelectOption<T extends string | number> {
   label: string;
@@ -306,10 +305,9 @@ export function DropSelect<T extends string | number>({
         style={triggerStyle}
       >
         <span className="truncate whitespace-nowrap">{visibleLabel}</span>
-        <Icon
-          icon={altArrowDownLinear}
-          width={iconWidth}
-          aria-hidden="true"
+        <ChevronIcon
+          direction="down"
+          size={iconWidth}
           className={cn(
             "pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-text-4 transition-transform",
             isOpen && "rotate-180",

--- a/src/shared/ui/libs/drop-select.tsx
+++ b/src/shared/ui/libs/drop-select.tsx
@@ -11,16 +11,16 @@ import { Icon } from "@iconify/react/offline";
 import altArrowDownLinear from "@iconify-icons/solar/alt-arrow-down-linear";
 import { cn } from "@shared/lib/style-utils";
 
-export interface CustomSelectOption<T extends string | number> {
+export interface DropSelectOption<T extends string | number> {
   label: string;
   triggerLabel?: string;
   value: T;
   depth?: number;
 }
 
-interface CustomSelectProps<T extends string | number> {
+interface DropSelectProps<T extends string | number> {
   value: T | null;
-  options: Array<CustomSelectOption<T>>;
+  options: Array<DropSelectOption<T>>;
   onChange: (value: T) => void;
   ariaLabel: string;
   placeholder?: string;
@@ -33,7 +33,7 @@ interface CustomSelectProps<T extends string | number> {
   iconWidth?: string;
 }
 
-export function CustomSelect<T extends string | number>({
+export function DropSelect<T extends string | number>({
   value,
   options,
   onChange,
@@ -46,7 +46,7 @@ export function CustomSelect<T extends string | number>({
   listboxClassName,
   iconClassName,
   iconWidth = "14",
-}: CustomSelectProps<T>) {
+}: DropSelectProps<T>) {
   const [isOpen, setIsOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
   const rootRef = useRef<HTMLDivElement | null>(null);

--- a/src/shared/ui/libs/drop-select.tsx
+++ b/src/shared/ui/libs/drop-select.tsx
@@ -233,7 +233,7 @@ export function DropSelect<T extends string | number>({
         }
         onKeyDown={handleTriggerKeyDown}
         className={cn(
-          "flex h-10 w-full items-center rounded-lg border border-border-3 bg-background-1 px-3 py-2 pr-8 text-left text-[14px] leading-5 text-text-1 outline-none transition-colors disabled:cursor-not-allowed disabled:opacity-60",
+          "flex h-10 w-full items-center rounded-lg border border-border-3 bg-background-1 px-3 py-2 pr-8 text-left text-sm leading-5 text-text-1 outline-none transition-colors disabled:cursor-not-allowed disabled:opacity-60",
           isOpen && "border-primary-1 ring-3 ring-primary-1/10",
           triggerClassName,
         )}
@@ -282,7 +282,7 @@ export function DropSelect<T extends string | number>({
                   onFocus={() => setActiveIndex(index)}
                   onKeyDown={(event) => handleOptionKeyDown(event, index)}
                   className={cn(
-                    "flex w-full items-center whitespace-nowrap px-3 py-2 text-left text-[14px] leading-5 text-text-1 transition-colors hover:bg-background-2",
+                    "flex w-full items-center whitespace-nowrap px-3 py-2 text-left text-sm leading-5 text-text-1 transition-colors hover:bg-background-2",
                     showSelectedIndicator && "justify-between gap-3",
                     isSelected && "font-medium text-primary-1",
                     optionClassName,

--- a/src/shared/ui/libs/drop-select.tsx
+++ b/src/shared/ui/libs/drop-select.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
   useEffect,
   useId,
@@ -23,14 +24,19 @@ interface DropSelectProps<T extends string | number> {
   options: Array<DropSelectOption<T>>;
   onChange: (value: T) => void;
   ariaLabel: string;
+  id?: string;
+  name?: string;
   placeholder?: string;
   disabled?: boolean;
   className?: string;
   triggerClassName?: string;
+  triggerStyle?: CSSProperties;
   optionClassName?: string;
   listboxClassName?: string;
   iconClassName?: string;
   iconWidth?: string;
+  showSelectedIndicator?: boolean;
+  selectedIndicatorLabel?: string;
 }
 
 export function DropSelect<T extends string | number>({
@@ -38,14 +44,19 @@ export function DropSelect<T extends string | number>({
   options,
   onChange,
   ariaLabel,
+  id,
+  name,
   placeholder,
   disabled,
   className,
   triggerClassName,
+  triggerStyle,
   optionClassName,
   listboxClassName,
   iconClassName,
   iconWidth = "14",
+  showSelectedIndicator = false,
+  selectedIndicatorLabel = "선택됨",
 }: DropSelectProps<T>) {
   const [isOpen, setIsOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
@@ -203,7 +214,11 @@ export function DropSelect<T extends string | number>({
 
   return (
     <div ref={rootRef} className={cn("relative inline-flex", className)}>
+      {name ? (
+        <input type="hidden" name={name} value={value === null ? "" : value} />
+      ) : null}
       <button
+        id={id}
         ref={triggerRef}
         type="button"
         disabled={disabled}
@@ -222,6 +237,7 @@ export function DropSelect<T extends string | number>({
           isOpen && "border-primary-1 ring-3 ring-primary-1/10",
           triggerClassName,
         )}
+        style={triggerStyle}
       >
         <span className="truncate whitespace-nowrap">{visibleLabel}</span>
         <Icon
@@ -267,6 +283,7 @@ export function DropSelect<T extends string | number>({
                   onKeyDown={(event) => handleOptionKeyDown(event, index)}
                   className={cn(
                     "flex w-full items-center whitespace-nowrap px-3 py-2 text-left text-[14px] leading-5 text-text-1 transition-colors hover:bg-background-2",
+                    showSelectedIndicator && "justify-between gap-3",
                     isSelected && "font-medium text-primary-1",
                     optionClassName,
                   )}
@@ -277,6 +294,11 @@ export function DropSelect<T extends string | number>({
                   }}
                 >
                   <span className="truncate">{option.label}</span>
+                  {showSelectedIndicator && isSelected ? (
+                    <span className="shrink-0 text-[11px] text-primary-1">
+                      {selectedIndicatorLabel}
+                    </span>
+                  ) : null}
                 </button>
               );
             })}

--- a/src/shared/ui/libs/drop-select.tsx
+++ b/src/shared/ui/libs/drop-select.tsx
@@ -3,8 +3,10 @@
 import {
   type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
+  useCallback,
   useEffect,
   useId,
+  useLayoutEffect,
   useRef,
   useState,
 } from "react";
@@ -39,6 +41,16 @@ interface DropSelectProps<T extends string | number> {
   selectedIndicatorLabel?: string;
 }
 
+type DropSelectPlacement = "bottom" | "top";
+
+interface ListboxLayout {
+  placement: DropSelectPlacement;
+  maxHeight?: number;
+}
+
+const LISTBOX_GAP_PX = 4;
+const LISTBOX_VIEWPORT_MARGIN_PX = 8;
+
 export function DropSelect<T extends string | number>({
   value,
   options,
@@ -60,8 +72,12 @@ export function DropSelect<T extends string | number>({
 }: DropSelectProps<T>) {
   const [isOpen, setIsOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
+  const [listboxLayout, setListboxLayout] = useState<ListboxLayout>({
+    placement: "bottom",
+  });
   const rootRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const listboxRef = useRef<HTMLDivElement | null>(null);
   const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const listboxId = useId();
   const selected = options.find((option) => option.value === value);
@@ -72,6 +88,34 @@ export function DropSelect<T extends string | number>({
   useEffect(() => {
     optionRefs.current = [];
   }, [options]);
+
+  const updateListboxLayout = useCallback(() => {
+    const trigger = triggerRef.current;
+    const listbox = listboxRef.current;
+
+    if (!trigger || !listbox) {
+      return;
+    }
+
+    const triggerRect = trigger.getBoundingClientRect();
+    const viewportHeight = window.innerHeight;
+    const spaceBelow =
+      viewportHeight -
+      triggerRect.bottom -
+      LISTBOX_GAP_PX -
+      LISTBOX_VIEWPORT_MARGIN_PX;
+    const spaceAbove =
+      triggerRect.top - LISTBOX_GAP_PX - LISTBOX_VIEWPORT_MARGIN_PX;
+    const preferredHeight = listbox.scrollHeight;
+    const shouldOpenAbove =
+      spaceBelow < preferredHeight && spaceAbove > spaceBelow;
+    const availableSpace = shouldOpenAbove ? spaceAbove : spaceBelow;
+
+    setListboxLayout({
+      placement: shouldOpenAbove ? "top" : "bottom",
+      maxHeight: Math.max(0, availableSpace),
+    });
+  }, []);
 
   useEffect(() => {
     if (!isOpen) {
@@ -90,6 +134,28 @@ export function DropSelect<T extends string | number>({
       document.removeEventListener("mousedown", handlePointerDown);
     };
   }, [isOpen]);
+
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    updateListboxLayout();
+  }, [isOpen, options, updateListboxLayout]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    window.addEventListener("resize", updateListboxLayout);
+    window.addEventListener("scroll", updateListboxLayout, true);
+
+    return () => {
+      window.removeEventListener("resize", updateListboxLayout);
+      window.removeEventListener("scroll", updateListboxLayout, true);
+    };
+  }, [isOpen, updateListboxLayout]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -254,10 +320,20 @@ export function DropSelect<T extends string | number>({
 
       {isOpen ? (
         <div
+          ref={listboxRef}
           className={cn(
-            "absolute left-0 top-[calc(100%+4px)] z-[200] min-w-full overflow-hidden rounded-lg border border-border-3 bg-background-1 shadow-[0_4px_16px_rgba(0,0,0,0.1)]",
+            "absolute left-0 z-[200] min-w-full overflow-y-auto rounded-lg border border-border-3 bg-background-1 shadow-[0_4px_16px_rgba(0,0,0,0.1)]",
+            listboxLayout.placement === "top"
+              ? "bottom-[calc(100%+4px)]"
+              : "top-[calc(100%+4px)]",
             listboxClassName,
           )}
+          style={{
+            maxHeight:
+              listboxLayout.maxHeight === undefined
+                ? undefined
+                : `${listboxLayout.maxHeight}px`,
+          }}
         >
           <div
             id={listboxId}

--- a/src/shared/ui/libs/empty-state.tsx
+++ b/src/shared/ui/libs/empty-state.tsx
@@ -16,8 +16,8 @@ const variantClasses: Record<
   string
 > = {
   default:
-    "rounded-[1.5rem] border border-dashed border-border-3 bg-background-1 px-6 py-12 text-center text-sm",
-  page: "rounded-[2rem] border border-border-3 bg-background-2/90 px-8 py-14 text-center shadow-[0_16px_48px_rgba(0,0,0,0.06)]",
+    "rounded-3xl border border-dashed border-border-3 bg-background-1 px-6 py-12 text-center text-sm",
+  page: "rounded-4xl border border-border-3 bg-background-2/90 px-8 py-14 text-center shadow-[0_16px_48px_rgba(0,0,0,0.06)]",
   "admin-page":
     "rounded-[1.75rem] border border-border-3 bg-background-2/90 px-8 py-14 text-center shadow-[0_16px_48px_rgba(0,0,0,0.06)]",
 };
@@ -45,12 +45,12 @@ export function EmptyState({
         </p>
       ) : null}
       {description ? (
-        <p className="mx-auto max-w-[32rem] break-keep text-body-sm leading-relaxed text-text-3">
+        <p className="mx-auto max-w-lg break-keep text-body-sm leading-relaxed text-text-3">
           {description}
         </p>
       ) : null}
       {!title && message ? (
-        <p className="mx-auto max-w-[28rem] break-keep text-body-sm leading-relaxed text-text-3">
+        <p className="mx-auto max-w-md break-keep text-body-sm leading-relaxed text-text-3">
           {message}
         </p>
       ) : null}

--- a/src/shared/ui/libs/empty-state.tsx
+++ b/src/shared/ui/libs/empty-state.tsx
@@ -17,9 +17,9 @@ const variantClasses: Record<
 > = {
   default:
     "rounded-3xl border border-dashed border-border-3 bg-background-1 px-6 py-12 text-center text-sm",
-  page: "rounded-4xl border border-border-3 bg-background-2/90 px-8 py-14 text-center shadow-[0_16px_48px_rgba(0,0,0,0.06)]",
+  page: "rounded-4xl border border-border-3 bg-background-2/90 px-8 py-14 text-center",
   "admin-page":
-    "rounded-[1.75rem] border border-border-3 bg-background-2/90 px-8 py-14 text-center shadow-[0_16px_48px_rgba(0,0,0,0.06)]",
+    "rounded-[1.75rem] border border-border-3 bg-background-2/90 px-8 py-14 text-center",
 };
 
 export function EmptyState({

--- a/src/shared/ui/libs/error-content.tsx
+++ b/src/shared/ui/libs/error-content.tsx
@@ -45,8 +45,8 @@ export function ErrorContent({
 
   const surfaceClasses =
     context === "admin"
-      ? "max-w-[36rem] rounded-[1.75rem] border border-border-3 bg-background-2/90 p-7 text-left shadow-[0_18px_48px_rgba(0,0,0,0.08)] md:p-8"
-      : "max-w-[38rem] rounded-[2rem] border border-border-3 bg-background-2/90 p-8 text-left shadow-[0_22px_60px_rgba(0,0,0,0.08)] md:p-10";
+      ? "max-w-xl rounded-[1.75rem] border border-border-3 bg-background-2/90 p-7 text-left shadow-[0_18px_48px_rgba(0,0,0,0.08)] md:p-8"
+      : "max-w-[38rem] rounded-4xl border border-border-3 bg-background-2/90 p-8 text-left shadow-[0_22px_60px_rgba(0,0,0,0.08)] md:p-10";
 
   return (
     <div
@@ -91,7 +91,7 @@ export function ErrorContent({
             </p>
           ) : null}
 
-          <h1 className="break-keep text-[1.5rem] leading-[1.95rem] font-bold tracking-tight text-text-1 md:text-[1.875rem] md:leading-[2.375rem]">
+          <h1 className="break-keep text-2xl leading-[1.95rem] font-bold tracking-tight text-text-1 md:text-3xl md:leading-9.5">
             {title}
           </h1>
 

--- a/src/shared/ui/libs/index.tsx
+++ b/src/shared/ui/libs/index.tsx
@@ -1,6 +1,7 @@
 export { ArchiveHeader } from "./archive-header";
 export { ArchiveTagBadge } from "./archive-tag-badge";
 export { Button } from "./button";
+export { CustomSelect, type CustomSelectOption } from "./custom-select";
 export { EmptyState } from "./empty-state";
 export { ErrorContent } from "./error-content";
 export { ScrollToTop } from "./scroll-to-top";

--- a/src/shared/ui/libs/index.tsx
+++ b/src/shared/ui/libs/index.tsx
@@ -1,7 +1,7 @@
 export { ArchiveHeader } from "./archive-header";
 export { ArchiveTagBadge } from "./archive-tag-badge";
 export { Button } from "./button";
-export { CustomSelect, type CustomSelectOption } from "./custom-select";
+export { DropSelect, type DropSelectOption } from "./drop-select";
 export { EmptyState } from "./empty-state";
 export { ErrorContent } from "./error-content";
 export { ScrollToTop } from "./scroll-to-top";

--- a/src/shared/ui/libs/index.tsx
+++ b/src/shared/ui/libs/index.tsx
@@ -12,5 +12,6 @@ export { Modal } from "./modal";
 export { Pagination } from "./pagination";
 export { Skeleton } from "./skeleton";
 export { Spinner } from "./spinner";
+export { TableSkeleton } from "./table-skeleton";
 export { Text } from "./text";
 export { SlideInPanel } from "./slide-in-panel";

--- a/src/shared/ui/libs/modal.tsx
+++ b/src/shared/ui/libs/modal.tsx
@@ -148,7 +148,7 @@ const Modal: React.FC<ModalProps> = ({
       <div
         ref={dialogRef}
         className={cn(
-          "min-w-[21.875rem] min-h-[5rem] max-h-[85%]",
+          "min-w-[21.875rem] min-h-20 max-h-[85%]",
           "bg-background-2 text-text-1",
           "rounded-[10px]",
           "shadow-[0_10px_20px_rgba(0,0,0,0.19),0_0px_6px_rgba(0,0,0,0.22)]",

--- a/src/shared/ui/libs/pagination.tsx
+++ b/src/shared/ui/libs/pagination.tsx
@@ -126,7 +126,7 @@ function Pagination({
               tabIndex={page === currentPage ? -1 : undefined}
               className={cn(
                 navBtnBase,
-                "min-w-[2rem]",
+                "min-w-8",
                 page === currentPage
                   ? "bg-primary-1 text-white font-semibold pointer-events-none"
                   : "text-text-1 hover:bg-background-2",
@@ -156,7 +156,7 @@ function Pagination({
               tabIndex={page === currentPage ? -1 : undefined}
               className={cn(
                 navBtnBase,
-                "min-w-[2rem]",
+                "min-w-8",
                 page === currentPage
                   ? "bg-primary-1 text-white font-semibold pointer-events-none"
                   : "text-text-1 hover:bg-background-2",

--- a/src/shared/ui/libs/table-skeleton.tsx
+++ b/src/shared/ui/libs/table-skeleton.tsx
@@ -1,0 +1,92 @@
+import { Skeleton } from "./skeleton";
+import { cn } from "@shared/lib/style-utils";
+
+interface TableSkeletonColumn {
+  width?: string;
+  className?: string;
+}
+
+interface TableSkeletonProps {
+  columns: TableSkeletonColumn[];
+  rows?: number;
+  rowHeight?: string;
+  containerClassName?: string;
+  headerClassName?: string;
+}
+
+export function TableSkeleton({
+  columns,
+  rows = 6,
+  rowHeight = "3.25rem",
+  containerClassName,
+  headerClassName,
+}: TableSkeletonProps) {
+  return (
+    <div
+      aria-busy="true"
+      className={cn(
+        "overflow-hidden rounded-2xl border border-border-4 bg-background-1",
+        containerClassName,
+      )}
+    >
+      <div className="overflow-x-auto">
+        <table className="min-w-full">
+          <thead
+            className={cn(
+              "bg-background-2 text-left text-[11px] font-semibold uppercase tracking-[0.16em] text-text-4",
+              headerClassName,
+            )}
+          >
+            <tr>
+              {columns.map((column, index) => (
+                <th
+                  key={index}
+                  className={cn(
+                    "whitespace-nowrap px-3 py-3.5 align-middle font-medium leading-none",
+                    column.className,
+                  )}
+                  style={column.width ? { width: column.width } : undefined}
+                >
+                  <Skeleton height="0.75rem" tone="soft" />
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border-4">
+            {Array.from({ length: rows }).map((_, rowIndex) => (
+              <tr key={rowIndex}>
+                {columns.map((column, columnIndex) => (
+                  <td
+                    key={columnIndex}
+                    className={cn(
+                      "whitespace-nowrap px-3 py-3.5 align-middle leading-none",
+                      column.className,
+                    )}
+                    style={
+                      column.width
+                        ? { width: column.width, height: rowHeight }
+                        : { height: rowHeight }
+                    }
+                  >
+                    <Skeleton
+                      height={columnIndex === 0 ? "1rem" : "0.875rem"}
+                      width={getCellWidth(columnIndex)}
+                      tone={columnIndex === 0 ? "strong" : "soft"}
+                      className={columnIndex === 0 ? "rounded" : undefined}
+                    />
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function getCellWidth(index: number) {
+  const widths = ["1rem", "70%", "55%", "80%", "48%", "2rem", "4rem"];
+
+  return widths[index % widths.length];
+}

--- a/src/shared/ui/toggle-switch.tsx
+++ b/src/shared/ui/toggle-switch.tsx
@@ -40,7 +40,7 @@ export function ToggleSwitch({
         className={cn(
           "pointer-events-none inline-block bg-white shadow-sm",
           "transform transition duration-200 ease-in-out",
-          size === "sm" ? "h-4 w-4 rounded-[8px]" : "h-5 w-5 rounded-full",
+          size === "sm" ? "h-4 w-4 rounded-lg" : "h-5 w-5 rounded-full",
           checked
             ? size === "sm"
               ? "translate-x-4"

--- a/src/widgets/admin-comments/ui/admin-comments-page.tsx
+++ b/src/widgets/admin-comments/ui/admin-comments-page.tsx
@@ -26,7 +26,7 @@ import {
 } from "@entities/comment";
 import { getErrorMessage } from "@shared/lib/get-error-message";
 import { cn } from "@shared/lib/style-utils";
-import { EmptyState, Skeleton } from "@shared/ui/libs";
+import { EmptyState, TableSkeleton } from "@shared/ui/libs";
 
 const PAGE_SIZE = 10;
 const EMPTY_COMMENT_ROWS: AdminCommentItem[] = [];
@@ -494,23 +494,22 @@ export function AdminCommentsPage() {
         ) : null}
 
         {isPending ? (
-          <div className="mt-4 overflow-hidden rounded-2xl border border-border-4 bg-background-1">
-            <div className="grid grid-cols-8 gap-3 border-b border-border-4 bg-background-2 px-4 py-3.5">
-              {Array.from({ length: 8 }).map((_, i) => (
-                <Skeleton key={i} />
-              ))}
-            </div>
-            <div className="space-y-3 px-4 py-4">
-              {Array.from({ length: 6 }).map((_, i) => (
-                <Skeleton
-                  key={i}
-                  variant="rect"
-                  height="3.25rem"
-                  className="rounded-[0.9rem]"
-                />
-              ))}
-            </div>
-          </div>
+          <TableSkeleton
+            rows={6}
+            rowHeight="3.25rem"
+            containerClassName="mt-4"
+            columns={[
+              { width: "2.5rem" },
+              { width: "10rem" },
+              { width: "5rem" },
+              { width: "22rem" },
+              { width: "12rem" },
+              { width: "4rem", className: "text-center" },
+              { width: "6rem" },
+              { width: "7rem" },
+              { width: "4rem", className: "text-center" },
+            ]}
+          />
         ) : null}
 
         {!isPending && isError ? (

--- a/src/widgets/admin-comments/ui/admin-comments-page.tsx
+++ b/src/widgets/admin-comments/ui/admin-comments-page.tsx
@@ -488,13 +488,13 @@ export function AdminCommentsPage() {
         </div>
 
         {actionError ? (
-          <div className="mt-4 rounded-[1rem] border border-negative-1/20 bg-negative-1/10 px-4 py-3 text-sm text-negative-1">
+          <div className="mt-4 rounded-2xl border border-negative-1/20 bg-negative-1/10 px-4 py-3 text-sm text-negative-1">
             {actionError}
           </div>
         ) : null}
 
         {isPending ? (
-          <div className="mt-4 overflow-hidden rounded-[1rem] border border-border-4 bg-background-1">
+          <div className="mt-4 overflow-hidden rounded-2xl border border-border-4 bg-background-1">
             <div className="grid grid-cols-8 gap-3 border-b border-border-4 bg-background-2 px-4 py-3.5">
               {Array.from({ length: 8 }).map((_, i) => (
                 <Skeleton key={i} />
@@ -521,7 +521,7 @@ export function AdminCommentsPage() {
             <button
               type="button"
               onClick={() => void queryClient.invalidateQueries({ queryKey })}
-              className="mt-4 inline-flex rounded-[0.75rem] border border-negative-1/20 px-4 py-2 text-sm font-medium text-negative-1 transition-colors hover:bg-negative-1/10"
+              className="mt-4 inline-flex rounded-xl border border-negative-1/20 px-4 py-2 text-sm font-medium text-negative-1 transition-colors hover:bg-negative-1/10"
             >
               다시 시도
             </button>
@@ -598,7 +598,7 @@ export function AdminCommentsPage() {
                     onClick={() => setPage(pageNumber)}
                     disabled={pageNumber === page}
                     className={cn(
-                      "inline-flex min-w-[2rem] items-center justify-center rounded px-2.5 py-1.5 text-sm transition-colors",
+                      "inline-flex min-w-8 items-center justify-center rounded px-2.5 py-1.5 text-sm transition-colors",
                       pageNumber === page
                         ? "pointer-events-none bg-primary-1 font-semibold text-white"
                         : "text-text-1 hover:bg-background-2",
@@ -647,7 +647,7 @@ export function AdminCommentsPage() {
 
       {selectedIds.length > 0 ? (
         <div className="fixed bottom-0 left-0 right-0 z-20 md:left-[var(--admin-sidebar-offset)]">
-          <div className="flex flex-wrap items-center gap-3 border-t border-border-3 bg-[rgba(241,242,243,0.95)] px-4 py-3 backdrop-blur-[12px] md:px-6 dark:bg-[rgba(19,20,21,0.94)]">
+          <div className="flex flex-wrap items-center gap-3 border-t border-border-3 bg-[rgba(241,242,243,0.95)] px-4 py-3 backdrop-blur-md md:px-6 dark:bg-[rgba(19,20,21,0.94)]">
             <span className="text-sm font-medium text-text-1">
               선택됨 {selectedIds.length}개
               {selectedOnOtherPages > 0 ? (

--- a/src/widgets/admin-comments/ui/comment-delete-modal.tsx
+++ b/src/widgets/admin-comments/ui/comment-delete-modal.tsx
@@ -147,7 +147,7 @@ export function CommentDeleteModal({
             <label
               key={option.value}
               className={cn(
-                "flex cursor-pointer gap-4 rounded-[1rem] border px-4 py-4 transition-colors",
+                "flex cursor-pointer gap-4 rounded-2xl border px-4 py-4 transition-colors",
                 selectedAction === option.value
                   ? "border-primary-1 bg-primary-1/5"
                   : "border-border-3 bg-background-1 hover:border-border-2",
@@ -177,7 +177,7 @@ export function CommentDeleteModal({
             type="button"
             onClick={handleClose}
             disabled={isPending}
-            className="inline-flex items-center justify-center rounded-[0.75rem] border border-border-3 px-4 py-2.5 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex items-center justify-center rounded-xl border border-border-3 px-4 py-2.5 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
           >
             취소
           </button>
@@ -190,7 +190,7 @@ export function CommentDeleteModal({
             }}
             disabled={!selectedOption || isPending}
             className={cn(
-              "inline-flex items-center justify-center rounded-[0.75rem] px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50",
+              "inline-flex items-center justify-center rounded-xl px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50",
               selectedOption?.tone === "danger"
                 ? "bg-negative-1"
                 : "bg-primary-1",

--- a/src/widgets/admin-comments/ui/comment-detail-modal.tsx
+++ b/src/widgets/admin-comments/ui/comment-detail-modal.tsx
@@ -213,7 +213,7 @@ export function CommentDetailModal({
       onClose={onClose}
       withBackground
       aria-label={mode === "thread" ? "댓글 스레드 보기" : "댓글 상세 보기"}
-      className="w-full max-w-xl overflow-hidden rounded-[1.5rem] border border-border-3 bg-background-2 text-left"
+      className="w-full max-w-xl overflow-hidden rounded-3xl border border-border-3 bg-background-2 text-left"
     >
       <div className="relative flex max-h-[85vh] flex-col">
         <div className="flex items-center justify-between px-6 py-5">
@@ -494,7 +494,7 @@ function DetailView({
           type="button"
           onClick={onOpenThread}
           disabled={threadLoading}
-          className="w-full cursor-pointer rounded-[0.75rem] border border-border-3 px-4 py-2.5 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-60"
+          className="w-full cursor-pointer rounded-xl border border-border-3 px-4 py-2.5 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {threadLoading
             ? "스레드 불러오는 중..."
@@ -511,7 +511,7 @@ function DetailView({
               type="button"
               onClick={() => onSelectAction("hard_delete")}
               disabled={isAnyPending}
-              className="inline-flex min-w-fit items-center justify-center gap-1 whitespace-nowrap rounded-[0.75rem] bg-negative-1 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex min-w-fit items-center justify-center gap-1 whitespace-nowrap rounded-xl bg-negative-1 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
             >
               <Icon
                 icon={trashBinMinimalisticLinear}
@@ -523,7 +523,7 @@ function DetailView({
             <button
               type="button"
               onClick={onClose}
-              className="inline-flex min-w-fit items-center justify-center whitespace-nowrap rounded-[0.75rem] border border-border-3 px-4 py-2.5 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
+              className="inline-flex min-w-fit items-center justify-center whitespace-nowrap rounded-xl border border-border-3 px-4 py-2.5 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
             >
               닫기
             </button>
@@ -665,7 +665,7 @@ function ThreadView({
           <button
             type="button"
             onClick={onClose}
-            className="inline-flex min-w-fit items-center justify-center whitespace-nowrap rounded-[0.75rem] border border-border-3 px-4 py-2.5 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
+            className="inline-flex min-w-fit items-center justify-center whitespace-nowrap rounded-xl border border-border-3 px-4 py-2.5 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
           >
             닫기
           </button>

--- a/src/widgets/admin-comments/ui/comment-filters.tsx
+++ b/src/widgets/admin-comments/ui/comment-filters.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, type KeyboardEvent } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   DayPicker,
   useDayPicker,
@@ -17,6 +17,7 @@ import { ko } from "date-fns/locale";
 import type { PostListItem } from "@entities/post";
 import { fetchAdminPosts } from "@entities/post";
 import { cn } from "@shared/lib/style-utils";
+import { DropSelect } from "@shared/ui/libs";
 
 export type CommentStatusFilter = "all" | "active" | "deleted" | "hidden";
 export type CommentAuthorTypeFilter = "all" | "oauth" | "guest";
@@ -42,15 +43,15 @@ interface SelectOption<T extends string> {
 
 const STATUS_OPTIONS: Array<SelectOption<CommentStatusFilter>> = [
   { label: "전체", value: "all", triggerLabel: "상태" },
-  { label: "정상", value: "active", triggerLabel: "상태" },
-  { label: "삭제됨", value: "deleted", triggerLabel: "상태" },
-  { label: "숨김", value: "hidden", triggerLabel: "상태" },
+  { label: "정상", value: "active" },
+  { label: "삭제됨", value: "deleted" },
+  { label: "숨김", value: "hidden" },
 ];
 
 const AUTHOR_TYPE_OPTIONS: Array<SelectOption<CommentAuthorTypeFilter>> = [
   { label: "전체", value: "all", triggerLabel: "작성자" },
-  { label: "OAuth", value: "oauth", triggerLabel: "작성자" },
-  { label: "게스트", value: "guest", triggerLabel: "작성자" },
+  { label: "OAuth", value: "oauth" },
+  { label: "게스트", value: "guest" },
 ];
 
 type DateRangePresetValue = "all" | "7d" | "30d" | "90d" | "custom";
@@ -139,210 +140,6 @@ function getSelectTriggerWidthCh<T extends string>(
   }, label.length);
 
   return `${Math.max(longest + 4, 7)}em`;
-}
-
-function FilterCustomSelect<T extends string>({
-  label,
-  value,
-  options,
-  onChange,
-  className,
-  triggerClassName,
-}: {
-  label: string;
-  value: T;
-  options: Array<SelectOption<T>>;
-  onChange: (value: T) => void;
-  className?: string;
-  triggerClassName?: string;
-}) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [activeIndex, setActiveIndex] = useState(-1);
-  const rootRef = useRef<HTMLDivElement | null>(null);
-  const listboxIdRef = useRef(
-    `comment-filter-select-${Math.random().toString(36).slice(2)}`,
-  );
-  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
-  const selected = options.find((option) => option.value === value);
-  const selectedIndex = options.findIndex((option) => option.value === value);
-  const triggerWidth = getSelectTriggerWidthCh(label, options);
-
-  useEffect(() => {
-    optionRefs.current = [];
-  }, [options]);
-
-  useEffect(() => {
-    if (!isOpen) {
-      setActiveIndex(-1);
-
-      return;
-    }
-
-    setActiveIndex(selectedIndex >= 0 ? selectedIndex : 0);
-  }, [isOpen, selectedIndex]);
-
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    const handlePointerDown = (event: MouseEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-
-    document.addEventListener("mousedown", handlePointerDown);
-
-    return () => {
-      document.removeEventListener("mousedown", handlePointerDown);
-    };
-  }, [isOpen]);
-
-  useEffect(() => {
-    if (!isOpen || activeIndex < 0) {
-      return;
-    }
-
-    optionRefs.current[activeIndex]?.focus();
-  }, [activeIndex, isOpen]);
-
-  function commitSelection(index: number) {
-    const option = options[index];
-
-    if (!option) {
-      return;
-    }
-
-    onChange(option.value);
-    setIsOpen(false);
-  }
-
-  function handleTriggerKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
-    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
-      event.preventDefault();
-      setIsOpen(true);
-      setActiveIndex(selectedIndex >= 0 ? selectedIndex : 0);
-
-      return;
-    }
-
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      setIsOpen((current) => !current);
-    }
-  }
-
-  function handleOptionKeyDown(
-    event: KeyboardEvent<HTMLButtonElement>,
-    index: number,
-  ) {
-    if (event.key === "ArrowDown") {
-      event.preventDefault();
-      setActiveIndex((index + 1) % options.length);
-
-      return;
-    }
-
-    if (event.key === "ArrowUp") {
-      event.preventDefault();
-      setActiveIndex((index - 1 + options.length) % options.length);
-
-      return;
-    }
-
-    if (event.key === "Home") {
-      event.preventDefault();
-      setActiveIndex(0);
-
-      return;
-    }
-
-    if (event.key === "End") {
-      event.preventDefault();
-      setActiveIndex(options.length - 1);
-
-      return;
-    }
-
-    if (event.key === "Escape") {
-      event.preventDefault();
-      setIsOpen(false);
-
-      return;
-    }
-
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      commitSelection(index);
-    }
-  }
-
-  return (
-    <div ref={rootRef} className={cn("relative", className)}>
-      <button
-        type="button"
-        onClick={() => setIsOpen((current) => !current)}
-        onKeyDown={handleTriggerKeyDown}
-        role="combobox"
-        aria-autocomplete="none"
-        aria-expanded={isOpen}
-        aria-controls={listboxIdRef.current}
-        aria-haspopup="listbox"
-        className={cn(
-          "relative flex h-10 w-fit items-center whitespace-nowrap rounded-[0.8rem] border border-border-3 bg-background-1 px-3 pr-8 text-left text-sm leading-none text-text-2 outline-none transition-colors hover:border-border-2 focus-visible:border-primary-1",
-          triggerClassName,
-        )}
-        style={triggerClassName ? undefined : { width: triggerWidth }}
-      >
-        <span className="truncate">
-          {selected?.value === "all"
-            ? (selected?.triggerLabel ?? label)
-            : (selected?.label ?? "")}
-        </span>
-        <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[11px] text-text-4">
-          ▾
-        </span>
-      </button>
-
-      {isOpen ? (
-        <div
-          id={listboxIdRef.current}
-          role="listbox"
-          className="absolute left-0 top-full z-20 mt-2 min-w-full overflow-hidden rounded-[1rem] border border-border-3 bg-background-1 shadow-[0px_16px_40px_0px_rgba(0,0,0,0.12)]"
-        >
-          <div className="max-h-60 overflow-y-auto py-1">
-            {options.map((option, index) => {
-              const isSelected = option.value === value;
-
-              return (
-                <button
-                  key={option.value}
-                  ref={(node) => {
-                    optionRefs.current[index] = node;
-                  }}
-                  type="button"
-                  role="option"
-                  aria-selected={isSelected}
-                  onClick={() => commitSelection(index)}
-                  onKeyDown={(event) => handleOptionKeyDown(event, index)}
-                  className={cn(
-                    "flex w-full items-center justify-between px-4 py-3 text-left text-sm leading-none outline-none transition-colors hover:bg-background-2 focus:bg-background-2",
-                    isSelected ? "text-primary-1" : "text-text-1",
-                  )}
-                >
-                  <span>{option.label}</span>
-                  {isSelected ? (
-                    <span className="text-[11px] text-primary-1">선택됨</span>
-                  ) : null}
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      ) : null}
-    </div>
-  );
 }
 
 function DateRangePicker({
@@ -550,10 +347,10 @@ export function CommentFilters({
   const activePreset = detectPreset(startDate, endDate);
   const dateRangeOptions: Array<SelectOption<DateRangePresetValue>> = [
     { label: "전체", value: "all", triggerLabel: "기간" },
-    { label: "7일", value: "7d", triggerLabel: "기간" },
-    { label: "30일", value: "30d", triggerLabel: "기간" },
-    { label: "90일", value: "90d", triggerLabel: "기간" },
-    { label: "사용자 지정", value: "custom", triggerLabel: "기간" },
+    { label: "7일", value: "7d" },
+    { label: "30일", value: "30d" },
+    { label: "90일", value: "90d" },
+    { label: "사용자 지정", value: "custom" },
   ];
 
   useEffect(() => {
@@ -734,26 +531,35 @@ export function CommentFilters({
         ) : null}
       </div>
 
-      <FilterCustomSelect
-        label="상태"
+      <DropSelect
+        ariaLabel="상태"
         value={status}
         options={STATUS_OPTIONS}
         onChange={onStatusChange}
         triggerClassName="w-[8em]"
+        showSelectedIndicator
       />
 
-      <FilterCustomSelect
-        label="작성자"
+      <DropSelect
+        ariaLabel="작성자"
         value={authorType}
         options={AUTHOR_TYPE_OPTIONS}
         onChange={onAuthorTypeChange}
+        triggerStyle={{
+          width: getSelectTriggerWidthCh("작성자", AUTHOR_TYPE_OPTIONS),
+        }}
+        showSelectedIndicator
       />
 
-      <FilterCustomSelect
-        label="기간"
+      <DropSelect
+        ariaLabel="기간"
         value={activePreset}
         options={dateRangeOptions}
         onChange={handlePresetChange}
+        triggerStyle={{
+          width: getSelectTriggerWidthCh("기간", dateRangeOptions),
+        }}
+        showSelectedIndicator
       />
 
       <DateRangePicker

--- a/src/widgets/admin-comments/ui/comment-filters.tsx
+++ b/src/widgets/admin-comments/ui/comment-filters.tsx
@@ -296,19 +296,19 @@ function DateRangePicker({
               week: "grid grid-cols-7",
               day: "h-10 w-10 p-0 text-sm leading-none",
               day_button:
-                "h-10 w-10 cursor-pointer rounded-[0.75rem] text-sm leading-none text-text-2 transition-colors hover:bg-background-2 hover:text-text-1",
+                "h-10 w-10 cursor-pointer rounded-xl text-sm leading-none text-text-2 transition-colors hover:bg-background-2 hover:text-text-1",
               selected:
                 "[&>button]:bg-primary-1 [&>button]:text-white [&>button]:hover:bg-primary-1",
               range_start: cn(
                 "[&>button]:bg-primary-1 [&>button]:text-white [&>button]:hover:bg-primary-1",
                 isSingleDaySelection
-                  ? "[&>button]:rounded-[0.75rem]"
+                  ? "[&>button]:rounded-xl"
                   : "[&>button]:rounded-r-none",
               ),
               range_end: cn(
                 "[&>button]:bg-primary-1 [&>button]:text-white [&>button]:hover:bg-primary-1",
                 isSingleDaySelection
-                  ? "[&>button]:rounded-[0.75rem]"
+                  ? "[&>button]:rounded-xl"
                   : "[&>button]:rounded-l-none",
               ),
               range_middle:
@@ -445,7 +445,7 @@ export function CommentFilters({
           type="button"
           onClick={handlePostInputFocus}
           className={cn(
-            "inline-flex h-10 min-w-[12rem] items-center gap-2 rounded-[0.8rem] border px-3 text-sm leading-none text-text-2 transition-colors",
+            "inline-flex h-10 min-w-48 items-center gap-2 rounded-[0.8rem] border px-3 text-sm leading-none text-text-2 transition-colors",
             selectedPostTitle
               ? "border-primary-1/30 bg-primary-1/8 text-text-1"
               : "border-border-3 bg-background-1 hover:border-border-2",
@@ -457,7 +457,7 @@ export function CommentFilters({
         </button>
 
         {postDropdownOpen ? (
-          <div className="absolute left-0 top-full z-20 mt-2 w-[20rem] overflow-hidden rounded-[1rem] border border-border-3 bg-background-1 shadow-[0px_16px_40px_0px_rgba(0,0,0,0.12)]">
+          <div className="absolute left-0 top-full z-20 mt-2 w-80 overflow-hidden rounded-2xl border border-border-3 bg-background-1 shadow-[0px_16px_40px_0px_rgba(0,0,0,0.12)]">
             <div className="border-b border-border-3 p-3">
               <div className="relative">
                 <Icon

--- a/src/widgets/admin-comments/ui/comment-table.tsx
+++ b/src/widgets/admin-comments/ui/comment-table.tsx
@@ -54,7 +54,7 @@ export function CommentTable({
     !allPageSelected && pageIds.some((id) => selectedIds.has(id));
 
   return (
-    <div className="overflow-hidden rounded-[1rem] border border-border-4 bg-background-1">
+    <div className="overflow-hidden rounded-2xl border border-border-4 bg-background-1">
       <div className="overflow-x-auto">
         <table className="min-w-full">
           <thead className="bg-background-2 text-left text-[11px] font-semibold uppercase tracking-[0.16em] text-text-4">

--- a/src/widgets/admin-post-list/ui/bulk-actions.tsx
+++ b/src/widgets/admin-post-list/ui/bulk-actions.tsx
@@ -186,9 +186,9 @@ export function BulkActions({
               }
               options={categoryOptions}
               ariaLabel="일괄 카테고리 변경"
-              className="min-w-[8rem]"
-              triggerClassName="h-8 rounded-md px-2.5 py-[5px] pr-7 text-[12px] font-normal leading-none"
-              optionClassName="text-[12px] leading-none"
+              className="min-w-32"
+              triggerClassName="h-8 rounded-md px-2.5 py-[5px] pr-7 text-xs font-normal leading-none"
+              optionClassName="text-xs leading-none"
               iconClassName="right-2"
               iconWidth="12"
             />
@@ -202,9 +202,9 @@ export function BulkActions({
               }
               options={commentStatusOptions}
               ariaLabel="일괄 댓글 상태 변경"
-              className="min-w-[8rem]"
-              triggerClassName="h-8 rounded-md px-2.5 py-[5px] pr-7 text-[12px] font-normal leading-none"
-              optionClassName="text-[12px] leading-none"
+              className="min-w-32"
+              triggerClassName="h-8 rounded-md px-2.5 py-[5px] pr-7 text-xs font-normal leading-none"
+              optionClassName="text-xs leading-none"
               iconClassName="right-2"
               iconWidth="12"
             />
@@ -227,7 +227,7 @@ export function BulkActions({
               onClick={() => setShowApplyDialog(true)}
               disabled={!hasUpdate || isPending}
               className={cn(
-                "inline-flex h-8 items-center justify-center rounded-md border px-3 text-[12px] font-medium leading-none transition-colors",
+                "inline-flex h-8 items-center justify-center rounded-md border px-3 text-xs font-medium leading-none transition-colors",
                 hasUpdate
                   ? "border-primary-1 bg-primary-1 text-white hover:opacity-90"
                   : "border border-border-3 text-text-3",
@@ -241,7 +241,7 @@ export function BulkActions({
               type="button"
               onClick={() => setShowDeleteDialog(true)}
               disabled={isPending}
-              className="inline-flex h-8 items-center justify-center rounded-md border border-negative-1 bg-negative-1 px-3 text-[12px] font-medium leading-none text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex h-8 items-center justify-center rounded-md border border-negative-1 bg-negative-1 px-3 text-xs font-medium leading-none text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
             >
               삭제
             </button>
@@ -252,7 +252,7 @@ export function BulkActions({
               type="button"
               onClick={() => setShowRestoreDialog(true)}
               disabled={isPending}
-              className="inline-flex h-8 items-center justify-center rounded-md border border-border-3 px-3 text-[12px] font-medium leading-none text-text-2 transition-colors hover:bg-background-3 disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex h-8 items-center justify-center rounded-md border border-border-3 px-3 text-xs font-medium leading-none text-text-2 transition-colors hover:bg-background-3 disabled:cursor-not-allowed disabled:opacity-50"
             >
               복원
             </button>
@@ -260,7 +260,7 @@ export function BulkActions({
               type="button"
               onClick={() => setShowHardDeleteDialog(true)}
               disabled={isPending}
-              className="inline-flex h-8 items-center justify-center rounded-md border border-negative-1 bg-negative-1 px-3 text-[12px] font-medium leading-none text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex h-8 items-center justify-center rounded-md border border-negative-1 bg-negative-1 px-3 text-xs font-medium leading-none text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
             >
               삭제
             </button>

--- a/src/widgets/admin-post-list/ui/bulk-actions.tsx
+++ b/src/widgets/admin-post-list/ui/bulk-actions.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { Icon } from "@iconify/react/offline";
-import altArrowDownLinear from "@iconify-icons/solar/alt-arrow-down-linear";
 import restartLinear from "@iconify-icons/solar/restart-linear";
 import type { AdminPostTab } from "./post-filters";
 import type { Category } from "@entities/category";
 import { cn } from "@shared/lib/style-utils";
 import { ConfirmDialog } from "@shared/ui/confirm-dialog";
+import { CustomSelect } from "@shared/ui/libs";
 
 interface BulkActionsProps {
   tab: AdminPostTab;
@@ -40,183 +40,6 @@ const COMMENT_STATUS_DESC: Record<"open" | "locked" | "disabled", string> = {
   locked: "기존 댓글은 유지되며 새 댓글 작성이 차단됩니다.",
   disabled: "댓글 영역이 완전히 숨겨집니다.",
 };
-
-function BulkSelect({
-  value,
-  onChange,
-  options,
-  ariaLabel,
-  className,
-}: {
-  value: string;
-  onChange: (value: string) => void;
-  options: Array<{ label: string; value: string; depth?: number }>;
-  ariaLabel: string;
-  className?: string;
-}) {
-  const [open, setOpen] = useState(false);
-  const [activeIndex, setActiveIndex] = useState(0);
-  const rootRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
-  const listboxId = useId();
-  const selectedOption =
-    options.find((option) => option.value === value) ?? options[0];
-  const selectedIndex = Math.max(
-    options.findIndex((option) => option.value === value),
-    0,
-  );
-
-  useEffect(() => {
-    function handlePointerDown(event: MouseEvent) {
-      if (rootRef.current && !rootRef.current.contains(event.target as Node)) {
-        setOpen(false);
-      }
-    }
-
-    document.addEventListener("mousedown", handlePointerDown);
-
-    return () => document.removeEventListener("mousedown", handlePointerDown);
-  }, []);
-
-  useEffect(() => {
-    if (!open) return;
-
-    const next = optionRefs.current[activeIndex];
-    if (!next) return;
-
-    const frame = requestAnimationFrame(() => next.focus());
-
-    return () => cancelAnimationFrame(frame);
-  }, [activeIndex, open]);
-
-  function openList(index = selectedIndex) {
-    setActiveIndex(index);
-    setOpen(true);
-  }
-
-  function closeList() {
-    setOpen(false);
-    triggerRef.current?.focus();
-  }
-
-  function selectValue(nextValue: string) {
-    onChange(nextValue);
-    closeList();
-  }
-
-  function moveActive(nextIndex: number) {
-    const maxIndex = options.length - 1;
-    setActiveIndex(Math.min(Math.max(nextIndex, 0), maxIndex));
-  }
-
-  return (
-    <div ref={rootRef} className={cn("relative inline-flex", className)}>
-      <button
-        ref={triggerRef}
-        type="button"
-        aria-label={ariaLabel}
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        aria-controls={listboxId}
-        onClick={() => (open ? setOpen(false) : openList(selectedIndex))}
-        onKeyDown={(event) => {
-          if (event.key === "ArrowDown") {
-            event.preventDefault();
-            openList(selectedIndex);
-          } else if (event.key === "ArrowUp") {
-            event.preventDefault();
-            openList(selectedIndex);
-          } else if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
-            openList(selectedIndex);
-          }
-        }}
-        className={cn(
-          "flex h-8 w-full items-center rounded-md border border-border-3 bg-background-1 px-2.5 py-[5px] pr-7 text-left text-[12px] font-normal leading-none text-text-1 outline-none transition-colors",
-          open && "border-primary-1 ring-3 ring-primary-1/10",
-        )}
-      >
-        <span className="truncate whitespace-nowrap">
-          {selectedOption?.label ?? ""}
-        </span>
-        <Icon
-          icon={altArrowDownLinear}
-          width="12"
-          aria-hidden="true"
-          className={cn(
-            "pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-text-4 transition-transform",
-            open && "rotate-180",
-          )}
-        />
-      </button>
-
-      {open ? (
-        <div className="absolute left-0 top-[calc(100%+4px)] z-[200] min-w-full overflow-hidden rounded-lg border border-border-3 bg-background-1 shadow-[0_4px_16px_rgba(0,0,0,0.1)]">
-          <div
-            id={listboxId}
-            role="listbox"
-            aria-label={ariaLabel}
-            className="py-0.5"
-          >
-            {options.map((option, index) => {
-              const isSelected = option.value === value;
-
-              return (
-                <button
-                  key={option.value}
-                  ref={(node) => {
-                    optionRefs.current[index] = node;
-                  }}
-                  type="button"
-                  role="option"
-                  aria-selected={isSelected}
-                  tabIndex={index === activeIndex ? 0 : -1}
-                  onClick={() => selectValue(option.value)}
-                  onFocus={() => setActiveIndex(index)}
-                  onKeyDown={(event) => {
-                    if (event.key === "ArrowDown") {
-                      event.preventDefault();
-                      moveActive(index + 1);
-                    } else if (event.key === "ArrowUp") {
-                      event.preventDefault();
-                      moveActive(index - 1);
-                    } else if (event.key === "Home") {
-                      event.preventDefault();
-                      moveActive(0);
-                    } else if (event.key === "End") {
-                      event.preventDefault();
-                      moveActive(options.length - 1);
-                    } else if (event.key === "Escape") {
-                      event.preventDefault();
-                      closeList();
-                    } else if (event.key === "Tab") {
-                      setOpen(false);
-                    } else if (event.key === " " || event.key === "Enter") {
-                      event.preventDefault();
-                      selectValue(option.value);
-                    }
-                  }}
-                  className={cn(
-                    "flex w-full items-center whitespace-nowrap px-3 py-2 text-left text-[12px] leading-none text-text-1 transition-colors hover:bg-background-2",
-                    isSelected && "font-medium text-primary-1",
-                  )}
-                  style={{
-                    paddingLeft: option.depth
-                      ? `${12 + option.depth * 16}px`
-                      : undefined,
-                  }}
-                >
-                  {option.label}
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      ) : null}
-    </div>
-  );
-}
 
 function buildCategoryTree(
   categories: Category[],
@@ -356,7 +179,7 @@ export function BulkActions({
 
         {tab === "active" ? (
           <div className="flex flex-1 flex-wrap items-center gap-2">
-            <BulkSelect
+            <CustomSelect
               value={categoryId ? String(categoryId) : ""}
               onChange={(value) =>
                 setCategoryId(value ? Number(value) : undefined)
@@ -364,9 +187,13 @@ export function BulkActions({
               options={categoryOptions}
               ariaLabel="일괄 카테고리 변경"
               className="min-w-[8rem]"
+              triggerClassName="h-8 rounded-md px-2.5 py-[5px] pr-7 text-[12px] font-normal leading-none"
+              optionClassName="text-[12px] leading-none"
+              iconClassName="right-2"
+              iconWidth="12"
             />
 
-            <BulkSelect
+            <CustomSelect
               value={commentStatus ?? ""}
               onChange={(value) =>
                 setCommentStatus(
@@ -376,6 +203,10 @@ export function BulkActions({
               options={commentStatusOptions}
               ariaLabel="일괄 댓글 상태 변경"
               className="min-w-[8rem]"
+              triggerClassName="h-8 rounded-md px-2.5 py-[5px] pr-7 text-[12px] font-normal leading-none"
+              optionClassName="text-[12px] leading-none"
+              iconClassName="right-2"
+              iconWidth="12"
             />
 
             <button

--- a/src/widgets/admin-post-list/ui/bulk-actions.tsx
+++ b/src/widgets/admin-post-list/ui/bulk-actions.tsx
@@ -7,7 +7,7 @@ import type { AdminPostTab } from "./post-filters";
 import type { Category } from "@entities/category";
 import { cn } from "@shared/lib/style-utils";
 import { ConfirmDialog } from "@shared/ui/confirm-dialog";
-import { CustomSelect } from "@shared/ui/libs";
+import { DropSelect } from "@shared/ui/libs";
 
 interface BulkActionsProps {
   tab: AdminPostTab;
@@ -179,7 +179,7 @@ export function BulkActions({
 
         {tab === "active" ? (
           <div className="flex flex-1 flex-wrap items-center gap-2">
-            <CustomSelect
+            <DropSelect
               value={categoryId ? String(categoryId) : ""}
               onChange={(value) =>
                 setCategoryId(value ? Number(value) : undefined)
@@ -193,7 +193,7 @@ export function BulkActions({
               iconWidth="12"
             />
 
-            <CustomSelect
+            <DropSelect
               value={commentStatus ?? ""}
               onChange={(value) =>
                 setCommentStatus(

--- a/src/widgets/admin-post-list/ui/post-filters.tsx
+++ b/src/widgets/admin-post-list/ui/post-filters.tsx
@@ -117,7 +117,7 @@ export function PostFilters({
             type="button"
             onClick={() => onTabChange("active")}
             className={cn(
-              "whitespace-nowrap rounded-lg px-4 py-2 text-[14px] font-medium leading-5 transition-colors",
+              "whitespace-nowrap rounded-lg px-4 py-2 text-sm font-medium leading-5 transition-colors",
               tab === "active"
                 ? "bg-primary-1/10 text-primary-1"
                 : "text-text-3 hover:text-text-2",
@@ -129,7 +129,7 @@ export function PostFilters({
             type="button"
             onClick={() => onTabChange("trash")}
             className={cn(
-              "whitespace-nowrap rounded-lg px-4 py-2 text-[14px] font-medium leading-5 transition-colors",
+              "whitespace-nowrap rounded-lg px-4 py-2 text-sm font-medium leading-5 transition-colors",
               tab === "trash"
                 ? "bg-primary-1/10 text-primary-1"
                 : "text-text-3 hover:text-text-2",
@@ -176,12 +176,12 @@ export function PostFilters({
             onChange={(value) =>
               onCategoryChange(value ? Number(value) : undefined)
             }
-            className="min-w-[10rem]"
+            className="min-w-40"
             ariaLabel="카테고리 필터"
             options={categoryOptions}
           />
 
-          <div className="relative flex h-10 w-full max-w-xs min-w-[15rem] items-center">
+          <div className="relative flex h-10 w-full max-w-xs min-w-60 items-center">
             <Icon
               icon={magniferLinear}
               width="16"
@@ -194,7 +194,7 @@ export function PostFilters({
               value={inputValue}
               onChange={(event) => setInputValue(event.target.value)}
               placeholder="제목으로 검색..."
-              className="h-10 w-full rounded-lg border border-border-3 bg-background-1 px-9 py-2 text-[14px] leading-5 text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 focus:ring-3 focus:ring-primary-1/10"
+              className="h-10 w-full rounded-lg border border-border-3 bg-background-1 px-9 py-2 text-sm leading-5 text-text-1 outline-none transition-colors placeholder:text-text-4 focus:border-primary-1 focus:ring-3 focus:ring-primary-1/10"
             />
             {inputValue ? (
               <button

--- a/src/widgets/admin-post-list/ui/post-filters.tsx
+++ b/src/widgets/admin-post-list/ui/post-filters.tsx
@@ -7,7 +7,7 @@ import magniferLinear from "@iconify-icons/solar/magnifer-linear";
 import type { Category } from "@entities/category";
 import type { PostListItem } from "@entities/post";
 import { cn } from "@shared/lib/style-utils";
-import { CustomSelect } from "@shared/ui/libs";
+import { DropSelect } from "@shared/ui/libs";
 
 export type AdminPostTab = "active" | "trash";
 export type AdminPostStatusFilter = PostListItem["status"] | "all";
@@ -153,7 +153,7 @@ export function PostFilters({
           onSubmit={handleSearch}
           className="flex flex-wrap items-center gap-3"
         >
-          <CustomSelect
+          <DropSelect
             value={status}
             onChange={(value) => onStatusChange(value as AdminPostStatusFilter)}
             className="min-w-[8.5rem]"
@@ -161,7 +161,7 @@ export function PostFilters({
             options={STATUS_OPTIONS}
           />
 
-          <CustomSelect
+          <DropSelect
             value={visibility}
             onChange={(value) =>
               onVisibilityChange(value as AdminPostVisibilityFilter)
@@ -171,7 +171,7 @@ export function PostFilters({
             options={VISIBILITY_OPTIONS}
           />
 
-          <CustomSelect
+          <DropSelect
             value={categoryId ? String(categoryId) : ""}
             onChange={(value) =>
               onCategoryChange(value ? Number(value) : undefined)

--- a/src/widgets/admin-post-list/ui/post-filters.tsx
+++ b/src/widgets/admin-post-list/ui/post-filters.tsx
@@ -1,20 +1,13 @@
 "use client";
 
 import type { ReactNode } from "react";
-import {
-  type FormEvent,
-  useEffect,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@iconify/react/offline";
-import altArrowDownLinear from "@iconify-icons/solar/alt-arrow-down-linear";
 import magniferLinear from "@iconify-icons/solar/magnifer-linear";
 import type { Category } from "@entities/category";
 import type { PostListItem } from "@entities/post";
 import { cn } from "@shared/lib/style-utils";
+import { CustomSelect } from "@shared/ui/libs";
 
 export type AdminPostTab = "active" | "trash";
 export type AdminPostStatusFilter = PostListItem["status"] | "all";
@@ -65,187 +58,6 @@ function flattenCategories(
     { category, depth },
     ...flattenCategories(categories, category.id, depth + 1),
   ]);
-}
-
-function FilterSelect({
-  value,
-  onChange,
-  className,
-  options,
-  ariaLabel,
-}: {
-  value: string;
-  onChange: (value: string) => void;
-  className?: string;
-  ariaLabel: string;
-  options: Array<{
-    label: string;
-    value: string;
-    depth?: number;
-  }>;
-}) {
-  const [open, setOpen] = useState(false);
-  const [activeIndex, setActiveIndex] = useState(0);
-  const rootRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
-  const listboxId = useId();
-  const selectedOption =
-    options.find((option) => option.value === value) ?? options[0];
-  const selectedIndex = Math.max(
-    options.findIndex((option) => option.value === value),
-    0,
-  );
-
-  useEffect(() => {
-    function handlePointerDown(event: MouseEvent) {
-      if (rootRef.current && !rootRef.current.contains(event.target as Node)) {
-        setOpen(false);
-      }
-    }
-
-    document.addEventListener("mousedown", handlePointerDown);
-
-    return () => document.removeEventListener("mousedown", handlePointerDown);
-  }, []);
-
-  useEffect(() => {
-    if (!open) return;
-
-    const next = optionRefs.current[activeIndex];
-    if (!next) return;
-
-    const frame = requestAnimationFrame(() => next.focus());
-
-    return () => cancelAnimationFrame(frame);
-  }, [activeIndex, open]);
-
-  function openList(index = selectedIndex) {
-    setActiveIndex(index);
-    setOpen(true);
-  }
-
-  function closeList() {
-    setOpen(false);
-    triggerRef.current?.focus();
-  }
-
-  function selectValue(nextValue: string) {
-    onChange(nextValue);
-    closeList();
-  }
-
-  function moveActive(nextIndex: number) {
-    const maxIndex = options.length - 1;
-    setActiveIndex(Math.min(Math.max(nextIndex, 0), maxIndex));
-  }
-
-  return (
-    <div ref={rootRef} className={cn("relative inline-flex", className)}>
-      <button
-        ref={triggerRef}
-        type="button"
-        aria-label={ariaLabel}
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        aria-controls={listboxId}
-        onClick={() => (open ? setOpen(false) : openList(selectedIndex))}
-        onKeyDown={(event) => {
-          if (event.key === "ArrowDown") {
-            event.preventDefault();
-            openList(selectedIndex);
-          } else if (event.key === "ArrowUp") {
-            event.preventDefault();
-            openList(selectedIndex);
-          } else if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
-            openList(selectedIndex);
-          }
-        }}
-        className={cn(
-          "flex h-10 w-full items-center rounded-lg border border-border-3 bg-background-1 px-3 py-2 pr-8 text-left text-[14px] leading-5 text-text-1 outline-none transition-colors",
-          open && "border-primary-1 ring-3 ring-primary-1/10",
-        )}
-      >
-        <span className="truncate whitespace-nowrap">
-          {selectedOption?.label ?? ""}
-        </span>
-        <Icon
-          icon={altArrowDownLinear}
-          width="14"
-          aria-hidden="true"
-          className={cn(
-            "pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-text-4 transition-transform",
-            open && "rotate-180",
-          )}
-        />
-      </button>
-
-      {open ? (
-        <div className="absolute left-0 top-[calc(100%+4px)] z-[200] min-w-full overflow-hidden rounded-lg border border-border-3 bg-background-1 shadow-[0_4px_16px_rgba(0,0,0,0.1)]">
-          <div
-            id={listboxId}
-            role="listbox"
-            aria-label={ariaLabel}
-            className="py-0.5"
-          >
-            {options.map((option, index) => {
-              const isSelected = option.value === value;
-
-              return (
-                <button
-                  key={option.value}
-                  ref={(node) => {
-                    optionRefs.current[index] = node;
-                  }}
-                  type="button"
-                  role="option"
-                  aria-selected={isSelected}
-                  tabIndex={index === activeIndex ? 0 : -1}
-                  onClick={() => selectValue(option.value)}
-                  onFocus={() => setActiveIndex(index)}
-                  onKeyDown={(event) => {
-                    if (event.key === "ArrowDown") {
-                      event.preventDefault();
-                      moveActive(index + 1);
-                    } else if (event.key === "ArrowUp") {
-                      event.preventDefault();
-                      moveActive(index - 1);
-                    } else if (event.key === "Home") {
-                      event.preventDefault();
-                      moveActive(0);
-                    } else if (event.key === "End") {
-                      event.preventDefault();
-                      moveActive(options.length - 1);
-                    } else if (event.key === "Escape") {
-                      event.preventDefault();
-                      closeList();
-                    } else if (event.key === "Tab") {
-                      setOpen(false);
-                    } else if (event.key === " " || event.key === "Enter") {
-                      event.preventDefault();
-                      selectValue(option.value);
-                    }
-                  }}
-                  className={cn(
-                    "flex w-full items-center whitespace-nowrap px-3 py-2 text-left text-[14px] leading-5 text-text-1 transition-colors hover:bg-background-2",
-                    isSelected && "font-medium text-primary-1",
-                  )}
-                  style={{
-                    paddingLeft: option.depth
-                      ? `${12 + option.depth * 16}px`
-                      : undefined,
-                  }}
-                >
-                  {option.label}
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      ) : null}
-    </div>
-  );
 }
 
 export function PostFilters({
@@ -341,7 +153,7 @@ export function PostFilters({
           onSubmit={handleSearch}
           className="flex flex-wrap items-center gap-3"
         >
-          <FilterSelect
+          <CustomSelect
             value={status}
             onChange={(value) => onStatusChange(value as AdminPostStatusFilter)}
             className="min-w-[8.5rem]"
@@ -349,7 +161,7 @@ export function PostFilters({
             options={STATUS_OPTIONS}
           />
 
-          <FilterSelect
+          <CustomSelect
             value={visibility}
             onChange={(value) =>
               onVisibilityChange(value as AdminPostVisibilityFilter)
@@ -359,7 +171,7 @@ export function PostFilters({
             options={VISIBILITY_OPTIONS}
           />
 
-          <FilterSelect
+          <CustomSelect
             value={categoryId ? String(categoryId) : ""}
             onChange={(value) =>
               onCategoryChange(value ? Number(value) : undefined)

--- a/src/widgets/admin-post-list/ui/post-table.tsx
+++ b/src/widgets/admin-post-list/ui/post-table.tsx
@@ -94,7 +94,7 @@ function Badge({
   return (
     <span
       className={cn(
-        "inline-flex items-center rounded-md px-2 py-0.5 text-[12px] font-medium leading-4 whitespace-nowrap",
+        "inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium leading-4 whitespace-nowrap",
         tone === "category" && "bg-primary-1/12 text-primary-1",
         tone === "published" && "bg-primary-1/12 text-primary-1",
         tone === "draft" && "bg-warning-1/12 text-warning-1",
@@ -397,17 +397,17 @@ export function PostTable({
                       />
                     </td>
                     <td className="border-b border-border-4 px-3 py-3 align-middle">
-                      <span className="truncate whitespace-nowrap text-[14px] font-medium leading-4 text-text-1">
+                      <span className="truncate whitespace-nowrap text-sm font-medium leading-4 text-text-1">
                         {post.title}
                       </span>
                     </td>
                     <td className="border-b border-border-4 px-3 py-3 align-middle">
                       {post.category ? (
-                        <span className="whitespace-nowrap text-[14px] leading-4 text-text-4">
+                        <span className="whitespace-nowrap text-sm leading-4 text-text-4">
                           {post.category.name}
                         </span>
                       ) : (
-                        <span className="whitespace-nowrap text-[14px] leading-4 text-text-4">
+                        <span className="whitespace-nowrap text-sm leading-4 text-text-4">
                           (카테고리 없음)
                         </span>
                       )}
@@ -421,7 +421,7 @@ export function PostTable({
                           type="button"
                           onClick={() => onRestore(post.id)}
                           disabled={deleteId === post.id}
-                          className="inline-flex h-8 items-center justify-center rounded-md border border-border-3 px-3 text-[12px] font-medium leading-none text-text-2 transition-colors hover:bg-background-3 disabled:cursor-not-allowed disabled:opacity-50"
+                          className="inline-flex h-8 items-center justify-center rounded-md border border-border-3 px-3 text-xs font-medium leading-none text-text-2 transition-colors hover:bg-background-3 disabled:cursor-not-allowed disabled:opacity-50"
                         >
                           복원
                         </button>
@@ -429,7 +429,7 @@ export function PostTable({
                           type="button"
                           onClick={() => setHardDeleteTarget(post)}
                           disabled={deleteId === post.id}
-                          className="inline-flex h-8 items-center justify-center rounded-md border border-negative-1 bg-negative-1 px-3 text-[12px] font-medium leading-none text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+                          className="inline-flex h-8 items-center justify-center rounded-md border border-negative-1 bg-negative-1 px-3 text-xs font-medium leading-none text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
                         >
                           영구 삭제
                         </button>
@@ -621,7 +621,7 @@ export function PostTable({
                       </button>
                     </td>
                     <td className="border-b border-border-4 px-3 py-3 align-middle">
-                      <div className="flex max-w-[20rem] items-center gap-3">
+                      <div className="flex max-w-xs items-center gap-3">
                         {post.thumbnailUrl ? (
                           <Image
                             src={post.thumbnailUrl}
@@ -636,7 +636,7 @@ export function PostTable({
                         )}
                         <div className="min-w-0">
                           <div className="flex items-center gap-2">
-                            <span className="block truncate whitespace-nowrap text-[14px] font-medium leading-4 text-text-1">
+                            <span className="block truncate whitespace-nowrap text-sm font-medium leading-4 text-text-1">
                               {post.title}
                             </span>
                             {post.category ? (
@@ -653,7 +653,7 @@ export function PostTable({
                             )}
                           </div>
                           {post.summary ? (
-                            <p className="mt-0.5 line-clamp-1 whitespace-nowrap text-[12px] leading-4 text-text-4">
+                            <p className="mt-0.5 line-clamp-1 whitespace-nowrap text-xs leading-4 text-text-4">
                               {post.summary}
                             </p>
                           ) : null}
@@ -695,7 +695,7 @@ export function PostTable({
                           {commentStatusLabelMap[post.commentStatus]}
                         </Badge>
                       ) : (
-                        <span className="whitespace-nowrap text-[14px] leading-5 text-text-4">
+                        <span className="whitespace-nowrap text-sm leading-5 text-text-4">
                           -
                         </span>
                       )}
@@ -723,7 +723,7 @@ export function PostTable({
                         />
                         <span
                           className={cn(
-                            "whitespace-nowrap text-[12px] font-medium leading-4",
+                            "whitespace-nowrap text-xs font-medium leading-4",
                             post.visibility === "public"
                               ? "text-primary-1"
                               : "text-text-4",
@@ -734,7 +734,7 @@ export function PostTable({
                       </div>
                     </td>
                     <td
-                      className="min-w-[112px] border-b border-border-4 px-3 py-3 align-middle"
+                      className="min-w-28 border-b border-border-4 px-3 py-3 align-middle"
                       onClick={(event) => event.stopPropagation()}
                     >
                       <div className="flex items-center gap-2">
@@ -746,7 +746,7 @@ export function PostTable({
                         />
                         <span
                           className={cn(
-                            "whitespace-nowrap text-[12px] font-medium leading-4",
+                            "whitespace-nowrap text-xs font-medium leading-4",
                             !isPrivate && post.searchIndexable
                               ? "text-primary-1"
                               : "text-text-4",

--- a/src/widgets/admin-post-list/ui/post-table.tsx
+++ b/src/widgets/admin-post-list/ui/post-table.tsx
@@ -18,7 +18,7 @@ import type { AdminPostTab } from "./post-filters";
 import type { FetchAdminPostsParams, PostListItem } from "@entities/post";
 import { cn } from "@shared/lib/style-utils";
 import { ConfirmDialog } from "@shared/ui/confirm-dialog";
-import { EmptyState, Skeleton } from "@shared/ui/libs";
+import { EmptyState, TableSkeleton } from "@shared/ui/libs";
 
 export type SortField = NonNullable<FetchAdminPostsParams["sort"]>;
 export type SortOrder = "asc" | "desc";
@@ -274,23 +274,26 @@ export function PostTable({
 
   if (isPending) {
     return (
-      <div className="overflow-hidden rounded-xl border border-border-4 bg-background-1">
-        <div className="grid grid-cols-6 gap-4 border-b border-border-4 px-4 py-4">
-          {Array.from({ length: 6 }).map((_, index) => (
-            <Skeleton key={index} />
-          ))}
-        </div>
-        <div className="space-y-3 px-4 py-4">
-          {Array.from({ length: 7 }).map((_, index) => (
-            <Skeleton
-              key={index}
-              variant="rect"
-              height="4.25rem"
-              className="rounded-lg"
-            />
-          ))}
-        </div>
-      </div>
+      <TableSkeleton
+        rows={7}
+        rowHeight="4.25rem"
+        containerClassName="rounded-xl"
+        columns={[
+          { width: "2.5rem", className: "text-center" },
+          { width: "2.5rem", className: "text-center" },
+          { width: "19rem" },
+          { width: "7rem" },
+          { width: "6rem" },
+          { width: "6rem" },
+          { width: "7rem" },
+          { width: "7rem" },
+          { width: "7rem" },
+          { width: "5rem" },
+          { width: "5rem" },
+          { width: "3rem" },
+          { width: "3rem" },
+        ]}
+      />
     );
   }
 

--- a/src/widgets/admin-post-preview/ui/post-preview.tsx
+++ b/src/widgets/admin-post-preview/ui/post-preview.tsx
@@ -107,7 +107,7 @@ export function PostPreview({ post, renderedContent }: PostPreviewProps) {
         <Link
           href="/manage/posts"
           prefetch={false}
-          className="inline-flex items-center gap-1.5 rounded-[0.75rem] border border-border-3 px-3 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
+          className="inline-flex items-center gap-1.5 rounded-xl border border-border-3 px-3 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
         >
           ← 목록
         </Link>
@@ -115,7 +115,7 @@ export function PostPreview({ post, renderedContent }: PostPreviewProps) {
         <Link
           href={`/manage/posts/${currentPost.id}/edit`}
           prefetch={false}
-          className="inline-flex items-center rounded-[0.75rem] border border-border-3 px-3 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
+          className="inline-flex items-center rounded-xl border border-border-3 px-3 py-2 text-sm font-medium text-text-2 transition-colors hover:border-border-2 hover:text-text-1"
         >
           수정
         </Link>
@@ -124,7 +124,7 @@ export function PostPreview({ post, renderedContent }: PostPreviewProps) {
           type="button"
           onClick={() => setShowDeleteDialog(true)}
           disabled={deleteMutation.isPending}
-          className="inline-flex items-center rounded-[0.75rem] border border-negative-1/30 px-3 py-2 text-sm font-medium text-negative-1 transition-colors hover:bg-negative-1/10 disabled:opacity-50"
+          className="inline-flex items-center rounded-xl border border-negative-1/30 px-3 py-2 text-sm font-medium text-negative-1 transition-colors hover:bg-negative-1/10 disabled:opacity-50"
         >
           삭제
         </button>
@@ -211,7 +211,7 @@ export function PostPreview({ post, renderedContent }: PostPreviewProps) {
             );
           }}
           className={cn(
-            "inline-flex items-center gap-1.5 rounded-[0.75rem] border px-3 py-2 text-sm font-medium transition-colors",
+            "inline-flex items-center gap-1.5 rounded-xl border px-3 py-2 text-sm font-medium transition-colors",
             "disabled:cursor-not-allowed disabled:opacity-50",
             currentPost.isPinned
               ? "border-primary-1/30 text-primary-1 hover:bg-primary-1/10"
@@ -239,7 +239,7 @@ export function PostPreview({ post, renderedContent }: PostPreviewProps) {
               );
             }}
             ariaLabel="글 상태"
-            triggerClassName="h-auto rounded-[0.75rem] px-3 py-2 text-sm text-text-1 disabled:opacity-50"
+            triggerClassName="h-auto rounded-xl px-3 py-2 text-sm text-text-1 disabled:opacity-50"
             options={statusOptions}
           />
         </div>

--- a/src/widgets/admin-post-preview/ui/post-preview.tsx
+++ b/src/widgets/admin-post-preview/ui/post-preview.tsx
@@ -17,6 +17,7 @@ import {
 import { getErrorMessage } from "@shared/lib/get-error-message";
 import { cn } from "@shared/lib/style-utils";
 import { ConfirmDialog } from "@shared/ui/confirm-dialog";
+import { DropSelect } from "@shared/ui/libs";
 import { ToggleSwitch } from "@shared/ui/toggle-switch";
 
 const dateFormatter = new Intl.DateTimeFormat("ko-KR", {
@@ -223,11 +224,10 @@ export function PostPreview({ post, renderedContent }: PostPreviewProps) {
 
         <div className="flex items-center gap-2 text-sm text-text-2">
           <span>상태</span>
-          <select
+          <DropSelect
             value={currentPost.status}
             disabled={isUpdating}
-            onChange={(e) => {
-              const value = e.target.value as PostDetail["status"];
+            onChange={(value) => {
               const prev = currentPost.status;
               setCurrentPost((p) => ({ ...p, status: value }));
               updateMutation.mutate(
@@ -238,14 +238,10 @@ export function PostPreview({ post, renderedContent }: PostPreviewProps) {
                 },
               );
             }}
-            className="rounded-[0.75rem] border border-border-3 bg-background-1 px-3 py-2 text-sm text-text-1 outline-none transition-colors focus:border-primary-1 disabled:opacity-50"
-          >
-            {statusOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
+            ariaLabel="글 상태"
+            triggerClassName="h-auto rounded-[0.75rem] px-3 py-2 text-sm text-text-1 disabled:opacity-50"
+            options={statusOptions}
+          />
         </div>
 
         <p className="text-sm text-text-3">

--- a/src/widgets/header/index.tsx
+++ b/src/widgets/header/index.tsx
@@ -84,7 +84,7 @@ const Header: React.FC<HeaderProps> = ({
           "fixed top-0 z-[1000]",
           "flex justify-center",
           "border-b text-text-1",
-          "bg-[rgba(249,249,250,0.8)] border-[rgba(219,221,224,0.5)] shadow-[0_1px_0_rgba(255,255,255,0.05)] backdrop-blur-[16px] backdrop-saturate-[1.4]",
+          "bg-[rgba(249,249,250,0.8)] border-[rgba(219,221,224,0.5)] shadow-[0_1px_0_rgba(255,255,255,0.05)] backdrop-blur-lg backdrop-saturate-[1.4]",
           "dark:bg-[rgba(19,20,21,0.85)] dark:border-[rgba(62,66,69,0.5)] dark:shadow-[0_1px_0_rgba(0,0,0,0.15)]",
           "transition-all duration-300",
           isShown ? "translate-y-0" : "-translate-y-full",
@@ -101,7 +101,7 @@ const Header: React.FC<HeaderProps> = ({
               height="1.75rem"
               className="text-primary-1"
             />
-            <span className="text-[0.875rem] leading-[1.188rem] font-bold tracking-tight text-text-1">
+            <span className="text-sm leading-[1.188rem] font-bold tracking-tight text-text-1">
               pyosh blog
             </span>
           </Link>

--- a/src/widgets/header/search-bar.tsx
+++ b/src/widgets/header/search-bar.tsx
@@ -124,7 +124,7 @@ const SearchBar: React.FC = () => {
       className={cn(
         "relative flex items-center overflow-hidden rounded-[0.625rem] transition-[width,min-width,border-color,background-color,box-shadow] duration-300",
         isExpanded
-          ? "h-[2.125rem] min-w-[10rem] border border-border-3 bg-background-2 focus-within:border-primary-1 focus-within:shadow-[0_0_0_3px_rgba(138,111,224,0.12)] md:min-w-[12.5rem]"
+          ? "h-[2.125rem] min-w-40 border border-border-3 bg-background-2 focus-within:border-primary-1 focus-within:shadow-[0_0_0_3px_rgba(138,111,224,0.12)] md:min-w-[12.5rem]"
           : "h-[2.125rem] w-[2.125rem] min-w-[2.125rem] cursor-pointer border border-transparent bg-transparent px-0 hover:bg-background-3",
       )}
       onSubmit={handleSubmit}
@@ -156,7 +156,7 @@ const SearchBar: React.FC = () => {
         maxLength={200}
         aria-label="검색어 입력"
         className={cn(
-          "min-w-0 bg-transparent pl-3 pr-2 text-[0.813rem] leading-[1.125rem] font-normal text-text-1 outline-none placeholder:text-text-4 transition-[max-width,opacity] duration-300",
+          "min-w-0 bg-transparent pl-3 pr-2 text-[0.813rem] leading-4.5 font-normal text-text-1 outline-none placeholder:text-text-4 transition-[max-width,opacity] duration-300",
           isExpanded
             ? "max-w-[12rem] opacity-100 md:max-w-[14rem]"
             : "max-w-0 opacity-0 pointer-events-none",
@@ -193,7 +193,7 @@ const SearchBar: React.FC = () => {
           <button
             type="submit"
             aria-label="검색 실행"
-            className="flex h-[2.125rem] w-[2.125rem] items-center justify-center rounded-[0.5rem] text-text-3 transition-colors hover:bg-background-3"
+            className="flex h-[2.125rem] w-[2.125rem] items-center justify-center rounded-lg text-text-3 transition-colors hover:bg-background-3"
           >
             <Icon icon={magniferLinear} width="16" aria-hidden="true" />
           </button>

--- a/src/widgets/home-page/ui/home-page.tsx
+++ b/src/widgets/home-page/ui/home-page.tsx
@@ -43,7 +43,7 @@ export async function HomePage({ searchParams }: HomePageProps) {
   }
 
   return (
-    <main className="mx-auto flex w-full max-w-270 flex-col gap-3 pb-16 pt-8">
+    <div className="flex w-full flex-col gap-3">
       <header
         className="motion-reveal pb-1"
         style={{ animationDelay: "100ms" }}
@@ -54,6 +54,6 @@ export async function HomePage({ searchParams }: HomePageProps) {
       </header>
 
       <PostList initialData={initialData} initialPage={page} />
-    </main>
+    </div>
   );
 }

--- a/src/widgets/home-page/ui/home-page.tsx
+++ b/src/widgets/home-page/ui/home-page.tsx
@@ -48,7 +48,7 @@ export async function HomePage({ searchParams }: HomePageProps) {
         className="motion-reveal pb-1"
         style={{ animationDelay: "100ms" }}
       >
-        <h1 className="break-keep text-[1.5rem] leading-[1.938rem] font-bold tracking-tight text-text-1 md:text-[1.875rem] md:leading-9.5">
+        <h1 className="break-keep text-2xl leading-[1.938rem] font-bold tracking-tight text-text-1 md:text-3xl md:leading-9.5">
           최근 글
         </h1>
       </header>

--- a/src/widgets/public-sidebar/ui/public-sidebar.tsx
+++ b/src/widgets/public-sidebar/ui/public-sidebar.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { Icon } from "@iconify/react/offline";
-import altArrowRightLinear from "@iconify-icons/solar/alt-arrow-right-linear";
 import closeCircleLinear from "@iconify-icons/solar/close-circle-linear";
 import eyeLinear from "@iconify-icons/solar/eye-linear";
 import folder2Linear from "@iconify-icons/solar/folder-2-linear";
@@ -23,6 +22,7 @@ import { TagCloud } from "@features/tag-cloud";
 import { TocSection } from "@features/toc";
 import { TotalViewCount } from "@features/total-view-count";
 import { cn } from "@shared/lib/style-utils";
+import { ChevronIcon } from "@shared/ui/icons";
 
 interface PublicSidebarContentProps {
   recentPosts: PostListItem[];
@@ -159,13 +159,7 @@ export function PublicSidebarContent({
               className="inline-flex items-center gap-0.5 text-ui-xs font-medium text-primary-1 underline-offset-4 hover:underline"
             >
               전체보기
-              <Icon
-                icon={altArrowRightLinear}
-                width="10"
-                height="10"
-                aria-hidden="true"
-                className="shrink-0"
-              />
+              <ChevronIcon direction="right" size="10" className="shrink-0" />
             </Link>
           }
         >
@@ -196,13 +190,7 @@ export function PublicSidebarContent({
               className="inline-flex items-center gap-0.5 text-ui-xs font-medium text-primary-1 underline-offset-4 hover:underline"
             >
               전체보기
-              <Icon
-                icon={altArrowRightLinear}
-                width="10"
-                height="10"
-                aria-hidden="true"
-                className="shrink-0"
-              />
+              <ChevronIcon direction="right" size="10" className="shrink-0" />
             </Link>
           }
         >


### PR DESCRIPTION
## Summary

- 에셋 업로더 UI를 업로드 큐 중심으로 정리하고 관련 컴포넌트를 분리했습니다.
- DropSelect를 공용 select UI로 정리하고 viewport 이탈 방지 처리를 추가했습니다.
- public/admin layout spacing, Tailwind utility class, chevron icon 사용을 공통 기준으로 정리했습니다.
- route/query loading skeleton을 현재 UI 구조에 맞게 조정하고 공용 TableSkeleton/PostListSkeleton을 추가했습니다.

## Verification

- `pnpm compile:types`
- `pnpm lint`
- `pnpm build`

Note: `pnpm build` completed successfully. During static page generation, API fetch attempts logged `ECONNREFUSED` because the local API endpoint was unavailable, but the command exited successfully.

Close #392
Close #393
Close #394
Close #395
Close #396
Close #397
